### PR TITLE
Fix Windows cursor telemetry path resolution

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -419,7 +419,9 @@ export default function VideoEditor() {
 		let mounted = true;
 
 		async function loadCursorTelemetry() {
-			if (!videoPath) {
+			const sourcePath = videoSourcePath ?? (videoPath ? fromFileUrl(videoPath) : null);
+
+			if (!sourcePath) {
 				if (mounted) {
 					setCursorTelemetry([]);
 				}
@@ -427,7 +429,7 @@ export default function VideoEditor() {
 			}
 
 			try {
-				const result = await window.electronAPI.getCursorTelemetry(fromFileUrl(videoPath));
+				const result = await window.electronAPI.getCursorTelemetry(sourcePath);
 				if (mounted) {
 					setCursorTelemetry(result.success ? result.samples : []);
 				}
@@ -444,7 +446,7 @@ export default function VideoEditor() {
 		return () => {
 			mounted = false;
 		};
-	}, [videoPath]);
+	}, [videoPath, videoSourcePath]);
 
 	function togglePlayPause() {
 		const playback = videoPlaybackRef.current;

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -61,9 +61,9 @@ function clamp(value: number, min: number, max: number) {
 export function toFileUrl(filePath: string): string {
 	const normalized = filePath.replace(/\\/g, "/");
 	if (normalized.match(/^[a-zA-Z]:/)) {
-		return `file:///${normalized}`;
+		return `file:///${encodeURI(normalized)}`;
 	}
-	return `file://${normalized}`;
+	return `file://${encodeURI(normalized)}`;
 }
 
 export function fromFileUrl(fileUrl: string): string {
@@ -73,9 +73,20 @@ export function fromFileUrl(fileUrl: string): string {
 
 	try {
 		const url = new URL(fileUrl);
-		return decodeURIComponent(url.pathname);
+		const pathname = decodeURIComponent(url.pathname);
+
+		if (url.host && url.host !== "localhost") {
+			return `//${url.host}${pathname}`;
+		}
+
+		if (/^\/[a-zA-Z]:/.test(pathname)) {
+			return pathname.slice(1);
+		}
+
+		return pathname;
 	} catch {
-		return fileUrl.replace(/^file:\/\//, "");
+		const fallbackPath = decodeURIComponent(fileUrl.replace(/^file:\/\//, ""));
+		return fallbackPath.replace(/^\/([a-zA-Z]:)/, "$1");
 	}
 }
 


### PR DESCRIPTION
## Description
This PR fixes Windows cursor telemetry loading so automatic zoom suggestions can find the recorded cursor data after a screencast is opened in the editor.

## Motivation
On Windows, the editor could fail to resolve the recorded cursor telemetry file because file URLs were not converted back to native paths correctly. That made the automatic zoom workflow report that no cursor telemetry was available even though the recording had been captured from the app.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fixes #197

## Screenshots / Video
Not included.

## Testing
- Manual validation on Windows confirmed that automatic zoom detection works again after recording a screencast
- Verified that the editor now loads cursor telemetry from the native source video path when available
- Verified correct file URL decoding for Windows drive-letter paths and UNC-style paths in the implementation

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
