### PR TITLE
fix: improve encoder queue management and adjust latency mode for beter troughput

### DIFF
--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -125,8 +125,8 @@ export class VideoExporter {
           });
 
           // Check encoder queue before encoding to keep it full
-          while (this.encodeQueue >= this.MAX_ENCODE_QUEUE && !this.cancelled) {
-            await new Promise(resolve => setTimeout(resolve, 0));
+          while (this.encoder && this.encoder.encodeQueueSize >= this.MAX_ENCODE_QUEUE && !this.cancelled) {
+            await new Promise(resolve => setTimeout(resolve, 5));
           }
 
           if (this.encoder && this.encoder.state === 'configured') {
@@ -250,7 +250,7 @@ export class VideoExporter {
       height: this.config.height,
       bitrate: this.config.bitrate,
       framerate: this.config.frameRate,
-      latencyMode: 'realtime',
+      latencyMode: 'quality', // Changed from 'realtime' to 'quality' for better throughput
       bitrateMode: 'variable',
       hardwareAcceleration: 'prefer-hardware',
     };


### PR DESCRIPTION
# Pull Request 

## Description
This PR significantly optimizes video export speed by adjusting the hardware encoder (`VideoEncoder`) configuration and improving the encoding queue management.

## Motivation
Video exports were unexpectedly slow (over 3 minutes for a 15-second video). The issue stemmed from two factors:
1. The encoder was configured in `realtime` mode, a mode designed for streaming (low latency) that throttles overall throughput.
2. The encoder queue loop used `setTimeout(..., 0)` with manual counter tracking, creating a "busy-loop" that overloaded the main thread and slowed down PixiJS rendering.

By switching to `quality` mode and using the native `encodeQueueSize` property with a slight delay (5ms), we free up CPU resources and allow the hardware encoder to process frames at maximum speed. Testing shows **3x faster export speed** (approximately 1 minute instead of 3+ minutes for 15s video on Windows).

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor / Code Cleanup (Performance Optimization)
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
#157 

## Images/Videos
*No visual changes, only performance improvements in the background.*

## Testing
1. Open a video in the editor (ideally around 15 seconds for comparison).
2. Trigger a video export (MP4).
3. Measure the export time.
4. Verify that the exported video has good quality and no defects (artifacts, desynchronization).
5. Compare the time with the main branch (should be approximately 3x faster).

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.