### PR TITLE
docs: add troubleshooting for Linux sandbox error

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ chmod +x Openscreen-Linux-*.AppImage
 
 You may need to grant screen recording permissions depending on your desktop environment.
 
+**Note:** If the app fails to launch due to a "sandbox" error, run it with --no-sandbox:
+```bash
+./Openscreen-Linux-*.AppImage --no-sandbox
+```
+
 ## Built with
 - Electron
 - React


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Briefly describe the purpose of this PR. -->
Added a troubleshooting note to the Linux installation section for the SUID sandbox error. This provides a workaround for users on modern distributions (Ubuntu 24.04, Linux Mint 22.1) where the AppImage fails to launch.

## Motivation
<!-- Explain why this change is needed. What problem does it solve? -->
As discussed in #145, several users are hitting a `FATAL:setuid_sandbox_host.cc` error due to stricter kernel restrictions on unprivileged namespaces. Documenting the `--no-sandbox` flag ensures users can actually run the app without manual permission hacks.

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [x] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->
#145  

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot** (if applicable):

without `--no-sandbox` flag
<img width="1017" height="210" alt="image" src="https://github.com/user-attachments/assets/77bf7096-75b6-46d2-aa4d-f55d3f4ad67a" />

with `--no-sandbox` flag
<img width="1030" height="193" alt="image" src="https://github.com/user-attachments/assets/afb6a1c2-dd3e-47aa-bd0e-996766f85eea" />


## Testing
<!-- Describe how reviewers can test the changes. Include steps, commands, or environment setup. -->
Verified that adding the `--no-sandbox` flag allows the AppImage to launch on Linux systems where the SUID sandbox is restricted.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*
