### PR TITLE
feat: add cursor highlight overlay to video editor and export pipeline

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -65,6 +65,16 @@ interface Window {
 		getCursorTelemetry: (videoPath?: string) => Promise<{
 			success: boolean;
 			samples: CursorTelemetryPoint[];
+			display?: {
+				boundsX: number;
+				boundsY: number;
+				boundsWidth: number;
+				boundsHeight: number;
+				workAreaX: number;
+				workAreaY: number;
+				workAreaWidth: number;
+				workAreaHeight: number;
+			};
 			message?: string;
 			error?: string;
 		}>;

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -74,6 +74,7 @@ interface Window {
 				workAreaY: number;
 				workAreaWidth: number;
 				workAreaHeight: number;
+				isWindowCapture?: boolean;
 			};
 			message?: string;
 			error?: string;

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -139,11 +139,20 @@ async function storeRecordedSessionFiles(payload: StoreRecordedSessionInput) {
 	if (pendingCursorSamples.length > 0) {
 		await fs.writeFile(
 			telemetryPath,
-			JSON.stringify({ version: CURSOR_TELEMETRY_VERSION, samples: pendingCursorSamples }, null, 2),
+			JSON.stringify(
+				{
+					version: CURSOR_TELEMETRY_VERSION,
+					samples: pendingCursorSamples,
+					display: captureDisplayInfo ?? undefined,
+				},
+				null,
+				2,
+			),
 			"utf-8",
 		);
 	}
 	pendingCursorSamples = [];
+	captureDisplayInfo = null;
 
 	const sessionManifestPath = path.join(
 		RECORDINGS_DIR,
@@ -185,6 +194,19 @@ function stopCursorCapture() {
 	}
 }
 
+// Store the capture display info so we can save it to cursor.json for correct mapping
+let captureDisplayInfo: {
+	boundsX: number;
+	boundsY: number;
+	boundsWidth: number;
+	boundsHeight: number;
+	workAreaX: number;
+	workAreaY: number;
+	workAreaWidth: number;
+	workAreaHeight: number;
+	scaleFactor: number;
+} | null = null;
+
 function sampleCursorPoint() {
 	const cursor = screen.getCursorScreenPoint();
 	const sourceDisplayId = Number(selectedSource?.display_id);
@@ -195,6 +217,21 @@ function sampleCursorPoint() {
 	const bounds = display.bounds;
 	const width = Math.max(1, bounds.width);
 	const height = Math.max(1, bounds.height);
+
+	// Save display info on first sample
+	if (!captureDisplayInfo) {
+		captureDisplayInfo = {
+			boundsX: bounds.x,
+			boundsY: bounds.y,
+			boundsWidth: bounds.width,
+			boundsHeight: bounds.height,
+			workAreaX: display.workArea.x,
+			workAreaY: display.workArea.y,
+			workAreaWidth: display.workArea.width,
+			workAreaHeight: display.workArea.height,
+			scaleFactor: display.scaleFactor,
+		};
+	}
 
 	const cx = clamp((cursor.x - bounds.x) / width, 0, 1);
 	const cy = clamp((cursor.y - bounds.y) / height, 0, 1);
@@ -369,6 +406,7 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("set-recording-state", (_, recording: boolean) => {
 		if (recording) {
+			captureDisplayInfo = null;
 			stopCursorCapture();
 			activeCursorSamples = [];
 			pendingCursorSamples = [];
@@ -426,7 +464,8 @@ export function registerIpcHandlers(
 				})
 				.sort((a: CursorTelemetryPoint, b: CursorTelemetryPoint) => a.timeMs - b.timeMs);
 
-			return { success: true, samples };
+			const display = parsed?.display ?? undefined;
+			return { success: true, samples, display };
 		} catch (error) {
 			const nodeError = error as NodeJS.ErrnoException;
 			if (nodeError.code === "ENOENT") {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -205,6 +205,7 @@ let captureDisplayInfo: {
 	workAreaWidth: number;
 	workAreaHeight: number;
 	scaleFactor: number;
+	isWindowCapture?: boolean;
 } | null = null;
 
 function sampleCursorPoint() {
@@ -230,6 +231,7 @@ function sampleCursorPoint() {
 			workAreaWidth: display.workArea.width,
 			workAreaHeight: display.workArea.height,
 			scaleFactor: display.scaleFactor,
+			isWindowCapture: String(selectedSource?.id ?? "").startsWith("window:"),
 		};
 	}
 

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1,16 +1,20 @@
 import Block from "@uiw/react-color-block";
 import {
 	Bug,
+	Circle,
 	Crop,
+	Crosshair,
 	Download,
 	Film,
 	FolderOpen,
 	Image,
 	Lock,
+	Mouse,
 	Palette,
 	Save,
 	Sparkles,
 	Star,
+	Target,
 	Trash2,
 	Unlock,
 	Upload,
@@ -41,6 +45,7 @@ import type {
 	AnnotationRegion,
 	AnnotationType,
 	CropRegion,
+	CursorStyle,
 	FigureData,
 	PlaybackSpeed,
 	ZoomDepth,
@@ -132,6 +137,23 @@ interface SettingsPanelProps {
 	selectedSpeedValue?: PlaybackSpeed | null;
 	onSpeedChange?: (speed: PlaybackSpeed) => void;
 	onSpeedDelete?: (id: string) => void;
+	// Cursor settings
+	hasCursorTelemetry?: boolean;
+	showCursorHighlight?: boolean;
+	onShowCursorHighlightChange?: (show: boolean) => void;
+	cursorStyle?: CursorStyle;
+	onCursorStyleChange?: (style: CursorStyle) => void;
+	cursorColor?: string;
+	onCursorColorChange?: (color: string) => void;
+	cursorSize?: number;
+	onCursorSizeChange?: (size: number) => void;
+	onCursorSizeCommit?: () => void;
+	cursorOpacity?: number;
+	onCursorOpacityChange?: (opacity: number) => void;
+	onCursorOpacityCommit?: () => void;
+	cursorStrokeWidth?: number;
+	onCursorStrokeWidthChange?: (width: number) => void;
+	onCursorStrokeWidthCommit?: () => void;
 }
 
 export default SettingsPanel;
@@ -197,6 +219,23 @@ export function SettingsPanel({
 	selectedSpeedValue,
 	onSpeedChange,
 	onSpeedDelete,
+	// Cursor settings
+	hasCursorTelemetry = false,
+	showCursorHighlight = false,
+	onShowCursorHighlightChange,
+	cursorStyle = "dot",
+	onCursorStyleChange,
+	cursorColor = "#ffcc00",
+	onCursorColorChange,
+	cursorSize = 32,
+	onCursorSizeChange,
+	onCursorSizeCommit,
+	cursorOpacity = 0.6,
+	onCursorOpacityChange,
+	onCursorOpacityCommit,
+	cursorStrokeWidth = 2,
+	onCursorStrokeWidthChange,
+	onCursorStrokeWidthCommit,
 }: SettingsPanelProps) {
 	const [wallpaperPaths, setWallpaperPaths] = useState<string[]>([]);
 	const [customImages, setCustomImages] = useState<string[]>([]);
@@ -662,6 +701,135 @@ export function SettingsPanel({
 								<Crop className="w-3 h-3" />
 								Crop Video
 							</Button>
+						</AccordionContent>
+					</AccordionItem>
+
+					<AccordionItem value="cursor" className="border-white/5 rounded-xl bg-white/[0.02] px-3">
+						<AccordionTrigger className="py-2.5 hover:no-underline">
+							<div className="flex items-center gap-2">
+								<Mouse className="w-4 h-4 text-[#34B27B]" />
+								<span className="text-xs font-medium">Cursor Highlight</span>
+							</div>
+						</AccordionTrigger>
+						<AccordionContent className="pb-3">
+							{!hasCursorTelemetry && (
+								<div className="text-[10px] text-slate-500 mb-2 p-2 rounded-lg bg-white/5 border border-white/5">
+									No cursor data — re-record to enable cursor effects.
+								</div>
+							)}
+
+							<div className={cn(!hasCursorTelemetry && "opacity-40 pointer-events-none")}>
+								<div className="flex items-center justify-between p-2 rounded-lg bg-white/5 border border-white/5 mb-2">
+									<div className="text-[10px] font-medium text-slate-300">
+										Show Cursor Highlight
+									</div>
+									<Switch
+										checked={showCursorHighlight}
+										onCheckedChange={onShowCursorHighlightChange}
+										className="data-[state=checked]:bg-[#34B27B] scale-90"
+									/>
+								</div>
+
+								<div className={cn(!showCursorHighlight && "opacity-40 pointer-events-none")}>
+									<div className="text-[10px] font-medium text-slate-400 mb-1.5 px-0.5">Style</div>
+									<div className="grid grid-cols-4 gap-1 mb-2">
+										{(["dot", "circle", "ring", "glow"] as const).map((style) => (
+											<button
+												key={style}
+												type="button"
+												onClick={() => onCursorStyleChange?.(style)}
+												className={cn(
+													"flex items-center justify-center gap-1 p-1.5 rounded-md text-[10px] font-medium border transition-all",
+													cursorStyle === style
+														? "bg-[#34B27B]/20 border-[#34B27B] text-[#34B27B]"
+														: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10",
+												)}
+											>
+												{style === "dot" && <Circle className="w-3 h-3" />}
+												{style === "circle" && <Crosshair className="w-3 h-3" />}
+												{style === "ring" && <Target className="w-3 h-3" />}
+												{style === "glow" && <Sparkles className="w-3 h-3" />}
+												<span className="capitalize">{style}</span>
+											</button>
+										))}
+									</div>
+
+									<div className="text-[10px] font-medium text-slate-400 mb-1.5 px-0.5">Color</div>
+									<div className="mb-2">
+										<Block
+											color={cursorColor}
+											colors={[
+												"#ffcc00",
+												"#ffffff",
+												"#000000",
+												"#ff0000",
+												"#ff6600",
+												"#00ff00",
+												"#0088ff",
+												"#ff66cc",
+												"#34B27B",
+												"#8b5cf6",
+											]}
+											onChange={(color) => onCursorColorChange?.(color.hex)}
+											className="!bg-transparent !shadow-none !border-0 !p-0"
+										/>
+									</div>
+
+									<div className="grid grid-cols-2 gap-2">
+										<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+											<div className="flex items-center justify-between mb-1">
+												<div className="text-[10px] font-medium text-slate-300">Size</div>
+												<span className="text-[10px] text-slate-500 font-mono">{cursorSize}px</span>
+											</div>
+											<Slider
+												value={[cursorSize]}
+												onValueChange={(values) => onCursorSizeChange?.(values[0])}
+												onValueCommit={() => onCursorSizeCommit?.()}
+												min={16}
+												max={64}
+												step={1}
+												className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+											/>
+										</div>
+										<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+											<div className="flex items-center justify-between mb-1">
+												<div className="text-[10px] font-medium text-slate-300">Opacity</div>
+												<span className="text-[10px] text-slate-500 font-mono">
+													{Math.round(cursorOpacity * 100)}%
+												</span>
+											</div>
+											<Slider
+												value={[cursorOpacity]}
+												onValueChange={(values) => onCursorOpacityChange?.(values[0])}
+												onValueCommit={() => onCursorOpacityCommit?.()}
+												min={0}
+												max={1}
+												step={0.01}
+												className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+											/>
+										</div>
+									</div>
+									{(cursorStyle === "circle" || cursorStyle === "ring") && (
+										<div className="p-2 rounded-lg bg-white/5 border border-white/5 mt-2">
+											<div className="flex items-center justify-between mb-1">
+												<div className="text-[10px] font-medium text-slate-300">Stroke</div>
+												<span className="text-[10px] text-slate-500 font-mono">
+													{cursorStrokeWidth}px
+												</span>
+											</div>
+											<Slider
+												value={[cursorStrokeWidth]}
+												onValueChange={(values) => onCursorStrokeWidthChange?.(values[0])}
+												onValueCommit={() => onCursorStrokeWidthCommit?.()}
+												min={1}
+												max={6}
+												step={0.5}
+												className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+											/>
+										</div>
+									)}
+								</div>
+							</div>
 						</AccordionContent>
 					</AccordionItem>
 

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -105,6 +105,7 @@ export default function VideoEditor() {
 		workAreaY: number;
 		workAreaWidth: number;
 		workAreaHeight: number;
+		isWindowCapture?: boolean;
 	} | null>(null);
 	const [selectedZoomId, setSelectedZoomId] = useState<string | null>(null);
 	const [selectedTrimId, setSelectedTrimId] = useState<string | null>(null);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -76,6 +76,12 @@ export default function VideoEditor() {
 		borderRadius,
 		padding,
 		aspectRatio,
+		showCursorHighlight,
+		cursorStyle,
+		cursorColor,
+		cursorSize,
+		cursorOpacity,
+		cursorStrokeWidth,
 	} = editorState;
 
 	// ── Non-undoable state
@@ -90,6 +96,16 @@ export default function VideoEditor() {
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState(0);
 	const [cursorTelemetry, setCursorTelemetry] = useState<CursorTelemetryPoint[]>([]);
+	const [cursorDisplayInfo, setCursorDisplayInfo] = useState<{
+		boundsX: number;
+		boundsY: number;
+		boundsWidth: number;
+		boundsHeight: number;
+		workAreaX: number;
+		workAreaY: number;
+		workAreaWidth: number;
+		workAreaHeight: number;
+	} | null>(null);
 	const [selectedZoomId, setSelectedZoomId] = useState<string | null>(null);
 	const [selectedTrimId, setSelectedTrimId] = useState<string | null>(null);
 	const [selectedSpeedId, setSelectedSpeedId] = useState<string | null>(null);
@@ -173,6 +189,12 @@ export default function VideoEditor() {
 				speedRegions: normalizedEditor.speedRegions,
 				annotationRegions: normalizedEditor.annotationRegions,
 				aspectRatio: normalizedEditor.aspectRatio,
+				showCursorHighlight: normalizedEditor.showCursorHighlight,
+				cursorStyle: normalizedEditor.cursorStyle,
+				cursorColor: normalizedEditor.cursorColor,
+				cursorSize: normalizedEditor.cursorSize,
+				cursorOpacity: normalizedEditor.cursorOpacity,
+				cursorStrokeWidth: normalizedEditor.cursorStrokeWidth,
 			});
 			setExportQuality(normalizedEditor.exportQuality);
 			setExportFormat(normalizedEditor.exportFormat);
@@ -240,6 +262,12 @@ export default function VideoEditor() {
 				speedRegions,
 				annotationRegions,
 				aspectRatio,
+				showCursorHighlight,
+				cursorStyle,
+				cursorColor,
+				cursorSize,
+				cursorOpacity,
+				cursorStrokeWidth,
 				exportQuality,
 				exportFormat,
 				gifFrameRate,
@@ -261,6 +289,12 @@ export default function VideoEditor() {
 		speedRegions,
 		annotationRegions,
 		aspectRatio,
+		showCursorHighlight,
+		cursorStyle,
+		cursorColor,
+		cursorSize,
+		cursorOpacity,
+		cursorStrokeWidth,
 		exportQuality,
 		exportFormat,
 		gifFrameRate,
@@ -352,6 +386,12 @@ export default function VideoEditor() {
 				speedRegions,
 				annotationRegions,
 				aspectRatio,
+				showCursorHighlight,
+				cursorStyle,
+				cursorColor,
+				cursorSize,
+				cursorOpacity,
+				cursorStrokeWidth,
 				exportQuality,
 				exportFormat,
 				gifFrameRate,
@@ -404,6 +444,12 @@ export default function VideoEditor() {
 			speedRegions,
 			annotationRegions,
 			aspectRatio,
+			showCursorHighlight,
+			cursorStyle,
+			cursorColor,
+			cursorSize,
+			cursorOpacity,
+			cursorStrokeWidth,
 			exportQuality,
 			exportFormat,
 			gifFrameRate,
@@ -482,6 +528,7 @@ export default function VideoEditor() {
 				const result = await window.electronAPI.getCursorTelemetry(sourcePath);
 				if (mounted) {
 					setCursorTelemetry(result.success ? result.samples : []);
+					setCursorDisplayInfo(result.display ?? null);
 				}
 			} catch (telemetryError) {
 				console.warn("Unable to load cursor telemetry:", telemetryError);
@@ -1023,6 +1070,14 @@ export default function VideoEditor() {
 						annotationRegions,
 						previewWidth,
 						previewHeight,
+						cursorTelemetry,
+						showCursorHighlight,
+						cursorStyle,
+						cursorColor,
+						cursorSize,
+						cursorOpacity,
+						cursorStrokeWidth,
+						cursorDisplayInfo,
 						onProgress: (progress: ExportProgress) => {
 							setExportProgress(progress);
 						},
@@ -1150,6 +1205,14 @@ export default function VideoEditor() {
 						annotationRegions,
 						previewWidth,
 						previewHeight,
+						cursorTelemetry,
+						showCursorHighlight,
+						cursorStyle,
+						cursorColor,
+						cursorSize,
+						cursorOpacity,
+						cursorStrokeWidth,
+						cursorDisplayInfo,
 						onProgress: (progress: ExportProgress) => {
 							setExportProgress(progress);
 						},
@@ -1212,6 +1275,14 @@ export default function VideoEditor() {
 			annotationRegions,
 			isPlaying,
 			aspectRatio,
+			cursorTelemetry,
+			showCursorHighlight,
+			cursorStyle,
+			cursorColor,
+			cursorSize,
+			cursorOpacity,
+			cursorStrokeWidth,
+			cursorDisplayInfo,
 			exportQuality,
 			handleExportSaved,
 		],
@@ -1377,6 +1448,14 @@ export default function VideoEditor() {
 												onSelectAnnotation={handleSelectAnnotation}
 												onAnnotationPositionChange={handleAnnotationPositionChange}
 												onAnnotationSizeChange={handleAnnotationSizeChange}
+												cursorTelemetry={cursorTelemetry}
+												showCursorHighlight={showCursorHighlight}
+												cursorStyle={cursorStyle}
+												cursorColor={cursorColor}
+												cursorSize={cursorSize}
+												cursorOpacity={cursorOpacity}
+												cursorStrokeWidth={cursorStrokeWidth}
+												cursorDisplayInfo={cursorDisplayInfo}
 											/>
 										</div>
 									</div>
@@ -1516,6 +1595,22 @@ export default function VideoEditor() {
 							}
 							onSpeedChange={handleSpeedChange}
 							onSpeedDelete={handleSpeedDelete}
+							hasCursorTelemetry={cursorTelemetry.length > 0}
+							showCursorHighlight={showCursorHighlight}
+							onShowCursorHighlightChange={(v) => pushState({ showCursorHighlight: v })}
+							cursorStyle={cursorStyle}
+							onCursorStyleChange={(v) => pushState({ cursorStyle: v })}
+							cursorColor={cursorColor}
+							onCursorColorChange={(v) => pushState({ cursorColor: v })}
+							cursorSize={cursorSize}
+							onCursorSizeChange={(v) => updateState({ cursorSize: v })}
+							onCursorSizeCommit={commitState}
+							cursorOpacity={cursorOpacity}
+							onCursorOpacityChange={(v) => updateState({ cursorOpacity: v })}
+							onCursorOpacityCommit={commitState}
+							cursorStrokeWidth={cursorStrokeWidth}
+							onCursorStrokeWidthChange={(v) => updateState({ cursorStrokeWidth: v })}
+							onCursorStrokeWidthCommit={commitState}
 						/>
 					</Panel>
 				</PanelGroup>

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -28,6 +28,8 @@ import {
 import { AnnotationOverlay } from "./AnnotationOverlay";
 import {
 	type AnnotationRegion,
+	type CursorStyle,
+	type CursorTelemetryPoint,
 	type SpeedRegion,
 	type TrimRegion,
 	ZOOM_DEPTH_SCALES,
@@ -84,6 +86,24 @@ interface VideoPlaybackProps {
 	onSelectAnnotation?: (id: string | null) => void;
 	onAnnotationPositionChange?: (id: string, position: { x: number; y: number }) => void;
 	onAnnotationSizeChange?: (id: string, size: { width: number; height: number }) => void;
+	// Cursor overlay
+	cursorTelemetry?: CursorTelemetryPoint[];
+	showCursorHighlight?: boolean;
+	cursorStyle?: CursorStyle;
+	cursorColor?: string;
+	cursorSize?: number;
+	cursorOpacity?: number;
+	cursorStrokeWidth?: number;
+	cursorDisplayInfo?: {
+		boundsX: number;
+		boundsY: number;
+		boundsWidth: number;
+		boundsHeight: number;
+		workAreaX: number;
+		workAreaY: number;
+		workAreaWidth: number;
+		workAreaHeight: number;
+	} | null;
 }
 
 export interface VideoPlaybackRef {
@@ -128,6 +148,15 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			onSelectAnnotation,
 			onAnnotationPositionChange,
 			onAnnotationSizeChange,
+			// Cursor overlay
+			cursorTelemetry = [],
+			showCursorHighlight = false,
+			cursorStyle = "dot",
+			cursorColor = "#ffcc00",
+			cursorSize = 32,
+			cursorOpacity = 0.6,
+			cursorStrokeWidth = 2,
+			cursorDisplayInfo = null,
 		},
 		ref,
 	) => {
@@ -171,6 +200,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const baseMaskRef = useRef({ x: 0, y: 0, width: 0, height: 0 });
 		const cropBoundsRef = useRef({ startX: 0, endX: 0, startY: 0, endY: 0 });
 		const maskGraphicsRef = useRef<Graphics | null>(null);
+		const cursorGraphicsRef = useRef<Graphics | null>(null);
+		const cursorGlowSpriteRef = useRef<Sprite | null>(null);
+		const cursorGlowCacheRef = useRef<{ color: string; size: number; opacity: number } | null>(
+			null,
+		);
 		const isPlayingRef = useRef(isPlaying);
 		const isSeekingRef = useRef(false);
 		const allowPlaybackRef = useRef(false);
@@ -575,6 +609,18 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				const videoContainer = new Container();
 				videoContainerRef.current = videoContainer;
 				cameraContainer.addChild(videoContainer);
+
+				// Cursor graphics - rendered on top of video inside cameraContainer
+				const cursorGfx = new Graphics();
+				cursorGraphicsRef.current = cursorGfx;
+				cameraContainer.addChild(cursorGfx);
+
+				// Glow sprite - uses offscreen canvas for smooth radial gradient
+				const glowSprite = new Sprite();
+				glowSprite.anchor.set(0.5, 0.5);
+				glowSprite.visible = false;
+				cursorGlowSpriteRef.current = glowSprite;
+				cameraContainer.addChild(glowSprite);
 
 				setPixiReady(true);
 			})();
@@ -1062,6 +1108,164 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			};
 		}, []);
 
+		// ── Cursor overlay (rendered in PixiJS for guaranteed coordinate alignment) ──
+		const updateCursorGraphics = useCallback(() => {
+			const gfx = cursorGraphicsRef.current;
+			const glowSprite = cursorGlowSpriteRef.current;
+			if (!gfx) return;
+
+			gfx.clear();
+			if (glowSprite) glowSprite.visible = false;
+
+			if (!showCursorHighlight || cursorTelemetry.length === 0) return;
+
+			const baseOffset = baseOffsetRef.current;
+			const scale = baseScaleRef.current;
+			if (scale === 0) return;
+
+			const samples = cursorTelemetry;
+			const timeMs = currentTime * 1000;
+
+			// Interpolate position
+			let cx: number;
+			let cy: number;
+			if (samples.length === 1) {
+				cx = samples[0].cx;
+				cy = samples[0].cy;
+			} else if (timeMs <= samples[0].timeMs) {
+				cx = samples[0].cx;
+				cy = samples[0].cy;
+			} else if (timeMs >= samples[samples.length - 1].timeMs) {
+				cx = samples[samples.length - 1].cx;
+				cy = samples[samples.length - 1].cy;
+			} else {
+				let lo = 0;
+				let hi = samples.length - 1;
+				while (lo < hi - 1) {
+					const mid = Math.floor((lo + hi) / 2);
+					if (samples[mid].timeMs <= timeMs) lo = mid;
+					else hi = mid;
+				}
+				const a = samples[lo];
+				const b = samples[hi];
+				const dt = b.timeMs - a.timeMs;
+				if (dt === 0) {
+					cx = a.cx;
+					cy = a.cy;
+				} else {
+					const t = Math.max(0, Math.min(1, (timeMs - a.timeMs) / dt));
+					cx = a.cx + (b.cx - a.cx) * t;
+					cy = a.cy + (b.cy - a.cy) * t;
+				}
+			}
+
+			// Remap bounds-normalized coords to video-space if display info available
+			if (
+				cursorDisplayInfo &&
+				cursorDisplayInfo.boundsWidth > 0 &&
+				cursorDisplayInfo.boundsHeight > 0
+			) {
+				const absX = cx * cursorDisplayInfo.boundsWidth + cursorDisplayInfo.boundsX;
+				const absY = cy * cursorDisplayInfo.boundsHeight + cursorDisplayInfo.boundsY;
+				const waW = Math.max(1, cursorDisplayInfo.workAreaWidth);
+				const waH = Math.max(1, cursorDisplayInfo.workAreaHeight);
+				cx = (absX - cursorDisplayInfo.workAreaX) / waW;
+				cy = (absY - cursorDisplayInfo.workAreaY) / waH;
+			}
+
+			// Check if inside crop region
+			const crop = cropRegion || { x: 0, y: 0, width: 1, height: 1 };
+			if (cx < crop.x || cx > crop.x + crop.width || cy < crop.y || cy > crop.y + crop.height) {
+				return;
+			}
+
+			// Position in the same coordinate space as the video sprite:
+			// videoSprite is at (baseOffset.x, baseOffset.y) with scale (baseScale)
+			// A pixel at normalized (cx, cy) in the video is at:
+			const videoSprite = videoSpriteRef.current;
+			if (!videoSprite) return;
+			const videoW = videoSprite.texture.width;
+			const videoH = videoSprite.texture.height;
+			const px = baseOffset.x + cx * videoW * scale;
+			const py = baseOffset.y + cy * videoH * scale;
+
+			// Draw cursor shape
+			const sz = cursorSize;
+			if (cursorStyle === "dot") {
+				gfx.circle(px, py, sz / 4);
+				gfx.fill({ color: cursorColor, alpha: cursorOpacity });
+			} else if (cursorStyle === "circle") {
+				gfx.circle(px, py, sz / 3);
+				gfx.stroke({ color: cursorColor, alpha: cursorOpacity, width: cursorStrokeWidth });
+			} else if (cursorStyle === "ring") {
+				gfx.circle(px, py, cursorStrokeWidth * 1.5);
+				gfx.fill({ color: cursorColor, alpha: cursorOpacity });
+				gfx.circle(px, py, sz / 3);
+				gfx.stroke({ color: cursorColor, alpha: cursorOpacity, width: cursorStrokeWidth });
+			} else if (cursorStyle === "glow" && glowSprite) {
+				// Use offscreen canvas with real radial gradient for perfectly smooth glow
+				// Glow renders 1.5x bigger than the size setting for a softer spread
+				const texSize = Math.max(Math.round(sz * 1.5), 4);
+				const cache = cursorGlowCacheRef.current;
+				if (
+					!cache ||
+					cache.color !== cursorColor ||
+					cache.size !== texSize ||
+					cache.opacity !== cursorOpacity
+				) {
+					const canvas = document.createElement("canvas");
+					canvas.width = texSize;
+					canvas.height = texSize;
+					const ctx = canvas.getContext("2d");
+					if (ctx) {
+						const cx = texSize / 2;
+						const cy = texSize / 2;
+						const r = texSize / 2;
+						const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+						// Use hexToRgba-style parsing (handle 0 values correctly)
+						const m = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(cursorColor);
+						const hr = m ? parseInt(m[1], 16) : 255;
+						const hg = m ? parseInt(m[2], 16) : 204;
+						const hb = m ? parseInt(m[3], 16) : 0;
+						// Softer center — peak alpha is 70% of opacity, fades gently
+						gradient.addColorStop(0, `rgba(${hr},${hg},${hb},${cursorOpacity * 0.7})`);
+						gradient.addColorStop(0.3, `rgba(${hr},${hg},${hb},${cursorOpacity * 0.4})`);
+						gradient.addColorStop(0.7, `rgba(${hr},${hg},${hb},${cursorOpacity * 0.12})`);
+						gradient.addColorStop(1, `rgba(${hr},${hg},${hb},0)`);
+						ctx.fillStyle = gradient;
+						ctx.fillRect(0, 0, texSize, texSize);
+					}
+					const oldTexture = glowSprite.texture;
+					glowSprite.texture = Texture.from(canvas);
+					if (oldTexture && oldTexture !== Texture.EMPTY) oldTexture.destroy(true);
+					cursorGlowCacheRef.current = {
+						color: cursorColor,
+						size: texSize,
+						opacity: cursorOpacity,
+					};
+				}
+				glowSprite.position.set(px, py);
+				glowSprite.width = texSize;
+				glowSprite.height = texSize;
+				glowSprite.visible = true;
+			}
+		}, [
+			showCursorHighlight,
+			cursorTelemetry,
+			currentTime,
+			cropRegion,
+			cursorStyle,
+			cursorColor,
+			cursorSize,
+			cursorOpacity,
+			cursorStrokeWidth,
+			cursorDisplayInfo,
+		]);
+
+		useEffect(() => {
+			updateCursorGraphics();
+		}, [updateCursorGraphics]);
+
 		const isImageUrl = Boolean(
 			resolvedWallpaper &&
 				(resolvedWallpaper.startsWith("file://") ||
@@ -1191,6 +1395,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								/>
 							));
 						})()}
+						{/* Cursor is rendered via PixiJS cursorGraphics in cameraContainer */}
 					</div>
 				)}
 				<video

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -103,6 +103,7 @@ interface VideoPlaybackProps {
 		workAreaY: number;
 		workAreaWidth: number;
 		workAreaHeight: number;
+		isWindowCapture?: boolean;
 	} | null;
 }
 
@@ -1159,9 +1160,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				}
 			}
 
-			// Remap bounds-normalized coords to video-space if display info available
+			// For window captures, remap from display-normalized to work-area-normalized coords
+			// (the video shows the window, which approximately matches the work area).
+			// For screen captures, coords are already correct — video shows the full display.
 			if (
 				cursorDisplayInfo &&
+				cursorDisplayInfo.isWindowCapture &&
 				cursorDisplayInfo.boundsWidth > 0 &&
 				cursorDisplayInfo.boundsHeight > 0
 			) {

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	createProjectData,
+	normalizeProjectEditor,
 	PROJECT_VERSION,
 	resolveProjectMedia,
 	validateProjectData,
@@ -39,6 +40,12 @@ describe("projectPersistence media compatibility", () => {
 				speedRegions: [],
 				annotationRegions: [],
 				aspectRatio: "16:9",
+				showCursorHighlight: false,
+				cursorStyle: "glow",
+				cursorColor: "#ffcc00",
+				cursorSize: 53,
+				cursorOpacity: 0.6,
+				cursorStrokeWidth: 2,
 				exportQuality: "good",
 				exportFormat: "mp4",
 				gifFrameRate: 15,
@@ -53,5 +60,52 @@ describe("projectPersistence media compatibility", () => {
 			webcamVideoPath: "/tmp/webcam.webm",
 		});
 		expect(validateProjectData(project)).toBe(true);
+	});
+});
+
+describe("normalizeProjectEditor cursor fields", () => {
+	it("provides defaults for missing cursor fields", () => {
+		const result = normalizeProjectEditor({});
+		expect(result.showCursorHighlight).toBe(false);
+		expect(result.cursorStyle).toBe("glow");
+		expect(result.cursorColor).toBe("#ffcc00");
+		expect(result.cursorSize).toBe(53);
+		expect(result.cursorOpacity).toBe(0.6);
+		expect(result.cursorStrokeWidth).toBe(2);
+	});
+
+	it("passes through valid cursor fields", () => {
+		const result = normalizeProjectEditor({
+			showCursorHighlight: true,
+			cursorStyle: "dot",
+			cursorColor: "#ff0000",
+			cursorSize: 48,
+		});
+		expect(result.showCursorHighlight).toBe(true);
+		expect(result.cursorStyle).toBe("dot");
+		expect(result.cursorColor).toBe("#ff0000");
+		expect(result.cursorSize).toBe(48);
+	});
+
+	it("falls back on invalid cursor color", () => {
+		const result = normalizeProjectEditor({
+			cursorColor: "not-a-color",
+		});
+		expect(result.cursorColor).toBe("#ffcc00");
+	});
+
+	it("clamps out-of-range cursor size", () => {
+		expect(normalizeProjectEditor({ cursorSize: 5 }).cursorSize).toBe(16);
+		expect(normalizeProjectEditor({ cursorSize: 100 }).cursorSize).toBe(64);
+	});
+
+	it("falls back on invalid cursor style", () => {
+		const result = normalizeProjectEditor({ cursorStyle: "invalid" as never });
+		expect(result.cursorStyle).toBe("glow");
+	});
+
+	it("accepts glow as valid cursor style", () => {
+		const result = normalizeProjectEditor({ cursorStyle: "glow" });
+		expect(result.cursorStyle).toBe("glow");
 	});
 });

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -5,6 +5,7 @@ import { ASPECT_RATIOS, type AspectRatio } from "@/utils/aspectRatioUtils";
 import {
 	type AnnotationRegion,
 	type CropRegion,
+	type CursorStyle,
 	DEFAULT_ANNOTATION_POSITION,
 	DEFAULT_ANNOTATION_SIZE,
 	DEFAULT_ANNOTATION_STYLE,
@@ -39,6 +40,14 @@ export interface ProjectEditorState {
 	speedRegions: SpeedRegion[];
 	annotationRegions: AnnotationRegion[];
 	aspectRatio: AspectRatio;
+	// Cursor highlight
+	showCursorHighlight: boolean;
+	cursorStyle: CursorStyle;
+	cursorColor: string;
+	cursorSize: number;
+	cursorOpacity: number;
+	cursorStrokeWidth: number;
+	// Export settings
 	exportQuality: ExportQuality;
 	exportFormat: ExportFormat;
 	gifFrameRate: GifFrameRate;
@@ -316,6 +325,9 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 	const cropWidth = clamp(rawCropWidth, 0.01, 1 - cropX);
 	const cropHeight = clamp(rawCropHeight, 0.01, 1 - cropY);
 
+	const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+	const VALID_CURSOR_STYLES = new Set<CursorStyle>(["dot", "circle", "ring", "glow"]);
+
 	return {
 		wallpaper: typeof editor.wallpaper === "string" ? editor.wallpaper : WALLPAPER_PATHS[0],
 		shadowIntensity: typeof editor.shadowIntensity === "number" ? editor.shadowIntensity : 0,
@@ -341,6 +353,26 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 		annotationRegions: normalizedAnnotationRegions,
 		aspectRatio:
 			editor.aspectRatio && validAspectRatios.has(editor.aspectRatio) ? editor.aspectRatio : "16:9",
+		// Cursor highlight
+		showCursorHighlight:
+			typeof editor.showCursorHighlight === "boolean"
+				? editor.showCursorHighlight
+				: typeof (editor as { showCursor?: unknown }).showCursor === "boolean"
+					? (editor as { showCursor?: boolean }).showCursor!
+					: false,
+		cursorStyle: VALID_CURSOR_STYLES.has(editor.cursorStyle as CursorStyle)
+			? (editor.cursorStyle as CursorStyle)
+			: "glow",
+		cursorColor:
+			typeof editor.cursorColor === "string" && HEX_COLOR_RE.test(editor.cursorColor)
+				? editor.cursorColor
+				: "#ffcc00",
+		cursorSize: isFiniteNumber(editor.cursorSize) ? clamp(editor.cursorSize, 16, 64) : 53,
+		cursorOpacity: isFiniteNumber(editor.cursorOpacity) ? clamp(editor.cursorOpacity, 0, 1) : 0.6,
+		cursorStrokeWidth: isFiniteNumber(editor.cursorStrokeWidth)
+			? clamp(editor.cursorStrokeWidth, 1, 6)
+			: 2,
+		// Export settings
 		exportQuality:
 			editor.exportQuality === "medium" || editor.exportQuality === "source"
 				? editor.exportQuality

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -19,6 +19,8 @@ export interface CursorTelemetryPoint {
 	cy: number;
 }
 
+export type CursorStyle = "dot" | "circle" | "ring" | "glow";
+
 export interface TrimRegion {
 	id: string;
 	startMs: number;

--- a/src/hooks/useEditorHistory.ts
+++ b/src/hooks/useEditorHistory.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import type {
 	AnnotationRegion,
 	CropRegion,
+	CursorStyle,
 	SpeedRegion,
 	TrimRegion,
 	ZoomRegion,
@@ -24,6 +25,13 @@ export interface EditorState {
 	borderRadius: number;
 	padding: number;
 	aspectRatio: AspectRatio;
+	// Cursor highlight
+	showCursorHighlight: boolean;
+	cursorStyle: CursorStyle;
+	cursorColor: string;
+	cursorSize: number;
+	cursorOpacity: number;
+	cursorStrokeWidth: number;
 }
 
 export const INITIAL_EDITOR_STATE: EditorState = {
@@ -39,6 +47,13 @@ export const INITIAL_EDITOR_STATE: EditorState = {
 	borderRadius: 0,
 	padding: 50,
 	aspectRatio: "16:9",
+	// Cursor highlight
+	showCursorHighlight: false,
+	cursorStyle: "glow",
+	cursorColor: "#ffcc00",
+	cursorSize: 53,
+	cursorOpacity: 0.6,
+	cursorStrokeWidth: 2,
 };
 
 type StateUpdate = Partial<EditorState> | ((prev: EditorState) => Partial<EditorState>);

--- a/src/lib/exporter/cursorUtils.test.ts
+++ b/src/lib/exporter/cursorUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { CursorTelemetryPoint } from "@/components/video-editor/types";
+import { hexToRgba, interpolateCursorPosition } from "./frameRenderer";
+
+describe("interpolateCursorPosition", () => {
+	it("returns null for empty array", () => {
+		expect(interpolateCursorPosition([], 100)).toBeNull();
+	});
+
+	it("returns null for undefined", () => {
+		expect(interpolateCursorPosition(undefined, 100)).toBeNull();
+	});
+
+	it("returns the single sample for a one-element array", () => {
+		const samples: CursorTelemetryPoint[] = [{ timeMs: 500, cx: 0.3, cy: 0.7 }];
+		expect(interpolateCursorPosition(samples, 0)).toEqual({ cx: 0.3, cy: 0.7 });
+		expect(interpolateCursorPosition(samples, 500)).toEqual({ cx: 0.3, cy: 0.7 });
+		expect(interpolateCursorPosition(samples, 1000)).toEqual({ cx: 0.3, cy: 0.7 });
+	});
+
+	it("clamps to first sample when timeMs is before range", () => {
+		const samples: CursorTelemetryPoint[] = [
+			{ timeMs: 100, cx: 0.1, cy: 0.2 },
+			{ timeMs: 200, cx: 0.5, cy: 0.6 },
+		];
+		expect(interpolateCursorPosition(samples, 0)).toEqual({ cx: 0.1, cy: 0.2 });
+		expect(interpolateCursorPosition(samples, 50)).toEqual({ cx: 0.1, cy: 0.2 });
+	});
+
+	it("clamps to last sample when timeMs is after range", () => {
+		const samples: CursorTelemetryPoint[] = [
+			{ timeMs: 100, cx: 0.1, cy: 0.2 },
+			{ timeMs: 200, cx: 0.5, cy: 0.6 },
+		];
+		expect(interpolateCursorPosition(samples, 300)).toEqual({ cx: 0.5, cy: 0.6 });
+		expect(interpolateCursorPosition(samples, 200)).toEqual({ cx: 0.5, cy: 0.6 });
+	});
+
+	it("returns exact sample when timeMs matches exactly", () => {
+		const samples: CursorTelemetryPoint[] = [
+			{ timeMs: 0, cx: 0.0, cy: 0.0 },
+			{ timeMs: 100, cx: 0.5, cy: 0.5 },
+			{ timeMs: 200, cx: 1.0, cy: 1.0 },
+		];
+		expect(interpolateCursorPosition(samples, 100)).toEqual({ cx: 0.5, cy: 0.5 });
+	});
+
+	it("interpolates linearly between two samples", () => {
+		const samples: CursorTelemetryPoint[] = [
+			{ timeMs: 0, cx: 0.0, cy: 0.0 },
+			{ timeMs: 100, cx: 1.0, cy: 0.5 },
+		];
+		const result = interpolateCursorPosition(samples, 50);
+		expect(result).not.toBeNull();
+		expect(result!.cx).toBeCloseTo(0.5, 5);
+		expect(result!.cy).toBeCloseTo(0.25, 5);
+	});
+
+	it("handles duplicate timestamps gracefully", () => {
+		const samples: CursorTelemetryPoint[] = [
+			{ timeMs: 100, cx: 0.2, cy: 0.3 },
+			{ timeMs: 100, cx: 0.8, cy: 0.9 },
+			{ timeMs: 200, cx: 0.5, cy: 0.5 },
+		];
+		// Should not throw or return NaN
+		const result = interpolateCursorPosition(samples, 100);
+		expect(result).not.toBeNull();
+		expect(Number.isFinite(result!.cx)).toBe(true);
+		expect(Number.isFinite(result!.cy)).toBe(true);
+	});
+});
+
+describe("hexToRgba", () => {
+	it("converts valid hex color with alpha", () => {
+		expect(hexToRgba("#ff0000", 0.5)).toBe("rgba(255,0,0,0.5)");
+		expect(hexToRgba("#00ff00", 1)).toBe("rgba(0,255,0,1)");
+		expect(hexToRgba("#0000ff", 0)).toBe("rgba(0,0,255,0)");
+	});
+
+	it("handles white and black", () => {
+		expect(hexToRgba("#ffffff", 0.6)).toBe("rgba(255,255,255,0.6)");
+		expect(hexToRgba("#000000", 0.6)).toBe("rgba(0,0,0,0.6)");
+	});
+
+	it("returns fallback for invalid hex", () => {
+		expect(hexToRgba("not-a-color", 0.5)).toBe("rgba(255,255,255,0.5)");
+		expect(hexToRgba("", 0.5)).toBe("rgba(255,255,255,0.5)");
+		expect(hexToRgba("#gg0000", 0.5)).toBe("rgba(255,255,255,0.5)");
+	});
+});

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -72,6 +72,7 @@ interface FrameRenderConfig {
 		workAreaY: number;
 		workAreaWidth: number;
 		workAreaHeight: number;
+		isWindowCapture?: boolean;
 	} | null;
 }
 
@@ -696,11 +697,11 @@ export class FrameRenderer {
 		const pos = this.interpolateCursorPosition(timeMs);
 		if (!pos) return;
 
-		// Remap bounds-normalized coords to video-space coords if display info is available
+		// For window captures, remap from display-normalized to work-area-normalized coords.
+		// For screen captures, coords are already correct — video shows the full display.
 		let { cx, cy } = pos;
 		const di = this.config.cursorDisplayInfo;
-		if (di && di.boundsWidth > 0 && di.boundsHeight > 0) {
-			// Convert from bounds-normalized to absolute logical coords, then to workArea-normalized
+		if (di && di.isWindowCapture && di.boundsWidth > 0 && di.boundsHeight > 0) {
 			const absX = cx * di.boundsWidth + di.boundsX;
 			const absY = cy * di.boundsHeight + di.boundsY;
 			const waW = Math.max(1, di.workAreaWidth);

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -11,6 +11,8 @@ import { MotionBlurFilter } from "pixi-filters/motion-blur";
 import type {
 	AnnotationRegion,
 	CropRegion,
+	CursorStyle,
+	CursorTelemetryPoint,
 	SpeedRegion,
 	ZoomDepth,
 	ZoomRegion,
@@ -53,6 +55,24 @@ interface FrameRenderConfig {
 	speedRegions?: SpeedRegion[];
 	previewWidth?: number;
 	previewHeight?: number;
+	// Cursor overlay
+	cursorTelemetry?: CursorTelemetryPoint[];
+	showCursorHighlight?: boolean;
+	cursorStyle?: CursorStyle;
+	cursorColor?: string;
+	cursorSize?: number;
+	cursorOpacity?: number;
+	cursorStrokeWidth?: number;
+	cursorDisplayInfo?: {
+		boundsX: number;
+		boundsY: number;
+		boundsWidth: number;
+		boundsHeight: number;
+		workAreaX: number;
+		workAreaY: number;
+		workAreaWidth: number;
+		workAreaHeight: number;
+	} | null;
 }
 
 interface AnimationState {
@@ -391,6 +411,11 @@ export class FrameRenderer {
 				scaleFactor,
 			);
 		}
+
+		// Render cursor overlay on top of everything
+		if (this.config.showCursorHighlight && this.compositeCtx) {
+			this.renderCursor(this.compositeCtx, timeMs);
+		}
 	}
 
 	private updateLayout(): void {
@@ -659,6 +684,112 @@ export class FrameRenderer {
 		}
 	}
 
+	// ── Cursor overlay ──────────────────────────────────────────────────
+
+	private interpolateCursorPosition(timeMs: number): { cx: number; cy: number } | null {
+		return interpolateCursorPosition(this.config.cursorTelemetry, timeMs);
+	}
+
+	private renderCursor(ctx: CanvasRenderingContext2D, timeMs: number): void {
+		if (!this.layoutCache) return;
+
+		const pos = this.interpolateCursorPosition(timeMs);
+		if (!pos) return;
+
+		// Remap bounds-normalized coords to video-space coords if display info is available
+		let { cx, cy } = pos;
+		const di = this.config.cursorDisplayInfo;
+		if (di && di.boundsWidth > 0 && di.boundsHeight > 0) {
+			// Convert from bounds-normalized to absolute logical coords, then to workArea-normalized
+			const absX = cx * di.boundsWidth + di.boundsX;
+			const absY = cy * di.boundsHeight + di.boundsY;
+			const waW = Math.max(1, di.workAreaWidth);
+			const waH = Math.max(1, di.workAreaHeight);
+			cx = (absX - di.workAreaX) / waW;
+			cy = (absY - di.workAreaY) / waH;
+		}
+		const { cropRegion } = this.config;
+
+		// Check if cursor is inside the visible crop region
+		if (
+			cx < cropRegion.x ||
+			cx > cropRegion.x + cropRegion.width ||
+			cy < cropRegion.y ||
+			cy > cropRegion.y + cropRegion.height
+		) {
+			return;
+		}
+
+		// Map normalized video coords → base layout coords
+		const relCropX = (cx - cropRegion.x) / cropRegion.width;
+		const relCropY = (cy - cropRegion.y) / cropRegion.height;
+		const baseX = this.layoutCache.baseOffset.x + relCropX * this.layoutCache.maskRect.width;
+		const baseY = this.layoutCache.baseOffset.y + relCropY * this.layoutCache.maskRect.height;
+
+		// Apply zoom transform
+		const finalX = baseX * this.animationState.appliedScale + this.animationState.x;
+		const finalY = baseY * this.animationState.appliedScale + this.animationState.y;
+
+		// Bounds check — skip if cursor center is outside the canvas
+		if (finalX < 0 || finalX > this.config.width || finalY < 0 || finalY > this.config.height) {
+			return;
+		}
+
+		// Scale cursor/highlight sizes proportionally to export resolution
+		// Use average of X and Y scales to match annotation scaling (frameRenderer.ts:395)
+		const previewWidth = this.config.previewWidth || 1920;
+		const previewHeight = this.config.previewHeight || 1080;
+		const scaleX = this.config.width / previewWidth;
+		const scaleY = this.config.height / previewHeight;
+		const canvasScaleFactor = (scaleX + scaleY) / 2;
+
+		// Clip to the rounded video mask so cursor doesn't bleed outside the video area
+		const mask = this.layoutCache.maskRect;
+		const zoomScale = this.animationState.appliedScale;
+		const zoomX = this.animationState.x;
+		const zoomY = this.animationState.y;
+		const clipX = this.layoutCache.baseOffset.x * zoomScale + zoomX;
+		const clipY = this.layoutCache.baseOffset.y * zoomScale + zoomY;
+		const clipW = mask.width * zoomScale;
+		const clipH = mask.height * zoomScale;
+
+		const previewW = this.config.previewWidth || 1920;
+		const previewH = this.config.previewHeight || 1080;
+		const canvasScale = Math.min(this.config.width / previewW, this.config.height / previewH);
+		const scaledBorderRadius = (this.config.borderRadius ?? 0) * canvasScale * zoomScale;
+
+		ctx.save();
+		ctx.beginPath();
+		ctx.roundRect(clipX, clipY, clipW, clipH, scaledBorderRadius);
+		ctx.clip();
+
+		// Draw cursor shape
+		const size = (this.config.cursorSize ?? 32) * canvasScaleFactor;
+		const color = this.config.cursorColor ?? "#ffffff";
+		const opacity = this.config.cursorOpacity ?? 1;
+		const strokeWidth = (this.config.cursorStrokeWidth ?? 2) * canvasScaleFactor;
+		ctx.globalAlpha = opacity;
+		switch (this.config.cursorStyle) {
+			case "dot":
+				drawDotCursor(ctx, finalX, finalY, size, color);
+				break;
+			case "circle":
+				drawCircleCursor(ctx, finalX, finalY, size, color, strokeWidth);
+				break;
+			case "ring":
+				drawRingCursor(ctx, finalX, finalY, size, color, strokeWidth);
+				break;
+			case "glow":
+				drawGlowCursor(ctx, finalX, finalY, size, color, opacity);
+				break;
+			default:
+				drawDotCursor(ctx, finalX, finalY, size, color);
+		}
+		ctx.globalAlpha = 1;
+
+		ctx.restore();
+	}
+
 	getCanvas(): HTMLCanvasElement {
 		if (!this.compositeCanvas) {
 			throw new Error("Renderer not initialized");
@@ -686,4 +817,141 @@ export class FrameRenderer {
 		this.compositeCanvas = null;
 		this.compositeCtx = null;
 	}
+}
+
+// ── Cursor utilities (exported for testing) ───────────────────────────
+
+export function interpolateCursorPosition(
+	samples: CursorTelemetryPoint[] | undefined,
+	timeMs: number,
+): { cx: number; cy: number } | null {
+	if (!samples || samples.length === 0) return null;
+
+	// Single sample
+	if (samples.length === 1) {
+		return { cx: samples[0].cx, cy: samples[0].cy };
+	}
+
+	// Clamp to first/last sample if out of range
+	if (timeMs <= samples[0].timeMs) {
+		return { cx: samples[0].cx, cy: samples[0].cy };
+	}
+	if (timeMs >= samples[samples.length - 1].timeMs) {
+		const last = samples[samples.length - 1];
+		return { cx: last.cx, cy: last.cy };
+	}
+
+	// Binary search for bracketing samples
+	let lo = 0;
+	let hi = samples.length - 1;
+	while (lo < hi - 1) {
+		const mid = Math.floor((lo + hi) / 2);
+		if (samples[mid].timeMs <= timeMs) lo = mid;
+		else hi = mid;
+	}
+
+	const a = samples[lo];
+	const b = samples[hi];
+	const dt = b.timeMs - a.timeMs;
+
+	// Guard against duplicate timestamps
+	if (dt === 0) return { cx: a.cx, cy: a.cy };
+
+	const t = Math.max(0, Math.min(1, (timeMs - a.timeMs) / dt));
+	return {
+		cx: a.cx + (b.cx - a.cx) * t,
+		cy: a.cy + (b.cy - a.cy) * t,
+	};
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+	if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
+		return `rgba(255,255,255,${alpha})`;
+	}
+	const r = parseInt(hex.slice(1, 3), 16);
+	const g = parseInt(hex.slice(3, 5), 16);
+	const b = parseInt(hex.slice(5, 7), 16);
+	return `rgba(${r},${g},${b},${alpha})`;
+}
+
+function drawDotCursor(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	size: number,
+	color: string,
+): void {
+	ctx.save();
+	ctx.shadowColor = "rgba(0,0,0,0.5)";
+	ctx.shadowBlur = 6;
+	ctx.fillStyle = color;
+	ctx.beginPath();
+	ctx.arc(x, y, size / 4, 0, Math.PI * 2);
+	ctx.fill();
+	ctx.restore();
+}
+
+function drawCircleCursor(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	size: number,
+	color: string,
+	strokeWidth = 2,
+): void {
+	ctx.save();
+	ctx.strokeStyle = color;
+	ctx.lineWidth = strokeWidth;
+	ctx.shadowColor = "rgba(0,0,0,0.4)";
+	ctx.shadowBlur = 4;
+	ctx.beginPath();
+	ctx.arc(x, y, size / 3, 0, Math.PI * 2);
+	ctx.stroke();
+	ctx.restore();
+}
+
+function drawRingCursor(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	size: number,
+	color: string,
+	strokeWidth = 2,
+): void {
+	// Center dot radius scales with strokeWidth (radius = strokeWidth * 1.5)
+	const dotRadius = strokeWidth * 1.5;
+	ctx.save();
+	ctx.shadowColor = "rgba(0,0,0,0.5)";
+	ctx.shadowBlur = 6;
+	ctx.fillStyle = color;
+	ctx.beginPath();
+	ctx.arc(x, y, dotRadius, 0, Math.PI * 2);
+	ctx.fill();
+	ctx.restore();
+	drawCircleCursor(ctx, x, y, size, color, strokeWidth);
+}
+
+function drawGlowCursor(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	size: number,
+	color: string,
+	opacity: number,
+): void {
+	// Glow renders 1.5x bigger than size for softer spread
+	const radius = (size * 1.5) / 2;
+	ctx.save();
+	ctx.globalAlpha = 1; // alpha is baked into the gradient stops
+	const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius);
+	// Softer center — peak alpha is 70% of opacity
+	gradient.addColorStop(0, hexToRgba(color, opacity * 0.7));
+	gradient.addColorStop(0.3, hexToRgba(color, opacity * 0.4));
+	gradient.addColorStop(0.7, hexToRgba(color, opacity * 0.12));
+	gradient.addColorStop(1, hexToRgba(color, 0));
+	ctx.fillStyle = gradient;
+	ctx.beginPath();
+	ctx.arc(x, y, radius, 0, Math.PI * 2);
+	ctx.fill();
+	ctx.restore();
 }

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -2,6 +2,8 @@ import GIF from "gif.js";
 import type {
 	AnnotationRegion,
 	CropRegion,
+	CursorStyle,
+	CursorTelemetryPoint,
 	SpeedRegion,
 	TrimRegion,
 	ZoomRegion,
@@ -42,6 +44,24 @@ interface GifExporterConfig {
 	annotationRegions?: AnnotationRegion[];
 	previewWidth?: number;
 	previewHeight?: number;
+	// Cursor overlay
+	cursorTelemetry?: CursorTelemetryPoint[];
+	showCursorHighlight?: boolean;
+	cursorStyle?: CursorStyle;
+	cursorColor?: string;
+	cursorSize?: number;
+	cursorOpacity?: number;
+	cursorStrokeWidth?: number;
+	cursorDisplayInfo?: {
+		boundsX: number;
+		boundsY: number;
+		boundsWidth: number;
+		boundsHeight: number;
+		workAreaX: number;
+		workAreaY: number;
+		workAreaWidth: number;
+		workAreaHeight: number;
+	} | null;
 	onProgress?: (progress: ExportProgress) => void;
 }
 
@@ -142,6 +162,14 @@ export class GifExporter {
 				speedRegions: this.config.speedRegions,
 				previewWidth: this.config.previewWidth,
 				previewHeight: this.config.previewHeight,
+				cursorTelemetry: this.config.cursorTelemetry,
+				showCursorHighlight: this.config.showCursorHighlight,
+				cursorStyle: this.config.cursorStyle,
+				cursorColor: this.config.cursorColor,
+				cursorSize: this.config.cursorSize,
+				cursorOpacity: this.config.cursorOpacity,
+				cursorStrokeWidth: this.config.cursorStrokeWidth,
+				cursorDisplayInfo: this.config.cursorDisplayInfo,
 			});
 			await this.renderer.initialize();
 

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -61,6 +61,7 @@ interface GifExporterConfig {
 		workAreaY: number;
 		workAreaWidth: number;
 		workAreaHeight: number;
+		isWindowCapture?: boolean;
 	} | null;
 	onProgress?: (progress: ExportProgress) => void;
 }

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -49,6 +49,7 @@ interface VideoExporterConfig extends ExportConfig {
 		workAreaY: number;
 		workAreaWidth: number;
 		workAreaHeight: number;
+		isWindowCapture?: boolean;
 	} | null;
 	onProgress?: (progress: ExportProgress) => void;
 }

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -1,6 +1,8 @@
 import type {
 	AnnotationRegion,
 	CropRegion,
+	CursorStyle,
+	CursorTelemetryPoint,
 	SpeedRegion,
 	TrimRegion,
 	ZoomRegion,
@@ -30,6 +32,24 @@ interface VideoExporterConfig extends ExportConfig {
 	annotationRegions?: AnnotationRegion[];
 	previewWidth?: number;
 	previewHeight?: number;
+	// Cursor overlay
+	cursorTelemetry?: CursorTelemetryPoint[];
+	showCursorHighlight?: boolean;
+	cursorStyle?: CursorStyle;
+	cursorColor?: string;
+	cursorSize?: number;
+	cursorOpacity?: number;
+	cursorStrokeWidth?: number;
+	cursorDisplayInfo?: {
+		boundsX: number;
+		boundsY: number;
+		boundsWidth: number;
+		boundsHeight: number;
+		workAreaX: number;
+		workAreaY: number;
+		workAreaWidth: number;
+		workAreaHeight: number;
+	} | null;
 	onProgress?: (progress: ExportProgress) => void;
 }
 
@@ -91,6 +111,14 @@ export class VideoExporter {
 				speedRegions: this.config.speedRegions,
 				previewWidth: this.config.previewWidth,
 				previewHeight: this.config.previewHeight,
+				cursorTelemetry: this.config.cursorTelemetry,
+				showCursorHighlight: this.config.showCursorHighlight,
+				cursorStyle: this.config.cursorStyle,
+				cursorColor: this.config.cursorColor,
+				cursorSize: this.config.cursorSize,
+				cursorOpacity: this.config.cursorOpacity,
+				cursorStrokeWidth: this.config.cursorStrokeWidth,
+				cursorDisplayInfo: this.config.cursorDisplayInfo,
 			});
 			await this.renderer.initialize();
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -58,6 +58,16 @@ interface Window {
 		getCursorTelemetry: (videoPath?: string) => Promise<{
 			success: boolean;
 			samples: CursorTelemetryPoint[];
+			display?: {
+				boundsX: number;
+				boundsY: number;
+				boundsWidth: number;
+				boundsHeight: number;
+				workAreaX: number;
+				workAreaY: number;
+				workAreaWidth: number;
+				workAreaHeight: number;
+			};
 			message?: string;
 			error?: string;
 		}>;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -67,6 +67,7 @@ interface Window {
 				workAreaY: number;
 				workAreaWidth: number;
 				workAreaHeight: number;
+				isWindowCapture?: boolean;
 			};
 			message?: string;
 			error?: string;


### PR DESCRIPTION
## Summary
- Add cursor highlight overlay to video editor with 4 styles: dot, circle, ring, and glow (soft radial gradient)
- Live preview via PixiJS in editor + canvas-based rendering in MP4/GIF export pipeline
- Cursor position from existing 10Hz telemetry data, remapped from display bounds to workArea coordinates using display metadata stored in cursor.json

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 27 tests pass (includes interpolation, hex color, persistence normalization)
- [x] `npm run lint` — clean
- [ ] Record screen → open editor → enable Cursor Highlight → verify overlay follows recorded cursor path
- [ ] Change style (dot/circle/ring/glow), color, size, opacity, stroke — verify preview updates
- [ ] Export MP4 with cursor highlight enabled → verify cursor renders in exported video
- [ ] Export GIF → same cursor rendering works
- [ ] Toggle off → no cursor in preview or export
- [ ] No cursor telemetry → section shows disabled notice
- [ ] Save/load project → cursor settings persist
- [ ] Undo/redo cursor setting changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor highlight added to the video editor with selectable styles (dot, circle, ring, glow) and customizable color, size, opacity, and stroke width.
  * Cursor overlays shown in preview and included in GIF/MP4 exports.
  * Display geometry captured during recording to improve cursor positioning and window-capture handling.
* **Tests**
  * Added tests for cursor interpolation and color conversion utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->