### PR TITLE
fix(linux): Greatly AppImage boot time from ~20s to ~2s

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -6,7 +6,7 @@
   "productName": "Openscreen",
   "npmRebuild": true,
   "buildDependenciesFromSource": true,
-  "compression": "maximum",
+  "compression": "normal",
   "directories": {
     "output": "release/${version}"
   },


### PR DESCRIPTION
Change compression from "maximum" to "normal" for electron-builder.

The "maximum" compression setting causes gzip/xz compression in the squashfs filesystem, which has extremely poor random access performance (~35 MB/s). This results in 20+ second boot times on Linux AppImage releases due to FUSE overhead during Electron's many small file reads at startup.

With "normal" compression, the AppImage uses faster decompression algorithms, dramatically improving startup time while only marginally increasing package size.

Refs: electron-userland/electron-builder#6317
Refs: electron-userland/electron-builder#7483

## Screenshots / Video

The decompression takes 2.34s on my system after the change.

Before it took an unbearable 20.34s.

The app boot time itself is near instant.

<img width="1190" height="559" alt="2026-01-01_17-07" src="https://github.com/user-attachments/assets/b37b631e-16dd-4535-998c-19cec6ff949e" />


The tiny disk usage saving isn't even close to worth the excessive boot time on every launch:

<img width="1177" height="150" alt="2026-01-01_17-08" src="https://github.com/user-attachments/assets/f8516530-4a43-4a02-a038-33631822a4d1" />

