### PR TITLE
feat(gif-worker): increase amount of web workers based on hardwarecon…

### DIFF
--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -122,9 +122,10 @@ export class GifExporter {
 			// Initialize GIF encoder
 			// Loop: 0 = infinite loop, 1 = play once (no loop)
 			const repeat = this.config.loop ? 0 : 1;
-
+			const cores = navigator.hardwareConcurrency || 4;
+			const WORKER_COUNT = Math.max(1, Math.min(8, cores - 1));
 			this.gif = new GIF({
-				workers: 4,
+				workers: WORKER_COUNT,
 				quality: 10,
 				width: this.config.width,
 				height: this.config.height,


### PR DESCRIPTION
# Pull Request Template

## Description
Optimizes the GIF exporting process by dynamically adjusting the number of worker threads based on the user's hardware capabilities. This change aims to improve performance and resource utilization during GIF generation.

## Motivation
Use navigator.hardwareConcurrency (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency) to more accurately use the amount of workers available
n-1 workers so one worker is for main thread
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [X] Other (please specify)

## Testing
- just my mac and exported the gif

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*
