### PR TITLE
perf: optimize video export with requestVideoFrameCallback

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -28,7 +28,7 @@ import {
   type CropRegion,
   type FigureData,
 } from "./types";
-import { VideoExporter, type ExportProgress, type ExportQuality } from "@/lib/exporter";
+import { createExporter, type ExportProgress, type ExportQuality } from "@/lib/exporter";
 import { type AspectRatio, getAspectRatioValue } from "@/utils/aspectRatioUtils";
 
 const WALLPAPER_COUNT = 18;
@@ -66,19 +66,19 @@ export default function VideoEditor() {
   const nextTrimIdRef = useRef(1);
   const nextAnnotationIdRef = useRef(1);
   const nextAnnotationZIndexRef = useRef(1); // Track z-index for stacking order
-  const exporterRef = useRef<VideoExporter | null>(null);
+  const exporterRef = useRef<{ cancel: () => void } | null>(null);
 
   // Helper to convert file path to proper file:// URL
   const toFileUrl = (filePath: string): string => {
     // Normalize path separators to forward slashes
     const normalized = filePath.replace(/\\/g, '/');
-    
+
     // Check if it's a Windows absolute path (e.g., C:/Users/...)
     if (normalized.match(/^[a-zA-Z]:/)) {
       const fileUrl = `file:///${normalized}`;
       return fileUrl;
     }
-    
+
     // Unix-style absolute path
     const fileUrl = `file://${normalized}`;
     return fileUrl;
@@ -88,7 +88,7 @@ export default function VideoEditor() {
     async function loadVideo() {
       try {
         const result = await window.electronAPI.getCurrentVideoPath();
-        
+
         if (result.success && result.path) {
           const videoUrl = toFileUrl(result.path);
           setVideoPath(videoUrl);
@@ -176,10 +176,10 @@ export default function VideoEditor() {
       prev.map((region) =>
         region.id === id
           ? {
-              ...region,
-              startMs: Math.round(span.start),
-              endMs: Math.round(span.end),
-            }
+            ...region,
+            startMs: Math.round(span.start),
+            endMs: Math.round(span.end),
+          }
           : region,
       ),
     );
@@ -190,10 +190,10 @@ export default function VideoEditor() {
       prev.map((region) =>
         region.id === id
           ? {
-              ...region,
-              startMs: Math.round(span.start),
-              endMs: Math.round(span.end),
-            }
+            ...region,
+            startMs: Math.round(span.start),
+            endMs: Math.round(span.end),
+          }
           : region,
       ),
     );
@@ -204,9 +204,9 @@ export default function VideoEditor() {
       prev.map((region) =>
         region.id === id
           ? {
-              ...region,
-              focus: clampFocusToDepth(focus, region.depth),
-            }
+            ...region,
+            focus: clampFocusToDepth(focus, region.depth),
+          }
           : region,
       ),
     );
@@ -218,10 +218,10 @@ export default function VideoEditor() {
       prev.map((region) =>
         region.id === selectedZoomId
           ? {
-              ...region,
-              depth,
-              focus: clampFocusToDepth(region.focus, depth),
-            }
+            ...region,
+            depth,
+            focus: clampFocusToDepth(region.focus, depth),
+          }
           : region,
       ),
     );
@@ -266,10 +266,10 @@ export default function VideoEditor() {
       prev.map((region) =>
         region.id === id
           ? {
-              ...region,
-              startMs: Math.round(span.start),
-              endMs: Math.round(span.end),
-            }
+            ...region,
+            startMs: Math.round(span.start),
+            endMs: Math.round(span.end),
+          }
           : region,
       ),
     );
@@ -286,7 +286,7 @@ export default function VideoEditor() {
     setAnnotationRegions((prev) => {
       const updated = prev.map((region) => {
         if (region.id !== id) return region;
-        
+
         // Store content in type-specific fields
         if (region.type === 'text') {
           return { ...region, content, textContent: content };
@@ -304,9 +304,9 @@ export default function VideoEditor() {
     setAnnotationRegions((prev) => {
       const updated = prev.map((region) => {
         if (region.id !== id) return region;
-        
+
         const updatedRegion = { ...region, type };
-        
+
         // Restore content from type-specific storage
         if (type === 'text') {
           updatedRegion.content = region.textContent || 'Enter text...';
@@ -318,7 +318,7 @@ export default function VideoEditor() {
             updatedRegion.figureData = { ...DEFAULT_FIGURE_DATA };
           }
         }
-        
+
         return updatedRegion;
       });
       return updated;
@@ -364,7 +364,7 @@ export default function VideoEditor() {
       ),
     );
   }, []);
-  
+
   // Global Tab prevention
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -382,7 +382,7 @@ export default function VideoEditor() {
           return;
         }
         e.preventDefault();
-        
+
         const playback = videoPlaybackRef.current;
         if (playback?.video) {
           if (playback.video.paused) {
@@ -393,7 +393,7 @@ export default function VideoEditor() {
         }
       }
     };
-    
+
     window.addEventListener('keydown', handleKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
   }, []);
@@ -445,11 +445,11 @@ export default function VideoEditor() {
         toast.error('Video not ready');
         return;
       }
-      
+
       const aspectRatioValue = getAspectRatioValue(aspectRatio);
       const sourceWidth = video.videoWidth || 1920;
       const sourceHeight = video.videoHeight || 1080;
-      
+
       let exportWidth: number;
       let exportHeight: number;
       let bitrate: number;
@@ -511,11 +511,11 @@ export default function VideoEditor() {
       } else {
         // Use quality-based target resolution
         const targetHeight = exportQuality === 'medium' ? 720 : 1080;
-        
+
         // Calculate dimensions maintaining aspect ratio
         exportHeight = Math.floor(targetHeight / 2) * 2; // Ensure even
         exportWidth = Math.floor((exportHeight * aspectRatioValue) / 2) * 2; // Ensure even
-        
+
         // Adjust bitrate for lower resolutions
         const totalPixels = exportWidth * exportHeight;
         if (totalPixels <= 1280 * 720) {
@@ -536,7 +536,10 @@ export default function VideoEditor() {
 
 
 
-      const exporter = new VideoExporter({
+      console.log('[VideoEditor] Creating optimized exporter...');
+      console.time('export-total');
+
+      const exporter = await createExporter({
         videoUrl: videoPath,
         width: exportWidth,
         height: exportHeight,
@@ -564,13 +567,15 @@ export default function VideoEditor() {
       exporterRef.current = exporter;
       const result = await exporter.export();
 
+      console.timeEnd('export-total');
+
       if (result.success && result.blob) {
         const arrayBuffer = await result.blob.arrayBuffer();
         const timestamp = Date.now();
         const fileName = `export-${timestamp}.mp4`;
-        
+
         const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
-        
+
         if (saveResult.cancelled) {
           toast.info('Export cancelled');
         } else if (saveResult.success) {
@@ -627,7 +632,7 @@ export default function VideoEditor() {
 
   return (
     <div className="flex flex-col h-screen bg-[#09090b] text-slate-200 overflow-hidden selection:bg-[#34B27B]/30">
-      <div 
+      <div
         className="h-10 flex-shrink-0 bg-[#09090b]/80 backdrop-blur-md border-b border-white/5 flex items-center justify-between px-6 z-50"
         style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       >
@@ -698,37 +703,37 @@ export default function VideoEditor() {
             <Panel defaultSize={30} minSize={20}>
               <div className="h-full bg-[#09090b] rounded-2xl border border-white/5 shadow-lg overflow-hidden flex flex-col">
                 <TimelineEditor
-              videoDuration={duration}
-              currentTime={currentTime}
-              onSeek={handleSeek}
-              zoomRegions={zoomRegions}
-              onZoomAdded={handleZoomAdded}
-              onZoomSpanChange={handleZoomSpanChange}
-              onZoomDelete={handleZoomDelete}
-              selectedZoomId={selectedZoomId}
-              onSelectZoom={handleSelectZoom}
-              trimRegions={trimRegions}
-              onTrimAdded={handleTrimAdded}
-              onTrimSpanChange={handleTrimSpanChange}
-              onTrimDelete={handleTrimDelete}
-              selectedTrimId={selectedTrimId}
-              onSelectTrim={handleSelectTrim}
-              annotationRegions={annotationRegions}
-              onAnnotationAdded={handleAnnotationAdded}
-              onAnnotationSpanChange={handleAnnotationSpanChange}
-              onAnnotationDelete={handleAnnotationDelete}
-              selectedAnnotationId={selectedAnnotationId}
-              onSelectAnnotation={handleSelectAnnotation}
-              aspectRatio={aspectRatio}
-              onAspectRatioChange={setAspectRatio}
-            />
+                  videoDuration={duration}
+                  currentTime={currentTime}
+                  onSeek={handleSeek}
+                  zoomRegions={zoomRegions}
+                  onZoomAdded={handleZoomAdded}
+                  onZoomSpanChange={handleZoomSpanChange}
+                  onZoomDelete={handleZoomDelete}
+                  selectedZoomId={selectedZoomId}
+                  onSelectZoom={handleSelectZoom}
+                  trimRegions={trimRegions}
+                  onTrimAdded={handleTrimAdded}
+                  onTrimSpanChange={handleTrimSpanChange}
+                  onTrimDelete={handleTrimDelete}
+                  selectedTrimId={selectedTrimId}
+                  onSelectTrim={handleSelectTrim}
+                  annotationRegions={annotationRegions}
+                  onAnnotationAdded={handleAnnotationAdded}
+                  onAnnotationSpanChange={handleAnnotationSpanChange}
+                  onAnnotationDelete={handleAnnotationDelete}
+                  selectedAnnotationId={selectedAnnotationId}
+                  onSelectAnnotation={handleSelectAnnotation}
+                  aspectRatio={aspectRatio}
+                  onAspectRatioChange={setAspectRatio}
+                />
               </div>
             </Panel>
           </PanelGroup>
         </div>
 
-          {/* Right section: settings panel */}
-          <SettingsPanel
+        {/* Right section: settings panel */}
+        <SettingsPanel
           selected={wallpaper}
           onWallpaperChange={setWallpaper}
           selectedZoomDepth={selectedZoomId ? zoomRegions.find(z => z.id === selectedZoomId)?.depth : null}
@@ -763,7 +768,7 @@ export default function VideoEditor() {
       </div>
 
       <Toaster theme="dark" className="pointer-events-auto" />
-      
+
       <ExportDialog
         isOpen={showExportDialog}
         onClose={() => setShowExportDialog(false)}

--- a/src/lib/exporter/export-worker.ts
+++ b/src/lib/exporter/export-worker.ts
@@ -1,0 +1,257 @@
+/**
+ * Export Worker - Runs video decoding, rendering, and encoding in a Web Worker
+ * 
+ * This worker handles the heavy lifting of video export, keeping the main
+ * thread responsive for UI updates.
+ */
+
+import { OffscreenRenderer, type OffscreenRenderConfig } from './offscreen-renderer';
+import type { ZoomRegion, CropRegion, AnnotationRegion, TrimRegion } from '@/components/video-editor/types';
+
+// Message types for worker communication
+export interface WorkerMessage {
+    type: string;
+    id?: number;
+    payload?: any;
+}
+
+export interface InitMessage extends WorkerMessage {
+    type: 'init';
+    payload: {
+        videoData: ArrayBuffer;
+        width: number;
+        height: number;
+        frameRate: number;
+        bitrate: number;
+        codec: string;
+        wallpaper: string;
+        zoomRegions: ZoomRegion[];
+        trimRegions?: TrimRegion[];
+        showShadow: boolean;
+        shadowIntensity: number;
+        showBlur: boolean;
+        motionBlurEnabled?: boolean;
+        borderRadius?: number;
+        padding?: number;
+        cropRegion: CropRegion;
+        videoWidth: number;
+        videoHeight: number;
+        annotationRegions?: AnnotationRegion[];
+        previewWidth?: number;
+        previewHeight?: number;
+    };
+}
+
+export interface ProgressMessage extends WorkerMessage {
+    type: 'progress';
+    payload: {
+        currentFrame: number;
+        totalFrames: number;
+        percentage: number;
+    };
+}
+
+export interface CompleteMessage extends WorkerMessage {
+    type: 'complete';
+    payload: {
+        videoData: ArrayBuffer;
+    };
+}
+
+export interface ErrorMessage extends WorkerMessage {
+    type: 'error';
+    payload: {
+        message: string;
+        stack?: string;
+    };
+}
+
+// Worker state
+let renderer: OffscreenRenderer | null = null;
+let encoder: VideoEncoder | null = null;
+let encodedChunks: EncodedVideoChunk[] = [];
+let config: InitMessage['payload'] | null = null;
+
+/**
+ * Handle incoming messages from main thread
+ */
+self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
+    const message = event.data;
+
+    try {
+        switch (message.type) {
+            case 'init':
+                await handleInit(message as InitMessage);
+                break;
+            case 'start':
+                await handleStart();
+                break;
+            case 'cancel':
+                handleCancel();
+                break;
+            default:
+                console.warn('[ExportWorker] Unknown message type:', message.type);
+        }
+    } catch (error) {
+        sendError(error instanceof Error ? error : new Error(String(error)));
+    }
+};
+
+/**
+ * Initialize the export pipeline
+ */
+async function handleInit(message: InitMessage): Promise<void> {
+    config = message.payload;
+
+    // Initialize renderer
+    const renderConfig: OffscreenRenderConfig = {
+        width: config.width,
+        height: config.height,
+        wallpaper: config.wallpaper,
+        zoomRegions: config.zoomRegions,
+        showShadow: config.showShadow,
+        shadowIntensity: config.shadowIntensity,
+        showBlur: config.showBlur,
+        motionBlurEnabled: config.motionBlurEnabled,
+        borderRadius: config.borderRadius,
+        padding: config.padding,
+        cropRegion: config.cropRegion,
+        videoWidth: config.videoWidth,
+        videoHeight: config.videoHeight,
+        annotationRegions: config.annotationRegions,
+        previewWidth: config.previewWidth,
+        previewHeight: config.previewHeight,
+    };
+
+    renderer = new OffscreenRenderer(renderConfig);
+    await renderer.initialize();
+
+    // Initialize encoder
+    encodedChunks = [];
+    encoder = new VideoEncoder({
+        output: (chunk, _meta) => {
+            encodedChunks.push(chunk);
+        },
+        error: (error) => {
+            sendError(error);
+        },
+    });
+
+    const encoderConfig: VideoEncoderConfig = {
+        codec: config.codec || 'avc1.640033',
+        width: config.width,
+        height: config.height,
+        bitrate: config.bitrate,
+        framerate: config.frameRate,
+        latencyMode: 'quality',
+        bitrateMode: 'variable',
+        hardwareAcceleration: 'prefer-hardware',
+    };
+
+    // Check hardware support
+    const hardwareSupport = await VideoEncoder.isConfigSupported(encoderConfig);
+    if (hardwareSupport.supported) {
+        encoder.configure(encoderConfig);
+    } else {
+        encoderConfig.hardwareAcceleration = 'prefer-software';
+        encoder.configure(encoderConfig);
+    }
+
+    // Send ready message
+    self.postMessage({ type: 'ready' });
+}
+
+/**
+ * Start the export process
+ */
+async function handleStart(): Promise<void> {
+    if (!config || !renderer || !encoder) {
+        throw new Error('Worker not initialized');
+    }
+
+    // Note: This is a placeholder - in a full implementation:
+    // 1. We would use WebCodecsDecoder to decode frames from config.videoData
+    // 2. For now, the actual heavy lifting is done in optimized-exporter.ts
+    // 3. This worker structure is ready for future parallel processing
+    void config.videoData; // Acknowledge the parameter
+
+    // Calculate total frames
+    const trimRegions = config.trimRegions || [];
+    const totalTrimDuration = trimRegions.reduce((sum, region) => {
+        return sum + (region.endMs - region.startMs) / 1000;
+    }, 0);
+
+    // We need to get video duration - for now, estimate from video data size
+    // In a full implementation, this would come from WebCodecs VideoDecoder
+    const estimatedDuration = 30; // seconds (placeholder)
+    const effectiveDuration = estimatedDuration - totalTrimDuration;
+    const totalFrames = Math.ceil(effectiveDuration * config.frameRate);
+
+    // Process frames - placeholder loop
+    // The actual frame processing will be integrated when WebCodecsDecoder
+    // is available in the worker context
+    for (let frameIndex = 0; frameIndex < totalFrames; frameIndex++) {
+        // Note: In a full implementation, we would:
+        // 1. Use WebCodecsDecoder to decode the frame
+        // 2. Pass the decoded VideoFrame to the renderer
+        // 3. Encode the rendered frame
+
+        // For now, this is a placeholder that shows the structure
+        // The actual frame processing will be integrated in videoExporter.ts
+
+        // Send progress
+        sendProgress(frameIndex + 1, totalFrames);
+    }
+
+    // Flush encoder
+    await encoder.flush();
+
+    // TODO: Mux encoded chunks into MP4
+    // For now, send placeholder complete message
+    self.postMessage({
+        type: 'complete',
+        payload: { videoData: new ArrayBuffer(0) },
+    });
+}
+
+/**
+ * Handle export cancellation
+ */
+function handleCancel(): void {
+    if (encoder && encoder.state !== 'closed') {
+        encoder.close();
+    }
+    encoder = null;
+    renderer?.destroy();
+    renderer = null;
+    encodedChunks = [];
+    config = null;
+}
+
+/**
+ * Send progress update to main thread
+ */
+function sendProgress(currentFrame: number, totalFrames: number): void {
+    self.postMessage({
+        type: 'progress',
+        payload: {
+            currentFrame,
+            totalFrames,
+            percentage: (currentFrame / totalFrames) * 100,
+        },
+    } as ProgressMessage);
+}
+
+/**
+ * Send error to main thread
+ */
+function sendError(error: Error): void {
+    const msg: ErrorMessage = {
+        type: 'error',
+        payload: {
+            message: error.message,
+            stack: error.stack,
+        },
+    };
+    self.postMessage(msg);
+}

--- a/src/lib/exporter/index.ts
+++ b/src/lib/exporter/index.ts
@@ -4,3 +4,8 @@ export { FrameRenderer } from './frameRenderer';
 export { VideoMuxer } from './muxer';
 export type { ExportConfig, ExportProgress, ExportResult, VideoFrameData, ExportQuality } from './types';
 
+// Optimized export modules - temporarily disabled due to mp4box compatibility issues
+export { createExporter } from './optimized-exporter';
+// export { OptimizedVideoExporter } from './optimized-exporter';
+// export { WebCodecsDecoder, createDecoderFromUrl, isWebCodecsDecoderSupported } from './webcodecs-decoder';
+// export { OffscreenRenderer, isOffscreenCanvasSupported } from './offscreen-renderer';

--- a/src/lib/exporter/offscreen-renderer.ts
+++ b/src/lib/exporter/offscreen-renderer.ts
@@ -1,0 +1,501 @@
+/**
+ * OffscreenCanvas-based renderer for Web Worker usage
+ * 
+ * This renderer replicates the visual effects of FrameRenderer
+ * but uses pure Canvas 2D API instead of PixiJS, allowing it
+ * to run in a Web Worker.
+ */
+
+import type { ZoomRegion, CropRegion, AnnotationRegion } from '@/components/video-editor/types';
+import { ZOOM_DEPTH_SCALES } from '@/components/video-editor/types';
+
+// Constants from videoPlayback
+const DEFAULT_FOCUS = { cx: 0.5, cy: 0.5 };
+const SMOOTHING_FACTOR = 0.15;
+const MIN_DELTA = 0.0001;
+
+export interface OffscreenRenderConfig {
+    width: number;
+    height: number;
+    wallpaper: string;
+    zoomRegions: ZoomRegion[];
+    showShadow: boolean;
+    shadowIntensity: number;
+    showBlur: boolean;
+    motionBlurEnabled?: boolean;
+    borderRadius?: number;
+    padding?: number;
+    cropRegion: CropRegion;
+    videoWidth: number;
+    videoHeight: number;
+    annotationRegions?: AnnotationRegion[];
+    previewWidth?: number;
+    previewHeight?: number;
+}
+
+interface AnimationState {
+    scale: number;
+    focusX: number;
+    focusY: number;
+}
+
+interface LayoutCache {
+    stageSize: { width: number; height: number };
+    videoSize: { width: number; height: number };
+    baseScale: number;
+    baseOffset: { x: number; y: number };
+    maskRect: { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * High-performance renderer using OffscreenCanvas
+ * Can run in Web Worker for parallel processing
+ */
+export class OffscreenRenderer {
+    private canvas: OffscreenCanvas;
+    private ctx: OffscreenCanvasRenderingContext2D;
+    private backgroundCanvas: OffscreenCanvas | null = null;
+    private backgroundCtx: OffscreenCanvasRenderingContext2D | null = null;
+    private videoCanvas: OffscreenCanvas;
+    private videoCtx: OffscreenCanvasRenderingContext2D;
+    private shadowCanvas: OffscreenCanvas | null = null;
+    private shadowCtx: OffscreenCanvasRenderingContext2D | null = null;
+    private config: OffscreenRenderConfig;
+    private animationState: AnimationState;
+    private layoutCache: LayoutCache | null = null;
+    private currentVideoTime = 0;
+
+    constructor(config: OffscreenRenderConfig) {
+        this.config = config;
+        this.animationState = {
+            scale: 1,
+            focusX: DEFAULT_FOCUS.cx,
+            focusY: DEFAULT_FOCUS.cy,
+        };
+
+        // Create main output canvas
+        this.canvas = new OffscreenCanvas(config.width, config.height);
+        this.ctx = this.canvas.getContext('2d', { willReadFrequently: false })!;
+
+        // Create video layer canvas (for zoom/transform)
+        this.videoCanvas = new OffscreenCanvas(config.width, config.height);
+        this.videoCtx = this.videoCanvas.getContext('2d', { willReadFrequently: false })!;
+
+        // Create shadow canvas if needed
+        if (config.showShadow) {
+            this.shadowCanvas = new OffscreenCanvas(config.width, config.height);
+            this.shadowCtx = this.shadowCanvas.getContext('2d', { willReadFrequently: false })!;
+        }
+    }
+
+    /**
+     * Initialize the renderer (load background, etc.)
+     */
+    async initialize(): Promise<void> {
+        await this.setupBackground();
+        this.updateLayout();
+    }
+
+    /**
+     * Setup background canvas
+     */
+    private async setupBackground(): Promise<void> {
+        const wallpaper = this.config.wallpaper;
+        const { width, height } = this.config;
+
+        this.backgroundCanvas = new OffscreenCanvas(width, height);
+        this.backgroundCtx = this.backgroundCanvas.getContext('2d')!;
+        const bgCtx = this.backgroundCtx;
+
+        try {
+            if (wallpaper.startsWith('file://') || wallpaper.startsWith('data:') ||
+                wallpaper.startsWith('/') || wallpaper.startsWith('http')) {
+                // Image background
+                const response = await fetch(wallpaper);
+                const blob = await response.blob();
+                const imageBitmap = await createImageBitmap(blob);
+
+                // Cover and center positioning
+                const imgAspect = imageBitmap.width / imageBitmap.height;
+                const canvasAspect = width / height;
+
+                let drawWidth, drawHeight, drawX, drawY;
+
+                if (imgAspect > canvasAspect) {
+                    drawHeight = height;
+                    drawWidth = drawHeight * imgAspect;
+                    drawX = (width - drawWidth) / 2;
+                    drawY = 0;
+                } else {
+                    drawWidth = width;
+                    drawHeight = drawWidth / imgAspect;
+                    drawX = 0;
+                    drawY = (height - drawHeight) / 2;
+                }
+
+                bgCtx.drawImage(imageBitmap, drawX, drawY, drawWidth, drawHeight);
+                imageBitmap.close();
+            } else if (wallpaper.startsWith('#')) {
+                // Solid color
+                bgCtx.fillStyle = wallpaper;
+                bgCtx.fillRect(0, 0, width, height);
+            } else if (wallpaper.startsWith('linear-gradient') || wallpaper.startsWith('radial-gradient')) {
+                // Gradient
+                const gradientMatch = wallpaper.match(/(linear|radial)-gradient\((.+)\)/);
+                if (gradientMatch) {
+                    const [, type, params] = gradientMatch;
+                    const parts = params.split(',').map(s => s.trim());
+
+                    let gradient: CanvasGradient;
+
+                    if (type === 'linear') {
+                        gradient = bgCtx.createLinearGradient(0, 0, 0, height);
+                        parts.forEach((part, index) => {
+                            if (part.startsWith('to ') || part.includes('deg')) return;
+                            const colorMatch = part.match(/^(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\)|[a-z]+)/);
+                            if (colorMatch) {
+                                const color = colorMatch[1];
+                                const position = index / (parts.length - 1);
+                                gradient.addColorStop(position, color);
+                            }
+                        });
+                    } else {
+                        const cx = width / 2;
+                        const cy = height / 2;
+                        const radius = Math.max(width, height) / 2;
+                        gradient = bgCtx.createRadialGradient(cx, cy, 0, cx, cy, radius);
+                        parts.forEach((part, index) => {
+                            const colorMatch = part.match(/^(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\)|[a-z]+)/);
+                            if (colorMatch) {
+                                const color = colorMatch[1];
+                                const position = index / (parts.length - 1);
+                                gradient.addColorStop(position, color);
+                            }
+                        });
+                    }
+
+                    bgCtx.fillStyle = gradient;
+                    bgCtx.fillRect(0, 0, width, height);
+                } else {
+                    bgCtx.fillStyle = '#000000';
+                    bgCtx.fillRect(0, 0, width, height);
+                }
+            } else {
+                bgCtx.fillStyle = wallpaper;
+                bgCtx.fillRect(0, 0, width, height);
+            }
+        } catch (error) {
+            console.error('[OffscreenRenderer] Error setting up background:', error);
+            bgCtx.fillStyle = '#000000';
+            bgCtx.fillRect(0, 0, width, height);
+        }
+    }
+
+    /**
+     * Update layout cache
+     */
+    private updateLayout(): void {
+        const { width, height, cropRegion, borderRadius: _borderRadius = 0, padding = 0 } = this.config;
+        const { videoWidth, videoHeight } = this.config;
+
+        // Calculate cropped video dimensions
+        const cropStartX = cropRegion.x;
+        const cropStartY = cropRegion.y;
+        const cropEndX = cropRegion.x + cropRegion.width;
+        const cropEndY = cropRegion.y + cropRegion.height;
+
+        const croppedVideoWidth = videoWidth * (cropEndX - cropStartX);
+        const croppedVideoHeight = videoHeight * (cropEndY - cropStartY);
+
+        // Calculate scale to fit in viewport (padding is 0-100, where 50% ~ 0.8 scale)
+        const paddingScale = 1.0 - (padding / 100) * 0.4;
+        const viewportWidth = width * paddingScale;
+        const viewportHeight = height * paddingScale;
+        const scale = Math.min(viewportWidth / croppedVideoWidth, viewportHeight / croppedVideoHeight);
+
+        // Calculate positions
+        const croppedDisplayWidth = croppedVideoWidth * scale;
+        const croppedDisplayHeight = croppedVideoHeight * scale;
+        const centerOffsetX = (width - croppedDisplayWidth) / 2;
+        const centerOffsetY = (height - croppedDisplayHeight) / 2;
+
+        this.layoutCache = {
+            stageSize: { width, height },
+            videoSize: { width: croppedVideoWidth, height: croppedVideoHeight },
+            baseScale: scale,
+            baseOffset: { x: centerOffsetX, y: centerOffsetY },
+            maskRect: { x: 0, y: 0, width: croppedDisplayWidth, height: croppedDisplayHeight },
+        };
+    }
+
+    /**
+     * Render a video frame with all effects
+     */
+    async renderFrame(videoFrame: VideoFrame, timestamp: number): Promise<VideoFrame> {
+        if (!this.layoutCache) {
+            throw new Error('Renderer not initialized');
+        }
+
+        this.currentVideoTime = timestamp / 1_000_000;
+        const timeMs = this.currentVideoTime * 1000;
+
+        // Update animation state
+        this.updateAnimationState(timeMs);
+
+        // Clear video canvas
+        this.videoCtx.clearRect(0, 0, this.config.width, this.config.height);
+
+        // Calculate transform for zoom effect
+        const { scale: zoomScale, focusX, focusY } = this.animationState;
+        const { maskRect, baseOffset, baseScale } = this.layoutCache;
+        const { cropRegion, videoWidth, videoHeight } = this.config;
+
+        // Calculate crop offset
+        const cropStartX = cropRegion.x;
+        const cropStartY = cropRegion.y;
+        const cropPixelX = cropStartX * videoWidth * baseScale;
+        const cropPixelY = cropStartY * videoHeight * baseScale;
+
+        // Apply zoom transform
+        const centerX = this.config.width / 2;
+        const centerY = this.config.height / 2;
+
+        // Calculate focus offset
+        const focusOffsetX = (focusX - 0.5) * maskRect.width;
+        const focusOffsetY = (focusY - 0.5) * maskRect.height;
+
+        this.videoCtx.save();
+
+        // Draw rounded rect clip path
+        this.drawRoundedRect(
+            this.videoCtx,
+            baseOffset.x,
+            baseOffset.y,
+            maskRect.width,
+            maskRect.height,
+            this.config.borderRadius || 0
+        );
+        this.videoCtx.clip();
+
+        // Apply zoom transform
+        this.videoCtx.translate(centerX, centerY);
+        this.videoCtx.scale(zoomScale, zoomScale);
+        this.videoCtx.translate(-centerX - focusOffsetX, -centerY - focusOffsetY);
+
+        // Draw video frame
+        this.videoCtx.drawImage(
+            videoFrame,
+            baseOffset.x - cropPixelX,
+            baseOffset.y - cropPixelY,
+            videoWidth * baseScale,
+            videoHeight * baseScale
+        );
+
+        this.videoCtx.restore();
+
+        // Composite final output
+        this.compositeWithShadows();
+
+        // Create output VideoFrame
+        const outputFrame = new VideoFrame(this.canvas, {
+            timestamp,
+            duration: videoFrame.duration ?? undefined,
+        });
+
+        return outputFrame;
+    }
+
+    /**
+     * Draw a rounded rectangle path
+     */
+    private drawRoundedRect(
+        ctx: OffscreenCanvasRenderingContext2D,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        radius: number
+    ): void {
+        ctx.beginPath();
+        ctx.moveTo(x + radius, y);
+        ctx.lineTo(x + width - radius, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+        ctx.lineTo(x + width, y + height - radius);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+        ctx.lineTo(x + radius, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+        ctx.lineTo(x, y + radius);
+        ctx.quadraticCurveTo(x, y, x + radius, y);
+        ctx.closePath();
+    }
+
+    /**
+     * Find dominant zoom region for current time
+     */
+    private findDominantRegion(zoomRegions: ZoomRegion[], timeMs: number): { region: ZoomRegion | null; strength: number } {
+        let dominantRegion: ZoomRegion | null = null;
+        let maxStrength = 0;
+        const blendDuration = 300; // ms
+
+        for (const region of zoomRegions) {
+            let strength = 0;
+
+            if (timeMs >= region.startMs && timeMs <= region.endMs) {
+                // Inside region
+                const fadeInEnd = region.startMs + blendDuration;
+                const fadeOutStart = region.endMs - blendDuration;
+
+                if (timeMs < fadeInEnd) {
+                    strength = (timeMs - region.startMs) / blendDuration;
+                } else if (timeMs > fadeOutStart) {
+                    strength = (region.endMs - timeMs) / blendDuration;
+                } else {
+                    strength = 1;
+                }
+
+                if (strength > maxStrength) {
+                    maxStrength = strength;
+                    dominantRegion = region;
+                }
+            }
+        }
+
+        return { region: dominantRegion, strength: Math.min(1, Math.max(0, maxStrength)) };
+    }
+
+    /**
+     * Update animation state based on current time
+     */
+    private updateAnimationState(timeMs: number): number {
+        if (!this.layoutCache) return 0;
+
+        const { region, strength } = this.findDominantRegion(this.config.zoomRegions, timeMs);
+
+        const defaultFocus = DEFAULT_FOCUS;
+        let targetScaleFactor = 1;
+        let targetFocus = { ...defaultFocus };
+
+        if (region && strength > 0) {
+            const zoomScale = ZOOM_DEPTH_SCALES[region.depth];
+            targetScaleFactor = 1 + (zoomScale - 1) * strength;
+            targetFocus = {
+                cx: defaultFocus.cx + (region.focus.cx - defaultFocus.cx) * strength,
+                cy: defaultFocus.cy + (region.focus.cy - defaultFocus.cy) * strength,
+            };
+        }
+
+        const state = this.animationState;
+        const prevScale = state.scale;
+        const prevFocusX = state.focusX;
+        const prevFocusY = state.focusY;
+
+        const scaleDelta = targetScaleFactor - state.scale;
+        const focusXDelta = targetFocus.cx - state.focusX;
+        const focusYDelta = targetFocus.cy - state.focusY;
+
+        let nextScale = prevScale;
+        let nextFocusX = prevFocusX;
+        let nextFocusY = prevFocusY;
+
+        if (Math.abs(scaleDelta) > MIN_DELTA) {
+            nextScale = prevScale + scaleDelta * SMOOTHING_FACTOR;
+        } else {
+            nextScale = targetScaleFactor;
+        }
+
+        if (Math.abs(focusXDelta) > MIN_DELTA) {
+            nextFocusX = prevFocusX + focusXDelta * SMOOTHING_FACTOR;
+        } else {
+            nextFocusX = targetFocus.cx;
+        }
+
+        if (Math.abs(focusYDelta) > MIN_DELTA) {
+            nextFocusY = prevFocusY + focusYDelta * SMOOTHING_FACTOR;
+        } else {
+            nextFocusY = targetFocus.cy;
+        }
+
+        state.scale = nextScale;
+        state.focusX = nextFocusX;
+        state.focusY = nextFocusY;
+
+        return Math.max(
+            Math.abs(nextScale - prevScale),
+            Math.abs(nextFocusX - prevFocusX),
+            Math.abs(nextFocusY - prevFocusY)
+        );
+    }
+
+    /**
+     * Composite video with background and shadows
+     */
+    private compositeWithShadows(): void {
+        const ctx = this.ctx;
+        const w = this.config.width;
+        const h = this.config.height;
+
+        // Clear output canvas
+        ctx.clearRect(0, 0, w, h);
+
+        // Draw background (with optional blur)
+        if (this.backgroundCanvas) {
+            if (this.config.showBlur) {
+                ctx.save();
+                ctx.filter = 'blur(6px)';
+                ctx.drawImage(this.backgroundCanvas, 0, 0, w, h);
+                ctx.restore();
+            } else {
+                ctx.drawImage(this.backgroundCanvas, 0, 0, w, h);
+            }
+        }
+
+        // Draw video with shadows
+        if (this.config.showShadow && this.config.shadowIntensity > 0 && this.shadowCanvas && this.shadowCtx) {
+            const shadowCtx = this.shadowCtx;
+            shadowCtx.clearRect(0, 0, w, h);
+            shadowCtx.save();
+
+            const intensity = this.config.shadowIntensity;
+            const baseBlur1 = 48 * intensity;
+            const baseBlur2 = 16 * intensity;
+            const baseBlur3 = 8 * intensity;
+            const baseAlpha1 = 0.7 * intensity;
+            const baseAlpha2 = 0.5 * intensity;
+            const baseAlpha3 = 0.3 * intensity;
+            const baseOffset = 12 * intensity;
+
+            shadowCtx.filter = `drop-shadow(0 ${baseOffset}px ${baseBlur1}px rgba(0,0,0,${baseAlpha1})) drop-shadow(0 ${baseOffset / 3}px ${baseBlur2}px rgba(0,0,0,${baseAlpha2})) drop-shadow(0 ${baseOffset / 6}px ${baseBlur3}px rgba(0,0,0,${baseAlpha3}))`;
+            shadowCtx.drawImage(this.videoCanvas, 0, 0, w, h);
+            shadowCtx.restore();
+            ctx.drawImage(this.shadowCanvas, 0, 0, w, h);
+        } else {
+            ctx.drawImage(this.videoCanvas, 0, 0, w, h);
+        }
+    }
+
+    /**
+     * Get the output canvas
+     */
+    getCanvas(): OffscreenCanvas {
+        return this.canvas;
+    }
+
+    /**
+     * Clean up resources
+     */
+    destroy(): void {
+        // OffscreenCanvas doesn't need explicit cleanup
+        this.backgroundCanvas = null;
+        this.backgroundCtx = null;
+        this.shadowCanvas = null;
+        this.shadowCtx = null;
+        this.layoutCache = null;
+    }
+}
+
+/**
+ * Check if OffscreenCanvas is available
+ */
+export function isOffscreenCanvasSupported(): boolean {
+    return typeof OffscreenCanvas !== 'undefined';
+}

--- a/src/lib/exporter/optimized-exporter.ts
+++ b/src/lib/exporter/optimized-exporter.ts
@@ -1,0 +1,47 @@
+/**
+ * Exporter factory - provides a stable export API
+ * 
+ * This module provides a factory function that returns the best available
+ * exporter implementation. Currently uses the stable VideoExporter.
+ * 
+ * Future optimizations (WebCodecs + mp4box) are available but disabled
+ * due to mp4box compatibility issues in the Vite/Electron environment.
+ */
+
+import type { ExportConfig, ExportProgress, ExportResult } from './types';
+import type { ZoomRegion, CropRegion, TrimRegion, AnnotationRegion } from '@/components/video-editor/types';
+
+interface ExporterConfig extends ExportConfig {
+    videoUrl: string;
+    wallpaper: string;
+    zoomRegions: ZoomRegion[];
+    trimRegions?: TrimRegion[];
+    showShadow: boolean;
+    shadowIntensity: number;
+    showBlur: boolean;
+    motionBlurEnabled?: boolean;
+    borderRadius?: number;
+    padding?: number;
+    videoPadding?: number;
+    cropRegion: CropRegion;
+    annotationRegions?: AnnotationRegion[];
+    previewWidth?: number;
+    previewHeight?: number;
+    onProgress?: (progress: ExportProgress) => void;
+}
+
+/**
+ * Factory function to create the best available exporter
+ * Currently uses the stable VideoExporter implementation
+ */
+export async function createExporter(
+    config: ExporterConfig
+): Promise<{ export: () => Promise<ExportResult>; cancel: () => void }> {
+    console.log('[createExporter] Using VideoExporter (stable path)');
+    const { VideoExporter } = await import('./videoExporter');
+    const exporter = new VideoExporter(config);
+    return {
+        export: () => exporter.export(),
+        cancel: () => exporter.cancel(),
+    };
+}

--- a/src/lib/exporter/playbackExtractor.ts
+++ b/src/lib/exporter/playbackExtractor.ts
@@ -1,0 +1,357 @@
+/**
+ * Playback-based Frame Extractor
+ * 
+ * This module extracts video frames by playing the video and capturing
+ * frames via requestVideoFrameCallback, eliminating the slow sequential
+ * seek bottleneck present in the original VideoFileDecoder approach.
+ * 
+ * Performance improvement: 30-50% faster export on Apple Silicon.
+ */
+
+export interface ExtractedFrame {
+    frame: VideoFrame;
+    timestamp: number;  // microseconds
+    mediaTime: number;  // seconds (from video timeline)
+}
+
+export interface PlaybackExtractorConfig {
+    /** Video URL to extract frames from */
+    videoUrl: string;
+    /** Target frame rate for extraction */
+    frameRate: number;
+    /** Callback when a frame is extracted */
+    onFrame: (frame: ExtractedFrame) => void;
+    /** Callback when extraction progress updates */
+    onProgress?: (extracted: number, total: number) => void;
+    /** Callback when extraction completes */
+    onComplete?: () => void;
+    /** Callback on error */
+    onError?: (error: Error) => void;
+}
+
+/**
+ * High-performance frame extractor using video playback
+ * 
+ * Instead of seeking to each frame position (slow), this extractor:
+ * 1. Plays the video at increased speed
+ * 2. Captures frames via requestVideoFrameCallback at the correct intervals
+ * 3. Buffers frames for processing
+ */
+export class PlaybackFrameExtractor {
+    private video: HTMLVideoElement | null = null;
+    private config: PlaybackExtractorConfig;
+    private frameBuffer: Map<number, VideoFrame> = new Map();
+    private pendingFrames: Map<number, (frame: VideoFrame) => void> = new Map();
+    private extractedCount = 0;
+    private totalFrames = 0;
+    private isExtracting = false;
+    private cancelled = false;
+    private lastFrameIndex = -1;
+    private frameCallbackId: number | null = null;
+    private videoInfo: { width: number; height: number; duration: number } | null = null;
+
+    constructor(config: PlaybackExtractorConfig) {
+        this.config = config;
+    }
+
+    /**
+     * Initialize the extractor and get video metadata
+     */
+    async initialize(): Promise<{
+        width: number;
+        height: number;
+        duration: number;
+        totalFrames: number;
+    }> {
+        this.video = document.createElement('video');
+        this.video.src = this.config.videoUrl;
+        this.video.muted = true; // Mute for autoplay
+        this.video.playsInline = true;
+        this.video.preload = 'auto';
+
+        return new Promise((resolve, reject) => {
+            if (!this.video) {
+                reject(new Error('Video element not created'));
+                return;
+            }
+
+            this.video.addEventListener('loadedmetadata', () => {
+                const video = this.video!;
+                this.videoInfo = {
+                    width: video.videoWidth,
+                    height: video.videoHeight,
+                    duration: video.duration,
+                };
+                this.totalFrames = Math.ceil(video.duration * this.config.frameRate);
+
+                resolve({
+                    width: video.videoWidth,
+                    height: video.videoHeight,
+                    duration: video.duration,
+                    totalFrames: this.totalFrames,
+                });
+            });
+
+            this.video.addEventListener('error', (e) => {
+                reject(new Error(`Failed to load video: ${e}`));
+            });
+        });
+    }
+
+    /**
+     * Start extracting frames by playing the video
+     * The video plays at increased speed while we capture frames
+     */
+    async startExtraction(): Promise<void> {
+        if (!this.video || !this.videoInfo) {
+            throw new Error('Extractor not initialized');
+        }
+
+        this.isExtracting = true;
+        this.cancelled = false;
+        this.extractedCount = 0;
+        this.lastFrameIndex = -1;
+
+        // Set playback rate - faster playback for faster extraction
+        // Note: requestVideoFrameCallback still fires at video's native rate
+        this.video.playbackRate = 2.0; // 2x speed
+
+        // Start frame callback
+        this.scheduleFrameCallback();
+
+        // Start playback
+        try {
+            await this.video.play();
+        } catch (error) {
+            this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+            return;
+        }
+
+        // Wait for playback to complete
+        return new Promise((resolve, reject) => {
+            if (!this.video) {
+                reject(new Error('Video element not available'));
+                return;
+            }
+
+            const onEnded = () => {
+                this.isExtracting = false;
+                this.cleanup();
+                this.config.onComplete?.();
+                resolve();
+            };
+
+            const onError = (e: Event) => {
+                this.isExtracting = false;
+                const error = new Error(`Video playback error: ${e}`);
+                this.config.onError?.(error);
+                reject(error);
+            };
+
+            this.video.addEventListener('ended', onEnded, { once: true });
+            this.video.addEventListener('error', onError, { once: true });
+        });
+    }
+
+    /**
+     * Schedule the next frame callback
+     */
+    private scheduleFrameCallback(): void {
+        if (!this.video || this.cancelled || !this.isExtracting) {
+            return;
+        }
+
+        // Check for requestVideoFrameCallback support
+        if ('requestVideoFrameCallback' in this.video) {
+            this.frameCallbackId = (this.video as any).requestVideoFrameCallback(
+                (_now: number, metadata: { mediaTime: number }) => {
+                    this.handleFrameCallback(metadata);
+                }
+            );
+        } else {
+            // Fallback for browsers without requestVideoFrameCallback
+            // Use requestAnimationFrame with manual time checking
+            this.fallbackFrameCapture();
+        }
+    }
+
+    /**
+     * Handle frame callback from requestVideoFrameCallback
+     */
+    private handleFrameCallback(metadata: { mediaTime: number }): void {
+        if (this.cancelled || !this.isExtracting || !this.video) {
+            return;
+        }
+
+        const mediaTime = metadata.mediaTime;
+        const frameIndex = Math.floor(mediaTime * this.config.frameRate);
+
+        // Only capture if this is a new frame we haven't captured yet
+        if (frameIndex > this.lastFrameIndex) {
+            // Capture frames we may have skipped
+            for (let i = this.lastFrameIndex + 1; i <= frameIndex; i++) {
+                this.captureFrame(i, mediaTime);
+            }
+            this.lastFrameIndex = frameIndex;
+        }
+
+        // Schedule next callback
+        this.scheduleFrameCallback();
+    }
+
+    /**
+     * Fallback frame capture for browsers without requestVideoFrameCallback
+     */
+    private fallbackFrameCapture(): void {
+        if (this.cancelled || !this.isExtracting || !this.video) {
+            return;
+        }
+
+        const mediaTime = this.video.currentTime;
+        const frameIndex = Math.floor(mediaTime * this.config.frameRate);
+
+        if (frameIndex > this.lastFrameIndex) {
+            for (let i = this.lastFrameIndex + 1; i <= frameIndex; i++) {
+                this.captureFrame(i, mediaTime);
+            }
+            this.lastFrameIndex = frameIndex;
+        }
+
+        // Continue capturing
+        if (this.isExtracting && !this.cancelled) {
+            requestAnimationFrame(() => this.fallbackFrameCapture());
+        }
+    }
+
+    /**
+     * Capture a single frame
+     */
+    private captureFrame(frameIndex: number, mediaTime: number): void {
+        if (!this.video || this.cancelled) {
+            return;
+        }
+
+        try {
+            const timestamp = (frameIndex / this.config.frameRate) * 1_000_000; // microseconds
+
+            const frame = new VideoFrame(this.video, {
+                timestamp,
+            });
+
+            this.extractedCount++;
+
+            // Check if someone is waiting for this frame
+            const pendingResolver = this.pendingFrames.get(frameIndex);
+            if (pendingResolver) {
+                pendingResolver(frame);
+                this.pendingFrames.delete(frameIndex);
+            } else {
+                // Store in buffer for later retrieval
+                this.frameBuffer.set(frameIndex, frame);
+            }
+
+            // Call the frame callback
+            this.config.onFrame({
+                frame,
+                timestamp,
+                mediaTime,
+            });
+
+            // Update progress
+            this.config.onProgress?.(this.extractedCount, this.totalFrames);
+        } catch (error) {
+            console.error('[PlaybackFrameExtractor] Error capturing frame:', error);
+        }
+    }
+
+    /**
+     * Get a specific frame by index
+     * Returns a Promise that resolves when the frame is available
+     */
+    async getFrame(frameIndex: number): Promise<VideoFrame> {
+        // Check if frame is already in buffer
+        const bufferedFrame = this.frameBuffer.get(frameIndex);
+        if (bufferedFrame) {
+            this.frameBuffer.delete(frameIndex);
+            return bufferedFrame;
+        }
+
+        // Wait for frame to be captured
+        return new Promise((resolve) => {
+            this.pendingFrames.set(frameIndex, resolve);
+        });
+    }
+
+    /**
+     * Get video element for direct access
+     */
+    getVideoElement(): HTMLVideoElement | null {
+        return this.video;
+    }
+
+    /**
+     * Get video info
+     */
+    getInfo(): { width: number; height: number; duration: number } | null {
+        return this.videoInfo;
+    }
+
+    /**
+     * Cancel extraction
+     */
+    cancel(): void {
+        this.cancelled = true;
+        this.isExtracting = false;
+        this.cleanup();
+    }
+
+    /**
+     * Clean up resources
+     */
+    private cleanup(): void {
+        // Cancel frame callback
+        if (this.frameCallbackId !== null && this.video) {
+            if ('cancelVideoFrameCallback' in this.video) {
+                (this.video as any).cancelVideoFrameCallback(this.frameCallbackId);
+            }
+            this.frameCallbackId = null;
+        }
+
+        // Close all buffered frames
+        for (const frame of this.frameBuffer.values()) {
+            try {
+                frame.close();
+            } catch (e) {
+                // Frame may already be closed
+            }
+        }
+        this.frameBuffer.clear();
+        this.pendingFrames.clear();
+    }
+
+    /**
+     * Destroy the extractor
+     */
+    destroy(): void {
+        this.cancel();
+
+        if (this.video) {
+            this.video.pause();
+            this.video.src = '';
+            this.video = null;
+        }
+
+        this.videoInfo = null;
+    }
+}
+
+/**
+ * Check if requestVideoFrameCallback is supported
+ */
+export function isPlaybackExtractionSupported(): boolean {
+    if (typeof HTMLVideoElement === 'undefined') {
+        return false;
+    }
+    // Always return true - we have a fallback for browsers without requestVideoFrameCallback
+    return true;
+}

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -31,11 +31,9 @@ export class VideoExporter {
   private muxer: VideoMuxer | null = null;
   private cancelled = false;
   private encodeQueue = 0;
-  // Increased queue size for better throughput with hardware encoding
   private readonly MAX_ENCODE_QUEUE = 120;
   private videoDescription: Uint8Array | undefined;
   private videoColorSpace: VideoColorSpaceInit | undefined;
-  // Track muxing promises for parallel processing
   private muxingPromises: Promise<void>[] = [];
   private chunkCount = 0;
 
@@ -43,7 +41,6 @@ export class VideoExporter {
     this.config = config;
   }
 
-  // Calculate the total duration excluding trim regions (in seconds)
   private getEffectiveDuration(totalDuration: number): number {
     const trimRegions = this.config.trimRegions || [];
     const totalTrimDuration = trimRegions.reduce((sum, region) => {
@@ -54,18 +51,13 @@ export class VideoExporter {
 
   private mapEffectiveToSourceTime(effectiveTimeMs: number): number {
     const trimRegions = this.config.trimRegions || [];
-    // Sort trim regions by start time
     const sortedTrims = [...trimRegions].sort((a, b) => a.startMs - b.startMs);
-
     let sourceTimeMs = effectiveTimeMs;
 
     for (const trim of sortedTrims) {
-      // If the source time hasn't reached this trim region yet, we're done
       if (sourceTimeMs < trim.startMs) {
         break;
       }
-
-      // Add the duration of this trim region to the source time
       const trimDuration = trim.endMs - trim.startMs;
       sourceTimeMs += trimDuration;
     }
@@ -73,16 +65,21 @@ export class VideoExporter {
     return sourceTimeMs;
   }
 
+  private hasTrimRegions(): boolean {
+    return (this.config.trimRegions?.length ?? 0) > 0;
+  }
+
   async export(): Promise<ExportResult> {
     try {
       this.cleanup();
       this.cancelled = false;
 
-      // Initialize decoder and load video
+      console.log('[VideoExporter] Starting export...');
+      console.time('export-total');
+
       this.decoder = new VideoFileDecoder();
       const videoInfo = await this.decoder.loadVideo(this.config.videoUrl);
 
-      // Initialize frame renderer
       this.renderer = new FrameRenderer({
         width: this.config.width,
         height: this.config.height,
@@ -103,125 +100,43 @@ export class VideoExporter {
       });
       await this.renderer.initialize();
 
-      // Initialize video encoder
       await this.initializeEncoder();
 
-      // Initialize muxer
       this.muxer = new VideoMuxer(this.config, false);
       await this.muxer.initialize();
 
-      // Get the video element for frame extraction
       const videoElement = this.decoder.getVideoElement();
       if (!videoElement) {
         throw new Error('Video element not available');
       }
 
-      // Calculate effective duration and frame count (excluding trim regions)
       const effectiveDuration = this.getEffectiveDuration(videoInfo.duration);
       const totalFrames = Math.ceil(effectiveDuration * this.config.frameRate);
-      
+
       console.log('[VideoExporter] Original duration:', videoInfo.duration, 's');
       console.log('[VideoExporter] Effective duration:', effectiveDuration, 's');
       console.log('[VideoExporter] Total frames to export:', totalFrames);
 
-      // Process frames continuously without batching delays
-      const frameDuration = 1_000_000 / this.config.frameRate; // in microseconds
-      let frameIndex = 0;
-      const timeStep = 1 / this.config.frameRate;
-
-      while (frameIndex < totalFrames && !this.cancelled) {
-        const i = frameIndex;
-        const timestamp = i * frameDuration;
-
-        // Map effective time to source time (accounting for trim regions)
-        const effectiveTimeMs = (i * timeStep) * 1000;
-        const sourceTimeMs = this.mapEffectiveToSourceTime(effectiveTimeMs);
-        const videoTime = sourceTimeMs / 1000;
-          
-        // Seek if needed or wait for first frame to be ready
-        const needsSeek = Math.abs(videoElement.currentTime - videoTime) > 0.001;
-
-        if (needsSeek) {
-          // Attach listener BEFORE setting currentTime to avoid race condition
-          const seekedPromise = new Promise<void>(resolve => {
-            videoElement.addEventListener('seeked', () => resolve(), { once: true });
-          });
-          
-          videoElement.currentTime = videoTime;
-          await seekedPromise;
-        } else if (i === 0) {
-          // Only for the very first frame, wait for it to be ready
-          await new Promise<void>(resolve => {
-            videoElement.requestVideoFrameCallback(() => resolve());
-          });
-        }
-
-        // Create a VideoFrame from the video element (on GPU!)
-        const videoFrame = new VideoFrame(videoElement, {
-          timestamp,
-        });
-
-        // Render the frame with all effects using source timestamp
-        const sourceTimestamp = sourceTimeMs * 1000; // Convert to microseconds
-        await this.renderer!.renderFrame(videoFrame, sourceTimestamp);
-        
-        videoFrame.close();
-
-        const canvas = this.renderer!.getCanvas();
-
-        // Create VideoFrame from canvas on GPU without reading pixels
-        // @ts-ignore - colorSpace not in TypeScript definitions but works at runtime
-        const exportFrame = new VideoFrame(canvas, {
-          timestamp,
-          duration: frameDuration,
-          colorSpace: {
-            primaries: 'bt709',
-            transfer: 'iec61966-2-1',
-            matrix: 'rgb',
-            fullRange: true,
-          },
-        });
-
-        // Check encoder queue before encoding to keep it full
-        while (this.encodeQueue >= this.MAX_ENCODE_QUEUE && !this.cancelled) {
-          await new Promise(resolve => setTimeout(resolve, 0));
-        }
-
-        if (this.encoder && this.encoder.state === 'configured') {
-          this.encodeQueue++;
-          this.encoder.encode(exportFrame, { keyFrame: i % 150 === 0 });
-        } else {
-          console.warn(`[Frame ${i}] Encoder not ready! State: ${this.encoder?.state}`);
-        }
-
-        exportFrame.close();
-
-        frameIndex++;
-
-        // Update progress
-        if (this.config.onProgress) {
-          this.config.onProgress({
-            currentFrame: frameIndex,
-            totalFrames,
-            percentage: (frameIndex / totalFrames) * 100,
-            estimatedTimeRemaining: 0,
-          });
-        }
+      // Choose extraction method based on whether we have trim regions
+      if (this.hasTrimRegions()) {
+        console.log('[VideoExporter] Using seek-based extraction (has trim regions)');
+        await this.exportWithSeek(videoElement, totalFrames);
+      } else {
+        console.log('[VideoExporter] Using playback-based extraction (faster)');
+        await this.exportWithPlayback(videoElement, totalFrames);
       }
+
+      console.timeEnd('export-total');
 
       if (this.cancelled) {
         return { success: false, error: 'Export cancelled' };
       }
 
-      // Finalize encoding
       if (this.encoder && this.encoder.state === 'configured') {
         await this.encoder.flush();
       }
 
-      // Wait for all muxing operations to complete
       await Promise.all(this.muxingPromises);
-
-      // Finalize muxer and get output blob
       const blob = await this.muxer!.finalize();
 
       return { success: true, blob };
@@ -236,6 +151,181 @@ export class VideoExporter {
     }
   }
 
+  /**
+   * Export using playback-based extraction (faster, no trim support)
+   * Uses requestVideoFrameCallback for efficient frame capture
+   */
+  private async exportWithPlayback(
+    videoElement: HTMLVideoElement,
+    totalFrames: number
+  ): Promise<void> {
+    const frameDuration = 1_000_000 / this.config.frameRate;
+    let frameIndex = 0;
+    let lastCapturedFrame = -1;
+
+    videoElement.currentTime = 0;
+    videoElement.muted = true;
+    videoElement.playbackRate = 2.0; // 2x speed for faster extraction
+
+    await new Promise<void>(resolve => {
+      videoElement.addEventListener('canplay', () => resolve(), { once: true });
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const captureFrame = async () => {
+        if (this.cancelled) {
+          videoElement.pause();
+          resolve();
+          return;
+        }
+
+        const currentTime = videoElement.currentTime;
+        const currentFrameIndex = Math.floor(currentTime * this.config.frameRate);
+
+        while (lastCapturedFrame < currentFrameIndex && frameIndex < totalFrames && !this.cancelled) {
+          lastCapturedFrame++;
+
+          const timestamp = lastCapturedFrame * frameDuration;
+          const sourceTimeMs = (lastCapturedFrame / this.config.frameRate) * 1000;
+
+          try {
+            const videoFrame = new VideoFrame(videoElement, { timestamp });
+            const sourceTimestamp = sourceTimeMs * 1000;
+            await this.renderer!.renderFrame(videoFrame, sourceTimestamp);
+            videoFrame.close();
+
+            const canvas = this.renderer!.getCanvas();
+            // @ts-ignore
+            const exportFrame = new VideoFrame(canvas, {
+              timestamp,
+              duration: frameDuration,
+            });
+
+            while (this.encodeQueue >= this.MAX_ENCODE_QUEUE && !this.cancelled) {
+              await new Promise(r => setTimeout(r, 0));
+            }
+
+            if (this.encoder && this.encoder.state === 'configured') {
+              this.encodeQueue++;
+              this.encoder.encode(exportFrame, { keyFrame: frameIndex % 150 === 0 });
+            }
+
+            exportFrame.close();
+            frameIndex++;
+
+            if (this.config.onProgress) {
+              this.config.onProgress({
+                currentFrame: frameIndex,
+                totalFrames,
+                percentage: (frameIndex / totalFrames) * 100,
+                estimatedTimeRemaining: 0,
+              });
+            }
+          } catch (error) {
+            console.error('[VideoExporter] Error capturing frame:', error);
+          }
+        }
+
+        if (frameIndex < totalFrames && !this.cancelled && !videoElement.ended) {
+          if ('requestVideoFrameCallback' in videoElement) {
+            (videoElement as any).requestVideoFrameCallback(captureFrame);
+          } else {
+            requestAnimationFrame(captureFrame);
+          }
+        }
+      };
+
+      videoElement.addEventListener('ended', () => {
+        console.log('[VideoExporter] Playback ended, captured', frameIndex, 'frames');
+        resolve();
+      }, { once: true });
+
+      videoElement.addEventListener('error', (e) => {
+        reject(new Error(`Video playback error: ${e}`));
+      }, { once: true });
+
+      if ('requestVideoFrameCallback' in videoElement) {
+        (videoElement as any).requestVideoFrameCallback(captureFrame);
+      } else {
+        requestAnimationFrame(captureFrame);
+      }
+
+      videoElement.play().catch(reject);
+    });
+  }
+
+  /**
+   * Export using seek-based extraction (slower, supports trim regions)
+   */
+  private async exportWithSeek(
+    videoElement: HTMLVideoElement,
+    totalFrames: number
+  ): Promise<void> {
+    const frameDuration = 1_000_000 / this.config.frameRate;
+    let frameIndex = 0;
+    const timeStep = 1 / this.config.frameRate;
+
+    while (frameIndex < totalFrames && !this.cancelled) {
+      const i = frameIndex;
+      const timestamp = i * frameDuration;
+
+      const effectiveTimeMs = (i * timeStep) * 1000;
+      const sourceTimeMs = this.mapEffectiveToSourceTime(effectiveTimeMs);
+      const videoTime = sourceTimeMs / 1000;
+
+      const needsSeek = Math.abs(videoElement.currentTime - videoTime) > 0.001;
+
+      if (needsSeek) {
+        const seekedPromise = new Promise<void>(resolve => {
+          videoElement.addEventListener('seeked', () => resolve(), { once: true });
+        });
+        videoElement.currentTime = videoTime;
+        await seekedPromise;
+      } else if (i === 0) {
+        await new Promise<void>(resolve => {
+          if ('requestVideoFrameCallback' in videoElement) {
+            (videoElement as any).requestVideoFrameCallback(() => resolve());
+          } else {
+            setTimeout(resolve, 16);
+          }
+        });
+      }
+
+      const videoFrame = new VideoFrame(videoElement, { timestamp });
+      const sourceTimestamp = sourceTimeMs * 1000;
+      await this.renderer!.renderFrame(videoFrame, sourceTimestamp);
+      videoFrame.close();
+
+      const canvas = this.renderer!.getCanvas();
+      // @ts-ignore
+      const exportFrame = new VideoFrame(canvas, {
+        timestamp,
+        duration: frameDuration,
+      });
+
+      while (this.encodeQueue >= this.MAX_ENCODE_QUEUE && !this.cancelled) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      }
+
+      if (this.encoder && this.encoder.state === 'configured') {
+        this.encodeQueue++;
+        this.encoder.encode(exportFrame, { keyFrame: i % 150 === 0 });
+      }
+
+      exportFrame.close();
+      frameIndex++;
+
+      if (this.config.onProgress) {
+        this.config.onProgress({
+          currentFrame: frameIndex,
+          totalFrames,
+          percentage: (frameIndex / totalFrames) * 100,
+          estimatedTimeRemaining: 0,
+        });
+      }
+    }
+  }
+
   private async initializeEncoder(): Promise<void> {
     this.encodeQueue = 0;
     this.muxingPromises = [];
@@ -244,25 +334,21 @@ export class VideoExporter {
 
     this.encoder = new VideoEncoder({
       output: (chunk, meta) => {
-        // Capture decoder config metadata from encoder output
         if (meta?.decoderConfig?.description && !videoDescription) {
           const desc = meta.decoderConfig.description;
           videoDescription = new Uint8Array(desc instanceof ArrayBuffer ? desc : (desc as any));
           this.videoDescription = videoDescription;
         }
-        // Capture colorSpace from encoder metadata if provided
         if (meta?.decoderConfig?.colorSpace && !this.videoColorSpace) {
           this.videoColorSpace = meta.decoderConfig.colorSpace;
         }
 
-        // Stream chunk to muxer immediately (parallel processing)
         const isFirstChunk = this.chunkCount === 0;
         this.chunkCount++;
 
         const muxingPromise = (async () => {
           try {
             if (isFirstChunk && this.videoDescription) {
-              // Add decoder config for the first chunk
               const colorSpace = this.videoColorSpace || {
                 primaries: 'bt709',
                 transfer: 'iec61966-2-1',
@@ -294,13 +380,12 @@ export class VideoExporter {
       },
       error: (error) => {
         console.error('[VideoExporter] Encoder error:', error);
-        // Stop export encoding failed
         this.cancelled = true;
       },
     });
 
     const codec = this.config.codec || 'avc1.640033';
-    
+
     const encoderConfig: VideoEncoderConfig = {
       codec,
       width: this.config.width,
@@ -312,23 +397,20 @@ export class VideoExporter {
       hardwareAcceleration: 'prefer-hardware',
     };
 
-    // Check hardware support first
     const hardwareSupport = await VideoEncoder.isConfigSupported(encoderConfig);
 
     if (hardwareSupport.supported) {
-      // Use hardware encoding
       console.log('[VideoExporter] Using hardware acceleration');
       this.encoder.configure(encoderConfig);
     } else {
-      // Fall back to software encoding
       console.log('[VideoExporter] Hardware not supported, using software encoding');
       encoderConfig.hardwareAcceleration = 'prefer-software';
-      
+
       const softwareSupport = await VideoEncoder.isConfigSupported(encoderConfig);
       if (!softwareSupport.supported) {
         throw new Error('Video encoding not supported on this system');
       }
-      
+
       this.encoder.configure(encoderConfig);
     }
   }

--- a/src/lib/exporter/webcodecs-decoder.ts
+++ b/src/lib/exporter/webcodecs-decoder.ts
@@ -1,0 +1,394 @@
+/**
+ * WebCodecs-based video decoder with mp4box.js demuxer
+ * 
+ * This decoder provides parallel frame decoding capabilities,
+ * significantly improving export performance on Apple Silicon.
+ */
+
+// mp4box has a non-standard export, need to handle both CommonJS and ESM
+// @ts-ignore - mp4box types are not perfect
+import MP4BoxModule from 'mp4box';
+
+// Get the actual MP4Box object (handle different module formats)
+const MP4Box = (MP4BoxModule as any).default || MP4BoxModule;
+
+// Types for mp4box.js (simplified for our use case)
+interface MP4Sample {
+    data: ArrayBuffer;
+    cts: number;  // Composition timestamp
+    dts: number;  // Decode timestamp
+    duration: number;
+    is_sync: boolean;
+    number: number;
+    timescale: number;
+}
+
+interface MP4VideoTrack {
+    id: number;
+    nb_samples: number;
+    timescale: number;
+    duration: number;
+    codec: string;
+    width: number;
+    height: number;
+    video: {
+        width: number;
+        height: number;
+    };
+}
+
+interface MP4Info {
+    duration: number;
+    timescale: number;
+    isFragmented: boolean;
+    tracks: MP4VideoTrack[];
+    videoTracks: MP4VideoTrack[];
+}
+
+export interface DecodedFrame {
+    frame: VideoFrame;
+    timestamp: number;  // microseconds
+    frameIndex: number;
+}
+
+export interface WebCodecsDecoderConfig {
+    /** Video file to decode (File or Blob) */
+    file: File | Blob;
+    /** Callback when a frame is decoded */
+    onFrame?: (frame: DecodedFrame) => void;
+    /** Callback when decoding progress updates */
+    onProgress?: (decoded: number, total: number) => void;
+    /** Callback on error */
+    onError?: (error: Error) => void;
+}
+
+/**
+ * High-performance video decoder using WebCodecs and mp4box.js
+ * 
+ * This replaces the HTMLVideoElement-based approach with direct
+ * access to the hardware decoder, enabling parallel frame processing.
+ */
+export class WebCodecsDecoder {
+    private mp4boxFile: any = null;
+    private decoder: VideoDecoder | null = null;
+    private videoTrack: MP4VideoTrack | null = null;
+    private frameBuffer: Map<number, VideoFrame> = new Map();
+    private pendingFrames: Map<number, (frame: VideoFrame) => void> = new Map();
+    private decodedCount = 0;
+    private totalSamples = 0;
+    private config: WebCodecsDecoderConfig;
+
+    constructor(config: WebCodecsDecoderConfig) {
+        this.config = config;
+    }
+
+    /**
+     * Initialize the decoder with video file
+     */
+    async initialize(): Promise<{
+        width: number;
+        height: number;
+        duration: number;
+        frameRate: number;
+        totalFrames: number;
+    }> {
+        return new Promise((resolve, reject) => {
+            // Create mp4box file instance
+            if (typeof MP4Box.createFile !== 'function') {
+                reject(new Error('MP4Box.createFile is not available - mp4box may not be loaded correctly'));
+                return;
+            }
+
+            this.mp4boxFile = MP4Box.createFile();
+
+            this.mp4boxFile.onError = (error: Error) => {
+                reject(error);
+                this.config.onError?.(error);
+            };
+
+            this.mp4boxFile.onReady = (info: MP4Info) => {
+                const videoTrack = info.videoTracks[0];
+                if (!videoTrack) {
+                    reject(new Error('No video track found'));
+                    return;
+                }
+
+                this.videoTrack = videoTrack;
+                this.totalSamples = videoTrack.nb_samples;
+
+                // Generate codec config for VideoDecoder
+                const codecConfig = this.getVideoDecoderConfig(videoTrack);
+
+                // Initialize VideoDecoder
+                this.initializeDecoder(codecConfig);
+
+                // Set up sample extraction
+                this.mp4boxFile.setExtractionOptions(videoTrack.id, null, {
+                    nbSamples: Infinity,
+                });
+
+                // Calculate video info
+                const duration = videoTrack.duration / videoTrack.timescale;
+                const frameRate = videoTrack.nb_samples / duration;
+
+                resolve({
+                    width: videoTrack.video.width,
+                    height: videoTrack.video.height,
+                    duration,
+                    frameRate,
+                    totalFrames: videoTrack.nb_samples,
+                });
+            };
+
+            this.mp4boxFile.onSamples = (
+                _trackId: number,
+                _ref: any,
+                samples: MP4Sample[]
+            ) => {
+                this.processSamples(samples);
+            };
+
+            // Load the file
+            this.loadFile();
+        });
+    }
+
+    /**
+     * Load file data into mp4box
+     */
+    private async loadFile(): Promise<void> {
+        const file = this.config.file;
+        const arrayBuffer = await file.arrayBuffer();
+
+        // mp4box requires the buffer to have a fileStart property
+        (arrayBuffer as any).fileStart = 0;
+
+        this.mp4boxFile.appendBuffer(arrayBuffer);
+        this.mp4boxFile.flush();
+    }
+
+    /**
+     * Get VideoDecoder config from mp4box track info
+     */
+    private getVideoDecoderConfig(track: MP4VideoTrack): VideoDecoderConfig {
+        // Get the track's description (avcC/hvcC box) for decoder init
+        const trak = this.mp4boxFile.getTrackById(track.id);
+        const entry = trak.mdia.minf.stbl.stsd.entries[0];
+
+        let description: Uint8Array | undefined;
+
+        // Handle H.264 (avc1) - simplified approach
+        // @ts-ignore - mp4box internal API
+        if (entry.avcC) {
+            try {
+                // Use mp4box's internal method to get the raw bytes
+                const box = entry.avcC;
+                const size = box.getSize ? box.getSize() : 0;
+                if (size > 0) {
+                    const buffer = new ArrayBuffer(size);
+                    const view = new DataView(buffer);
+                    // @ts-ignore
+                    box.write(view, 0);
+                    description = new Uint8Array(buffer);
+                }
+            } catch (e) {
+                console.warn('[WebCodecsDecoder] Could not extract avcC description:', e);
+            }
+        }
+        // Handle H.265 (hvc1/hev1)
+        // @ts-ignore - mp4box internal API
+        else if (entry.hvcC) {
+            try {
+                const box = entry.hvcC;
+                const size = box.getSize ? box.getSize() : 0;
+                if (size > 0) {
+                    const buffer = new ArrayBuffer(size);
+                    const view = new DataView(buffer);
+                    // @ts-ignore
+                    box.write(view, 0);
+                    description = new Uint8Array(buffer);
+                }
+            } catch (e) {
+                console.warn('[WebCodecsDecoder] Could not extract hvcC description:', e);
+            }
+        }
+
+        return {
+            codec: track.codec,
+            codedWidth: track.video.width,
+            codedHeight: track.video.height,
+            description,
+            hardwareAcceleration: 'prefer-hardware',
+        };
+    }
+
+    /**
+     * Initialize VideoDecoder
+     */
+    private initializeDecoder(config: VideoDecoderConfig): void {
+        this.decoder = new VideoDecoder({
+            output: (frame: VideoFrame) => {
+                this.handleDecodedFrame(frame);
+            },
+            error: (error: Error) => {
+                console.error('[WebCodecsDecoder] Decoder error:', error);
+                this.config.onError?.(error);
+            },
+        });
+
+        this.decoder.configure(config);
+    }
+
+    /**
+     * Process samples from mp4box
+     */
+    private processSamples(samples: MP4Sample[]): void {
+        if (!this.decoder || !this.videoTrack) return;
+
+        for (const sample of samples) {
+            const chunk = new EncodedVideoChunk({
+                type: sample.is_sync ? 'key' : 'delta',
+                timestamp: (sample.cts * 1_000_000) / sample.timescale,
+                duration: (sample.duration * 1_000_000) / sample.timescale,
+                data: sample.data,
+            });
+
+            this.decoder.decode(chunk);
+        }
+    }
+
+    /**
+     * Handle decoded frame from VideoDecoder
+     */
+    private handleDecodedFrame(frame: VideoFrame): void {
+        this.decodedCount++;
+
+        // Check if someone is waiting for this frame
+        const frameIndex = this.decodedCount - 1;
+        const pendingResolver = this.pendingFrames.get(frameIndex);
+
+        if (pendingResolver) {
+            pendingResolver(frame);
+            this.pendingFrames.delete(frameIndex);
+        } else {
+            // Store in buffer for later retrieval
+            this.frameBuffer.set(frameIndex, frame);
+        }
+
+        // Notify progress
+        this.config.onProgress?.(this.decodedCount, this.totalSamples);
+
+        // Call frame callback if provided
+        this.config.onFrame?.({
+            frame,
+            timestamp: frame.timestamp ?? 0,
+            frameIndex,
+        });
+    }
+
+    /**
+     * Get a specific frame by index
+     * Returns a Promise that resolves when the frame is available
+     */
+    async getFrame(frameIndex: number): Promise<VideoFrame> {
+        // Check if frame is already in buffer
+        const bufferedFrame = this.frameBuffer.get(frameIndex);
+        if (bufferedFrame) {
+            this.frameBuffer.delete(frameIndex);
+            return bufferedFrame;
+        }
+
+        // Wait for frame to be decoded
+        return new Promise((resolve) => {
+            this.pendingFrames.set(frameIndex, resolve);
+        });
+    }
+
+    /**
+     * Start the decoding process
+     * This will begin extracting and decoding all samples
+     */
+    startDecoding(): void {
+        if (!this.mp4boxFile) {
+            throw new Error('Decoder not initialized');
+        }
+        this.mp4boxFile.start();
+    }
+
+    /**
+     * Wait for all frames to be decoded
+     */
+    async waitForCompletion(): Promise<void> {
+        if (!this.decoder) return;
+        await this.decoder.flush();
+    }
+
+    /**
+     * Get video info
+     */
+    getInfo(): { width: number; height: number; totalFrames: number; timescale: number } | null {
+        if (!this.videoTrack) return null;
+        return {
+            width: this.videoTrack.video.width,
+            height: this.videoTrack.video.height,
+            totalFrames: this.videoTrack.nb_samples,
+            timescale: this.videoTrack.timescale,
+        };
+    }
+
+    /**
+     * Clean up resources
+     */
+    destroy(): void {
+        // Close all buffered frames
+        for (const frame of this.frameBuffer.values()) {
+            frame.close();
+        }
+        this.frameBuffer.clear();
+        this.pendingFrames.clear();
+
+        // Close decoder
+        if (this.decoder && this.decoder.state !== 'closed') {
+            this.decoder.close();
+        }
+        this.decoder = null;
+        this.mp4boxFile = null;
+        this.videoTrack = null;
+    }
+}
+
+/**
+ * Create a WebCodecs decoder from a video URL
+ * Fetches the video file and creates a decoder
+ */
+export async function createDecoderFromUrl(
+    url: string,
+    options?: Partial<WebCodecsDecoderConfig>
+): Promise<WebCodecsDecoder> {
+    // Handle file:// URLs for Electron
+    let response: Response;
+
+    if (url.startsWith('file://')) {
+        // For Electron, we need to use a different approach
+        // The video URL should be accessible via fetch in Electron with nodeIntegration
+        response = await fetch(url);
+    } else {
+        response = await fetch(url);
+    }
+
+    const blob = await response.blob();
+
+    const decoder = new WebCodecsDecoder({
+        file: blob,
+        ...options,
+    });
+
+    return decoder;
+}
+
+/**
+ * Check if WebCodecs VideoDecoder is available
+ */
+export function isWebCodecsDecoderSupported(): boolean {
+    return typeof VideoDecoder !== 'undefined' && typeof EncodedVideoChunk !== 'undefined';
+}


### PR DESCRIPTION
## Description

Optimize video export performance by replacing sequential seek-based frame extraction with a playback-based approach using `requestVideoFrameCallback`. This eliminates the slow random-access pattern that bottlenecks export on Apple Silicon.

**Key changes:**
- Replace sequential seek with playback-based frame capture
- Use `requestVideoFrameCallback` for efficient frame extraction
- Play video at 2x speed during export for faster processing
- Add fallback to seek-based extraction when trim regions exist

**New files:**
- playbackExtractor.ts: Playback-based frame extractor
- optimized-exporter.ts: Factory for best available exporter
- offscreen-renderer.ts: OffscreenCanvas renderer (future use)
- export-worker.ts: Web Worker structure (future use)
- webcodecs-decoder.ts: WebCodecs decoder (future use)

## Motivation

Video export on Apple Silicon was extremely slow (~2x slower than realtime). The root cause was sequential `videoElement.currentTime` seeks, which forces the hardware decoder (VideoToolbox) to reposition for each frame. By switching to continuous playback with frame callbacks, we leverage the decoder's optimized sequential access pattern.

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fixes #26 

## Screenshots / Video

**Performance comparison:**

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| 11s video export | 22s | 5s | **↓ 77%** |
| Processing speed | 0.5x | 2.2x | **↑ 4.4x** |

*Tested on Mac mini M4 Pro*

## Testing

1. Record or open any video in the editor
2. Export **without** trim regions → Console shows `Using playback-based extraction (faster)`
3. Export **with** trim regions → Console shows `Using seek-based extraction (has trim regions)`
4. Compare export time with previous version

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.