### PR TITLE
docs: add ATTRIBUTION.md for Recordly zoom animation code

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,12 @@
+# Attribution
+
+OpenScreen thanks the following open-source projects for inspiring and contributing code:
+
+## Zoom & Pan Animation
+
+The zoom and pan animation system in OpenScreen was inspired by and ported from [Recordly](https://github.com/Recordly-dev/Recordly).
+
+- `src/components/video-editor/videoPlayback/mathUtils.ts` — `easeOutScreenStudio()` and `cubicBezier()` implementation
+- `src/components/video-editor/videoPlayback/zoomRegionUtils.ts` — zoom region strength, chaining, and connected pan transitions
+
+We apologize for the omission and thank Recordly's maintainers for their excellent work.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ _I'm new to open source, idk what I'm doing lol. If something is wrong please ra
 
 Contributions are welcome! If you’d like to help out or see what’s currently being worked on, take a look at the open issues and the [project roadmap](https://github.com/users/siddharthvaddem/projects/3) to understand the current direction of the project and find ways to contribute.
 
+## Attribution
+
+Third-party attributions are listed in [ATTRIBUTION.md](./ATTRIBUTION.md).
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE). By using this software, you agree that the authors are not liable for any issues, damages, or claims arising from its use.


### PR DESCRIPTION
## Summary

Add attribution crediting [Recordly](https://github.com/Recordly-dev/Recordly) for the zoom & pan animation system ported into OpenScreen, as requested in #263.

## Changes

- **New file `ATTRIBUTION.md`** — lists Recordly as the source of the zoom/pan animation code (`mathUtils.ts` and `zoomRegionUtils.ts`)
- **Updated `README.md`** — added Attribution section linking to `ATTRIBUTION.md`

Fixes: siddharthvaddem/openscreen#263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added attribution documentation acknowledging third-party open-source projects and utilities that contributed to the application, specifically recognizing zoom and pan animation systems.
  * Updated README with an "Attribution" section directing users to view third-party credits and acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->