### PR TITLE
fix: Add configurable shortcut for speed adjustment in TimelineEditor

### DIFF
--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -967,7 +967,7 @@ export default function TimelineEditor({
       if (matchesShortcut(e, keyShortcuts.addAnnotation, isMac)) {
         handleAddAnnotation();
       }
-      if (e.key === 's' || e.key === 'S') {
+      if (matchesShortcut(e, keyShortcuts.addSpeed, isMac)) {
         handleAddSpeed();
       }
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,6 +1,7 @@
 export const SHORTCUT_ACTIONS = [
   'addZoom',
   'addTrim',
+  'addSpeed',
   'addAnnotation',
   'addKeyframe',
   'deleteSelected',
@@ -67,6 +68,7 @@ export function findConflict(
 export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
   addZoom:        { key: 'z' },
   addTrim:        { key: 't' },
+  addSpeed:       { key: 's' },
   addAnnotation:  { key: 'a' },
   addKeyframe:    { key: 'f' },
   deleteSelected: { key: 'd', ctrl: true },
@@ -76,6 +78,7 @@ export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
 export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
   addZoom:        'Add Zoom',
   addTrim:        'Add Trim',
+  addSpeed:       'Add Speed',
   addAnnotation:  'Add Annotation',
   addKeyframe:    'Add Keyframe',
   deleteSelected: 'Delete Selected',


### PR DESCRIPTION
# Pull Request Template

## Description
Make the S key configurable

## Motivation


## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

**Screenshot**
<img width="452" height="752" alt="image" src="https://github.com/user-attachments/assets/9d9b14f1-7ad0-479b-b5f6-f1b221478897" />

## Testing
Work on Windows

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
