### PR TITLE
feat: disable source selection and project selection when recording

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -118,6 +118,7 @@ export function LaunchWindow() {
           size="sm"
           className={`gap-1 text-white bg-transparent hover:bg-transparent px-0 flex-1 text-left text-xs ${styles.electronNoDrag}`}
           onClick={openSourceSelector}
+          disabled={recording}
         >
           <MdMonitor size={14} className="text-white" />
           {truncateText(selectedSource, 6)}
@@ -154,6 +155,7 @@ export function LaunchWindow() {
           size="sm"
           onClick={openVideoFile}
           className={`gap-1 text-white bg-transparent hover:bg-transparent px-0 flex-1 text-right text-xs ${styles.electronNoDrag} ${styles.folderButton}`}
+          disabled={recording}
         >
           <FaFolderMinus size={14} className="text-white" />
           <span className={styles.folderText}>Open</span>


### PR DESCRIPTION
# Pull Request Template

## Description

Disable source selection and project opening buttons when recording.

> Currently with the least change to the code by adding disabled property to both buttons. When there's more buttons to be added, the developer may miss this property.
> I think it would be better to add a hud buttons config and a config like `DISABLED_BUTTONS_DURING_RECORDING`.
> Which one do you prefer? A simple patch or a refactor of the hud overlay code?

## Motivation

Leaving the two buttons available when recording may be misleading for users.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Fixes #21 

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot** (if applicable):

<img width="589" height="122" alt="image" src="https://github.com/user-attachments/assets/23ebdb69-ca26-4d96-bf30-7f585e912e95" />


## Testing
<!-- Describe how reviewers can test the changes. Include steps, commands, or environment setup. -->

1. Pull the new code.
2. Start dev server.
3. Select source and start recording.
4. Click on the source selection and project selection buttons.
5. Expect these buttons' style shows they are disabled. Expect no effect after clicking on them.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
