### PR TITLE
feat: add localStorage persistence for video editor settings (Auto-save all video editor settings)

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -90,6 +90,11 @@ interface SettingsPanelProps {
   onAnnotationStyleChange?: (id: string, style: Partial<AnnotationRegion['style']>) => void;
   onAnnotationFigureDataChange?: (id: string, figureData: any) => void;
   onAnnotationDelete?: (id: string) => void;
+  customImages?: string[];
+  onCustomImageAdd?: (imageUrl: string) => void;
+  onCustomImageRemove?: (imageUrl: string) => void;
+  activeBackgroundTab?: 'image' | 'color' | 'gradient';
+  onActiveBackgroundTabChange?: (tab: 'image' | 'color' | 'gradient') => void;
 }
 
 export default SettingsPanel;
@@ -145,9 +150,13 @@ export function SettingsPanel({
   onAnnotationStyleChange,
   onAnnotationFigureDataChange,
   onAnnotationDelete,
+  customImages = [],
+  onCustomImageAdd,
+  onCustomImageRemove,
+  activeBackgroundTab = 'image',
+  onActiveBackgroundTabChange,
 }: SettingsPanelProps) {
   const [wallpaperPaths, setWallpaperPaths] = useState<string[]>([]);
-  const [customImages, setCustomImages] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -208,7 +217,7 @@ export function SettingsPanel({
     reader.onload = (e) => {
       const dataUrl = e.target?.result as string;
       if (dataUrl) {
-        setCustomImages(prev => [...prev, dataUrl]);
+        onCustomImageAdd?.(dataUrl);
         onWallpaperChange(dataUrl);
         toast.success('Custom image uploaded successfully!');
       }
@@ -227,7 +236,7 @@ export function SettingsPanel({
 
   const handleRemoveCustomImage = (imageUrl: string, event: React.MouseEvent) => {
     event.stopPropagation();
-    setCustomImages(prev => prev.filter(img => img !== imageUrl));
+    onCustomImageRemove?.(imageUrl);
     // If the removed image was selected, clear selection
     if (selected === imageUrl) {
       onWallpaperChange(wallpaperPaths[0] || WALLPAPER_RELATIVE[0]);
@@ -413,7 +422,7 @@ export function SettingsPanel({
               </div>
             </AccordionTrigger>
             <AccordionContent className="pb-3">
-              <Tabs defaultValue="image" className="w-full">
+              <Tabs value={activeBackgroundTab} onValueChange={(value) => onActiveBackgroundTabChange?.(value as 'image' | 'color' | 'gradient')} className="w-full">
                 <TabsList className="mb-2 bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
                   <TabsTrigger value="image" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all">Image</TabsTrigger>
                   <TabsTrigger value="color" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all">Color</TabsTrigger>

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -1,3 +1,5 @@
+import type { ExportQuality, ExportFormat, GifFrameRate, GifSizePreset } from '@/lib/exporter';
+
 export type ZoomDepth = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface ZoomFocus {
@@ -130,3 +132,95 @@ function clamp(value: number, min: number, max: number) {
   if (Number.isNaN(value)) return (min + max) / 2;
   return Math.min(max, Math.max(min, value));
 }
+
+export interface VideoEditorEffects {
+  motionBlurEnabled: boolean;
+  blurBgEnabled: boolean;
+  shadowIntensity: number;
+  borderRadius: number;
+  padding: number;
+}
+
+export interface VideoEditorBackground {
+  type: 'image' | 'color' | 'gradient';
+  value: string;
+  customImages: string[];
+  selectedColor: string;
+  selectedGradient: string;
+}
+
+export interface VideoEditorExport {
+  format: ExportFormat;
+  quality: ExportQuality;
+  gifFrameRate: GifFrameRate;
+  gifLoop: boolean;
+  gifSizePreset: GifSizePreset;
+}
+
+export interface VideoEditorRegions {
+  zoomRegions: ZoomRegion[];
+  trimRegions: TrimRegion[];
+  cropRegion: CropRegion;
+}
+
+export interface VideoEditorUI {
+  activeAccordionItems: string[];
+  activeBackgroundTab: 'image' | 'color' | 'gradient';
+}
+
+export interface VideoEditorSettings {
+  version: number;
+  lastUpdated: string;
+  effects: VideoEditorEffects;
+  background: VideoEditorBackground;
+  export: VideoEditorExport;
+  regions: VideoEditorRegions;
+  ui: VideoEditorUI;
+}
+
+export const DEFAULT_VIDEO_EDITOR_EFFECTS: VideoEditorEffects = {
+  motionBlurEnabled: false,
+  blurBgEnabled: false,
+  shadowIntensity: 0,
+  borderRadius: 0,
+  padding: 50,
+};
+
+export const DEFAULT_VIDEO_EDITOR_BACKGROUND: VideoEditorBackground = {
+  type: 'image',
+  value: 'wallpapers/wallpaper1.jpg',
+  customImages: [],
+  selectedColor: '#ADADAD',
+  selectedGradient: 'linear-gradient(111.6deg, rgba(114,167,232,1) 9.4%, rgba(253,129,82,1) 43.9%)',
+};
+
+export const DEFAULT_VIDEO_EDITOR_EXPORT: VideoEditorExport = {
+  format: 'mp4',
+  quality: 'good',
+  gifFrameRate: 15,
+  gifLoop: true,
+  gifSizePreset: 'medium',
+};
+
+export const DEFAULT_VIDEO_EDITOR_REGIONS: VideoEditorRegions = {
+  zoomRegions: [],
+  trimRegions: [],
+  cropRegion: DEFAULT_CROP_REGION,
+};
+
+export const DEFAULT_VIDEO_EDITOR_UI: VideoEditorUI = {
+  activeAccordionItems: ['effects', 'background'],
+  activeBackgroundTab: 'image',
+};
+
+export const DEFAULT_VIDEO_EDITOR_SETTINGS: VideoEditorSettings = {
+  version: 1,
+  lastUpdated: new Date().toISOString(),
+  effects: DEFAULT_VIDEO_EDITOR_EFFECTS,
+  background: DEFAULT_VIDEO_EDITOR_BACKGROUND,
+  export: DEFAULT_VIDEO_EDITOR_EXPORT,
+  regions: DEFAULT_VIDEO_EDITOR_REGIONS,
+  ui: DEFAULT_VIDEO_EDITOR_UI,
+};
+
+export const SETTINGS_STORAGE_KEY = 'openscreen_video_editor_settings';

--- a/src/hooks/useSettingsPersistence.ts
+++ b/src/hooks/useSettingsPersistence.ts
@@ -1,0 +1,225 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type {
+  VideoEditorSettings,
+  VideoEditorEffects,
+  VideoEditorBackground,
+  VideoEditorExport,
+  VideoEditorRegions,
+  VideoEditorUI,
+} from '@/components/video-editor/types';
+import {
+  DEFAULT_VIDEO_EDITOR_SETTINGS,
+  SETTINGS_STORAGE_KEY,
+} from '@/components/video-editor/types';
+
+type PartialSettings = {
+  effects?: Partial<VideoEditorEffects>;
+  background?: Partial<VideoEditorBackground>;
+  export?: Partial<VideoEditorExport>;
+  regions?: Partial<VideoEditorRegions>;
+  ui?: Partial<VideoEditorUI>;
+};
+
+function migrateSettings(stored: unknown): VideoEditorSettings {
+  if (!stored || typeof stored !== 'object') {
+    return DEFAULT_VIDEO_EDITOR_SETTINGS;
+  }
+
+  const storedSettings = stored as Partial<VideoEditorSettings>;
+  
+  if (!storedSettings.version || storedSettings.version < 1) {
+    return {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS,
+      ...storedSettings,
+      version: 1,
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+
+  return {
+    version: storedSettings.version || 1,
+    lastUpdated: storedSettings.lastUpdated || new Date().toISOString(),
+    effects: {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS.effects,
+      ...storedSettings.effects,
+    },
+    background: {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS.background,
+      ...storedSettings.background,
+    },
+    export: {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS.export,
+      ...storedSettings.export,
+    },
+    regions: {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS.regions,
+      ...storedSettings.regions,
+    },
+    ui: {
+      ...DEFAULT_VIDEO_EDITOR_SETTINGS.ui,
+      ...storedSettings.ui,
+    },
+  };
+}
+
+export function useSettingsPersistence() {
+  const [settings, setSettings] = useState<VideoEditorSettings>(DEFAULT_VIDEO_EDITOR_SETTINGS);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const settingsRef = useRef<VideoEditorSettings>(DEFAULT_VIDEO_EDITOR_SETTINGS);
+  
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        const migrated = migrateSettings(parsed);
+        setSettings(migrated);
+      }
+    } catch (error) {
+      console.error('Error loading settings from localStorage:', error);
+    }
+    setIsLoaded(true);
+  }, []);
+
+  const saveToStorage = useCallback((newSettings: VideoEditorSettings) => {
+    try {
+      const settingsToSave = {
+        ...newSettings,
+        lastUpdated: new Date().toISOString(),
+      };
+      localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settingsToSave));
+    } catch (error) {
+      if (error instanceof Error && error.name === 'QuotaExceededError') {
+        console.warn('localStorage quota exceeded. Removing custom images to save space.');
+        const trimmedSettings = {
+          ...newSettings,
+          background: {
+            ...newSettings.background,
+            customImages: [],
+          },
+          lastUpdated: new Date().toISOString(),
+        };
+        try {
+          localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(trimmedSettings));
+          setSettings(trimmedSettings);
+        } catch (e) {
+          console.error('Failed to save even without custom images:', e);
+        }
+      } else {
+        console.error('Error saving settings to localStorage:', error);
+      }
+    }
+  }, []);
+
+  const updateSettings = useCallback((update: PartialSettings) => {
+    setSettings((prev) => {
+      const newSettings = { ...prev };
+      
+      if (update.effects) {
+        newSettings.effects = { ...prev.effects, ...update.effects };
+      }
+      if (update.background) {
+        newSettings.background = { ...prev.background, ...update.background };
+      }
+      if (update.export) {
+        newSettings.export = { ...prev.export, ...update.export };
+      }
+      if (update.regions) {
+        newSettings.regions = { ...prev.regions, ...update.regions };
+      }
+      if (update.ui) {
+        newSettings.ui = { ...prev.ui, ...update.ui };
+      }
+      
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+      
+      saveTimeoutRef.current = setTimeout(() => {
+        saveToStorage(newSettings);
+      }, 500);
+      
+      return newSettings;
+    });
+  }, [saveToStorage]);
+
+  const updateEffects = useCallback((effects: Partial<VideoEditorEffects>) => {
+    updateSettings({ effects });
+  }, [updateSettings]);
+
+  const updateBackground = useCallback((background: Partial<VideoEditorBackground>) => {
+    updateSettings({ background });
+  }, [updateSettings]);
+
+  const updateExport = useCallback((exportSettings: Partial<VideoEditorExport>) => {
+    updateSettings({ export: exportSettings });
+  }, [updateSettings]);
+
+  const updateRegions = useCallback((regions: Partial<VideoEditorRegions>) => {
+    updateSettings({ regions });
+  }, [updateSettings]);
+
+  const updateUI = useCallback((ui: Partial<VideoEditorUI>) => {
+    updateSettings({ ui });
+  }, [updateSettings]);
+
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_VIDEO_EDITOR_SETTINGS);
+    try {
+      localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(DEFAULT_VIDEO_EDITOR_SETTINGS));
+    } catch (error) {
+      console.error('Error resetting settings:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveToStorage(settingsRef.current);
+      }
+    };
+  }, [saveToStorage]);
+
+  return {
+    settings,
+    isLoaded,
+    updateSettings,
+    updateEffects,
+    updateBackground,
+    updateExport,
+    updateRegions,
+    updateUI,
+    resetSettings,
+  };
+}
+
+export function useEffectsSettings() {
+  const { settings, updateEffects, isLoaded } = useSettingsPersistence();
+  return { effects: settings.effects, updateEffects, isLoaded };
+}
+
+export function useBackgroundSettings() {
+  const { settings, updateBackground, isLoaded } = useSettingsPersistence();
+  return { background: settings.background, updateBackground, isLoaded };
+}
+
+export function useExportSettings() {
+  const { settings, updateExport, isLoaded } = useSettingsPersistence();
+  return { export: settings.export, updateExport, isLoaded };
+}
+
+export function useRegionsSettings() {
+  const { settings, updateRegions, isLoaded } = useSettingsPersistence();
+  return { regions: settings.regions, updateRegions, isLoaded };
+}
+
+export function useUISettings() {
+  const { settings, updateUI, isLoaded } = useSettingsPersistence();
+  return { ui: settings.ui, updateUI, isLoaded };
+}


### PR DESCRIPTION
Auto-save all video editor settings (effects, background, export config, regions) to localStorage with debounced writes. Settings restore automatically when reopening the editor with new recordings.

- Add useSettingsPersistence hook with schema versioning
- Persist effects, background, export settings, zoom/trim/crop regions
- Add active tab state persistence for background panel
- Handle quota exceeded errors gracefully

## Description
This PR implements automatic persistence of video editor settings using localStorage. When users close and reopen the video editor with different recordings, their settings (effects, background, export config, regions) are automatically restored.

## Motivation
Previously, users had to reconfigure their video editor settings every time they opened a new recording. This feature improves UX by remembering user preferences across sessions.

## Type of Change
- [x] New Feature

## Testing
1. Open video editor with any recording
2. Change some settings (effects, background, etc.)
3. Close editor
4. Open different recording
5. Verify previous settings are restored

## Checklist
- [x] I have performed a self-review of my code.
- [x] Code has been reviewed (code review completed)