### PR TITLE
fix(linux): reduce AppImage boot time from ~50s to near-instant

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -6,7 +6,7 @@
   "productName": "Openscreen",
   "npmRebuild": true,
   "buildDependenciesFromSource": true,
-  "compression": "maximum",
+  "compression": "normal",
   "directories": {
     "output": "release/${version}"
   },


### PR DESCRIPTION
Change compression from "maximum" to "normal" for electron-builder.

The "maximum" compression setting causes gzip/xz compression in the squashfs filesystem, which has extremely poor random access performance (~35 MB/s). This results in 50+ second boot times on Linux AppImage releases due to FUSE overhead during Electron's many small file reads at startup.

With "normal" compression, the AppImage uses faster decompression algorithms, dramatically improving startup time while only marginally increasing package size.

Refs: electron-userland/electron-builder#6317
Refs: electron-userland/electron-builder#7483

# Pull Request Template

## Description
<!-- Briefly describe the purpose of this PR. -->

## Motivation
<!-- Explain why this change is needed. What problem does it solve? -->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot** (if applicable):

```markdown
![Screenshot Description](path/to/screenshot.png)
```

**Video** (if applicable):

```html
<video src="path/to/video.mp4" controls width="600"></video>
```

## Testing
<!-- Describe how reviewers can test the changes. Include steps, commands, or environment setup. -->

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*
