### PR TITLE
docs: add ATTRIBUTION.md for Recordly zoom animation code

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,14 @@
+# Attribution
+
+OpenScreen thanks the following open-source projects for inspiring and contributing code:
+
+## Zoom & Pan Animation
+
+The zoom and pan animation system in OpenScreen was inspired by and ported from [Recordly](https://github.com/Recordly-dev/Recordly).
+
+The following functions in `src/components/video-editor/videoPlayback/` were ported from Recordly:
+
+- `mathUtils.ts` — `easeOutScreenStudio()`, `cubicBezier()`, and `clamp01()`
+- `zoomRegionUtils.ts` — zoom region strength, chaining, and connected pan transition logic
+
+We apologize for the omission and thank Recordly's maintainers for their excellent work.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ _I'm new to open source, idk what I'm doing lol. If something is wrong please ra
 
 Contributions are welcome! If you’d like to help out or see what’s currently being worked on, take a look at the open issues and the [project roadmap](https://github.com/users/siddharthvaddem/projects/3) to understand the current direction of the project and find ways to contribute.
 
+## Attribution
+
+Third-party attributions are listed in [ATTRIBUTION.md](./ATTRIBUTION.md).
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE). By using this software, you agree that the authors are not liable for any issues, damages, or claims arising from its use.

--- a/src/components/video-editor/videoPlayback/mathUtils.ts
+++ b/src/components/video-editor/videoPlayback/mathUtils.ts
@@ -1,3 +1,6 @@
+// Ported from Recordly (https://github.com/Recordly-dev/Recordly).
+// See ATTRIBUTION.md for details.
+
 export function clamp01(value: number) {
 	return Math.max(0, Math.min(1, value));
 }

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -1,3 +1,6 @@
+// Ported from Recordly (https://github.com/Recordly-dev/Recordly).
+// See ATTRIBUTION.md for details.
+
 import type { ZoomFocus, ZoomRegion } from "../types";
 import { ZOOM_DEPTH_SCALES } from "../types";
 import { TRANSITION_WINDOW_MS, ZOOM_IN_TRANSITION_WINDOW_MS } from "./constants";


### PR DESCRIPTION
## Summary

Add attribution crediting Recordly for the zoom & pan animation system ported into OpenScreen, as requested in #263.

## Changes

- **New file `ATTRIBUTION.md`** — lists Recordly as the source of the zoom/pan animation code (`mathUtils.ts` and `zoomRegionUtils.ts`)
- **Updated `README.md`** — added Attribution section linking to `ATTRIBUTION.md`
- **Inline headers in `mathUtils.ts` and `zoomRegionUtils.ts`** — added `// Ported from Recordly` comment headers per review
- **`clamp01()`** added to the attribution entry per review

Fixes: siddharthvaddem/openscreen#263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new attribution file documenting open-source attributions and providing detailed acknowledgments
  * Updated README.md with a dedicated Attribution section directing users to attribution details
  * Added attribution header comments to animation-related utility modules with references to attribution documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->