### PR TITLE
Default to Windows tab when no screens available, show source counts

### DIFF
--- a/src/components/launch/SourceSelector.tsx
+++ b/src/components/launch/SourceSelector.tsx
@@ -70,10 +70,10 @@ export function SourceSelector() {
   return (
     <div className={`min-h-screen flex flex-col items-center justify-center ${styles.glassContainer}`}>
       <div className="flex-1 flex flex-col w-full max-w-xl" style={{ padding: 0 }}>
-        <Tabs defaultValue="screens">
+        <Tabs defaultValue={screenSources.length === 0 ? "windows" : "screens"}>
           <TabsList className="grid grid-cols-2 mb-3 bg-zinc-900/40 rounded-full">
-            <TabsTrigger value="screens" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-zinc-200 rounded-full text-xs py-1">Screens</TabsTrigger>
-            <TabsTrigger value="windows" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-zinc-200 rounded-full text-xs py-1">Windows</TabsTrigger>
+            <TabsTrigger value="screens" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-zinc-200 rounded-full text-xs py-1">Screens ({screenSources.length})</TabsTrigger>
+            <TabsTrigger value="windows" className="data-[state=active]:bg-[#34B27B] data-[state=active]:text-white text-zinc-200 rounded-full text-xs py-1">Windows ({windowSources.length})</TabsTrigger>
           </TabsList>
             <div className="h-72 flex flex-col justify-stretch">
             <TabsContent value="screens" className="h-full">


### PR DESCRIPTION
## Summary
- On Linux (Ubuntu), screen sources are often empty — the selector now **defaults to the Windows tab** when there are no screens instead of showing an empty Screens tab
- **Shows source counts** in the tab labels (e.g. "Screens (0)" / "Windows (5)") so users can immediately see what's available

## Test plan
- [ ] On Linux with no screen sources, verify the Windows tab is selected by default
- [ ] On a system with screen sources, verify the Screens tab is still the default
- [ ] Verify the counts in both tab labels match the actual number of sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)