### PR TITLE
Add custom aspect ratio picker (Custom W:H)

### DIFF
--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -1,5 +1,5 @@
 import type { ExportFormat, ExportQuality, GifFrameRate, GifSizePreset } from "@/lib/exporter";
-import { ASPECT_RATIOS, type AspectRatio } from "@/utils/aspectRatioUtils";
+import { ASPECT_RATIOS, type AspectRatio, isCustomAspectRatio } from "@/utils/aspectRatioUtils";
 import {
 	type AnnotationRegion,
 	type CropRegion,
@@ -317,7 +317,11 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 		speedRegions: normalizedSpeedRegions,
 		annotationRegions: normalizedAnnotationRegions,
 		aspectRatio:
-			editor.aspectRatio && validAspectRatios.has(editor.aspectRatio) ? editor.aspectRatio : "16:9",
+			typeof editor.aspectRatio === "string" &&
+			(validAspectRatios.has(editor.aspectRatio as AspectRatio) ||
+				isCustomAspectRatio(editor.aspectRatio))
+				? (editor.aspectRatio as AspectRatio)
+				: "16:9",
 		exportQuality:
 			editor.exportQuality === "medium" || editor.exportQuality === "source"
 				? editor.exportQuality

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -23,7 +23,12 @@ import {
 import { useShortcuts } from "@/contexts/ShortcutsContext";
 import { matchesShortcut } from "@/lib/shortcuts";
 import { cn } from "@/lib/utils";
-import { ASPECT_RATIOS, type AspectRatio, getAspectRatioLabel } from "@/utils/aspectRatioUtils";
+import {
+	ASPECT_RATIOS,
+	type AspectRatio,
+	getAspectRatioLabel,
+	isCustomAspectRatio,
+} from "@/utils/aspectRatioUtils";
 import { formatShortcut } from "@/utils/platformUtils";
 import { TutorialHelp } from "../TutorialHelp";
 import type {
@@ -656,12 +661,44 @@ export default function TimelineEditor({
 	const [range, setRange] = useState<Range>(() => createInitialRange(totalMs));
 	const [keyframes, setKeyframes] = useState<{ id: string; time: number }[]>([]);
 	const [selectedKeyframeId, setSelectedKeyframeId] = useState<string | null>(null);
+	const [customAspectWidth, setCustomAspectWidth] = useState("16");
+	const [customAspectHeight, setCustomAspectHeight] = useState("9");
 	const [scrollLabels, setScrollLabels] = useState({
 		pan: "Shift + Ctrl + Scroll",
 		zoom: "Ctrl + Scroll",
 	});
 	const timelineContainerRef = useRef<HTMLDivElement>(null);
 	const { shortcuts: keyShortcuts, isMac } = useShortcuts();
+
+	useEffect(() => {
+		const [width, height] = aspectRatio.split(":");
+		if (width && height) {
+			setCustomAspectWidth(width);
+			setCustomAspectHeight(height);
+		}
+	}, [aspectRatio]);
+
+	const applyCustomAspectRatio = useCallback(() => {
+		const width = Number.parseInt(customAspectWidth, 10);
+		const height = Number.parseInt(customAspectHeight, 10);
+		if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+			toast.error("Custom aspect ratio must be positive numbers.");
+			return;
+		}
+		onAspectRatioChange(`${width}:${height}` as AspectRatio);
+	}, [customAspectHeight, customAspectWidth, onAspectRatioChange]);
+
+	const handleCustomAspectRatioKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLInputElement>) => {
+			// Prevent DropdownMenu typeahead from selecting preset items while typing.
+			event.stopPropagation();
+			if (event.key === "Enter") {
+				event.preventDefault();
+				applyCustomAspectRatio();
+			}
+		},
+		[applyCustomAspectRatio],
+	);
 
 	useEffect(() => {
 		formatShortcut(["shift", "mod", "Scroll"]).then((pan) => {
@@ -1302,6 +1339,38 @@ export default function TimelineEditor({
 									{aspectRatio === ratio && <Check className="w-3 h-3 text-[#34B27B]" />}
 								</DropdownMenuItem>
 							))}
+							<div className="mx-1 my-1 h-px bg-white/10" />
+							<div className="px-2 py-1.5 flex items-center gap-2 text-slate-300">
+								<span className="text-sm">Custom</span>
+								<input
+									type="text"
+									inputMode="numeric"
+									value={customAspectWidth}
+									onChange={(event) => setCustomAspectWidth(event.target.value.replace(/\D/g, ""))}
+									onKeyDown={handleCustomAspectRatioKeyDown}
+									className="w-12 h-7 rounded border border-white/15 bg-black/20 px-1.5 text-sm text-slate-100 focus:outline-none focus:ring-1 focus:ring-[#34B27B]"
+									aria-label="Custom aspect width"
+								/>
+								<span className="text-slate-500">:</span>
+								<input
+									type="text"
+									inputMode="numeric"
+									value={customAspectHeight}
+									onChange={(event) => setCustomAspectHeight(event.target.value.replace(/\D/g, ""))}
+									onKeyDown={handleCustomAspectRatioKeyDown}
+									className="w-12 h-7 rounded border border-white/15 bg-black/20 px-1.5 text-sm text-slate-100 focus:outline-none focus:ring-1 focus:ring-[#34B27B]"
+									aria-label="Custom aspect height"
+								/>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={applyCustomAspectRatio}
+									className="h-7 px-2 text-xs text-slate-300 hover:text-white hover:bg-white/10"
+								>
+									Set
+								</Button>
+								{isCustomAspectRatio(aspectRatio) && <Check className="w-3 h-3 text-[#34B27B] ml-auto" />}
+							</div>
 						</DropdownMenuContent>
 					</DropdownMenu>
 					<div className="w-[1px] h-4 bg-white/10" />

--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -1,6 +1,37 @@
 export const ASPECT_RATIOS = ["16:9", "9:16", "1:1", "4:3", "4:5", "16:10", "10:16"] as const;
 
-export type AspectRatio = (typeof ASPECT_RATIOS)[number];
+type PresetAspectRatio = (typeof ASPECT_RATIOS)[number];
+type CustomAspectRatio = `${number}:${number}`;
+
+export type AspectRatio = PresetAspectRatio | CustomAspectRatio;
+
+const CUSTOM_ASPECT_RATIO_REGEX = /^(\d+):(\d+)$/;
+
+export function isCustomAspectRatio(aspectRatio: string): aspectRatio is CustomAspectRatio {
+	if ((ASPECT_RATIOS as readonly string[]).includes(aspectRatio)) {
+		return false;
+	}
+	const match = aspectRatio.match(CUSTOM_ASPECT_RATIO_REGEX);
+	if (!match) {
+		return false;
+	}
+	const width = Number(match[1]);
+	const height = Number(match[2]);
+	return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0;
+}
+
+function parseCustomAspectRatioValue(aspectRatio: string): number | null {
+	if (!isCustomAspectRatio(aspectRatio)) {
+		return null;
+	}
+	const [widthText, heightText] = aspectRatio.split(":");
+	const width = Number(widthText);
+	const height = Number(heightText);
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+		return null;
+	}
+	return width / height;
+}
 
 /**
  * Returns the numeric value of an aspect ratio.
@@ -23,11 +54,8 @@ export function getAspectRatioValue(aspectRatio: AspectRatio): number {
 			return 16 / 10;
 		case "10:16":
 			return 10 / 16;
-		default: {
-			// Ensures all cases are handled - TypeScript errors if missing
-			const _exhaustiveCheck: never = aspectRatio;
-			return _exhaustiveCheck;
-		}
+		default:
+			return parseCustomAspectRatioValue(aspectRatio) ?? 16 / 9;
 	}
 }
 
@@ -43,6 +71,9 @@ export function getAspectRatioDimensions(
 }
 
 export function getAspectRatioLabel(aspectRatio: AspectRatio): string {
+	if (isCustomAspectRatio(aspectRatio)) {
+		return `Custom ${aspectRatio}`;
+	}
 	return aspectRatio;
 }
 


### PR DESCRIPTION
## Summary
- add inline custom aspect ratio controls in timeline dropdown: Custom W : H + Set
- prevent dropdown typeahead from hijacking numeric typing in custom inputs
- support custom ratio strings in aspect ratio utils and labels
- persist/restore valid custom ratios in project normalization

## Validation
- npx tsc --noEmit

## Scope
- only touches aspect ratio picker and ratio normalization paths