### PR TITLE
fix(ui): set minimum height for image selection tab in settings panel

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -424,7 +424,7 @@ export function SettingsPanel({
         </>
       )}
 
-      <Tabs defaultValue="image" className="flex-1 flex flex-col min-h-0">
+      <Tabs defaultValue="image" className="flex-1 flex flex-col min-h-[200px]">
         <TabsList className="mb-4 bg-white/5 border border-white/5 p-1 w-full grid grid-cols-3 h-auto rounded-xl">
           <TabsTrigger value="image" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-slate-400 py-2 rounded-lg transition-all">Image</TabsTrigger>
           <TabsTrigger value="color" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-slate-400 py-2 rounded-lg transition-all">Color</TabsTrigger>


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed the background selection panel (Image/Color/Gradient tabs) being completely cut off on smaller screens. On devices like the MacBook Pro 13-inch (M1, 2020) with a 13.3-inch Retina Display (2560 × 1600), users were unable to see or access the background selection area in the settings panel.

The issue was caused by min-h-0 on the Tabs component, which allowed it to shrink to zero height when the upper controls consumed all available space.

## Motivation
On smaller screen sizes, the settings panel was unusable for changing backgrounds:

The Image/Color/Gradient tabs were completely hidden
The "Upload Custom Image" button was not visible
Users could not select any wallpaper, solid color, or gradient as background
The upper controls (Zoom Level, Motion Blur, Shadow, Roundness, Padding, Crop Video) consumed all vertical space
This fix adds a minimum height of 200px to the Tabs component, ensuring users on all screen sizes can access the full background selection functionality. The parent container's scrolling handles any overflow gracefully.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->
https://github.com/siddharthvaddem/openscreen/issues/81

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot**:
**Before (on MacBook Pro 13-inch):**
The Image/Color/Gradient tabs and background selection options were completely hidden.
<img width="1436" height="899" alt="image" src="https://github.com/user-attachments/assets/e8225135-0d54-43e5-b2b3-c8b1e1fbfc91" />

**After:**
Background selection area is now visible with minimum 200px height, and sidebar scrolls when needed.
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/22a76b0a-a510-4f43-839f-b5ca75976df3" />

## Testing
Works as expected 

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*
