### PR TITLE
Add attribution for zoom & pan animation code ported over from Recordly

### DIFF
--- a/src/components/video-editor/videoPlayback/mathUtils.ts
+++ b/src/components/video-editor/videoPlayback/mathUtils.ts
@@ -1,3 +1,5 @@
+// Zoom animation math ported from Recordly (https://github.com/webadderall/Recordly)
+
 export function clamp01(value: number) {
 	return Math.max(0, Math.min(1, value));
 }

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -1,3 +1,5 @@
+// Zoom region animation logic ported from Recordly (https://github.com/webadderall/Recordly)
+
 import type { ZoomFocus, ZoomRegion } from "../types";
 import { ZOOM_DEPTH_SCALES } from "../types";
 import { TRANSITION_WINDOW_MS, ZOOM_IN_TRANSITION_WINDOW_MS } from "./constants";

--- a/src/components/video-editor/videoPlayback/zoomTransform.ts
+++ b/src/components/video-editor/videoPlayback/zoomTransform.ts
@@ -1,3 +1,5 @@
+// Zoom transform and motion blur logic ported from Recordly (https://github.com/webadderall/Recordly)
+
 import { BlurFilter, Container } from "pixi.js";
 import { MotionBlurFilter } from "pixi-filters/motion-blur";
 


### PR DESCRIPTION
# Pull Request Template

## Description
Adds attribution to Recordly from animation code ported from Recordly to OpenScreen

## Motivation
I only found out today that Recordly wasn't attributed for the zoom animation code, and originally, I was fine with it, but as OpenScreen grows I think the origins of the zoom animations should be set clear, especially as I spent days working on them.

I don't wish ill towards OpenScreen, just something small I wanted to set straight :)

## Type of Change
- Documentation Update