### PR TITLE
feat: add support for 16:10 aspect ratio

### DIFF
--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { type AspectRatio, getAspectRatioLabel } from "@/utils/aspectRatioUtils";
+import { type AspectRatio, getAspectRatioLabel, ASPECT_RATIOS } from "@/utils/aspectRatioUtils";
 import { formatShortcut } from "@/utils/platformUtils";
 import { TutorialHelp } from "../TutorialHelp";
 
@@ -896,7 +896,7 @@ export default function TimelineEditor({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="bg-[#1a1a1a] border-white/10">
-              {(['16:9', '9:16', '1:1', '4:3', '4:5', '16:10', "10:16"] as AspectRatio[]).map((ratio) => (
+              {ASPECT_RATIOS.map((ratio) => (
                 <DropdownMenuItem
                   key={ratio}
                   onClick={() => onAspectRatioChange(ratio)}

--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -1,5 +1,12 @@
-export type AspectRatio = '16:9' | '9:16' | '1:1' | '4:3' | '4:5' | '16:10' | '10:16';
+export const ASPECT_RATIOS = ['16:9', '9:16', '1:1', '4:3', '4:5', '16:10', '10:16'] as const;
 
+export type AspectRatio = typeof ASPECT_RATIOS[number];
+
+/**
+ * Returns the numeric value of an aspect ratio.
+ * Uses exhaustive type checking to ensure all AspectRatio cases are handled.
+ * If TypeScript errors here, a new ratio was added to the type but not handled.
+ */
 export function getAspectRatioValue(aspectRatio: AspectRatio): number {
   switch (aspectRatio) {
     case '16:9': return 16 / 9;
@@ -9,7 +16,11 @@ export function getAspectRatioValue(aspectRatio: AspectRatio): number {
     case '4:5':  return 4 / 5;
     case '16:10': return 16 / 10;
     case '10:16': return 10 / 16;
-    default: return 1;
+    default: {
+      // Ensures all cases are handled - TypeScript errors if missing
+      const _exhaustiveCheck: never = aspectRatio;
+      return _exhaustiveCheck;
+    }
   }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description
- Add support for "16:10" aspect ratio monitors/screens.
- Update the Util to be more typesafe and making it the source of truth for all available aspect ratios

## Motivation
"16:10" has become a quite common aspect ratio, specially for programming use case.

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Testing
- run the development server on a "16:10" monitor and check the exported video.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*
