### PR TITLE
fix(#264): read raw pixels from canvas for VideoFrame to avoid silent failures on Linux

### DIFF
--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -230,8 +230,16 @@ export class VideoExporter {
 
 						const canvas = renderer.getCanvas();
 
-						// @ts-expect-error - colorSpace is available at runtime even if TS does not know it.
-						const exportFrame = new VideoFrame(canvas, {
+						// Read raw pixels from the canvas instead of passing
+						// the canvas directly to VideoFrame. On some Linux
+						// systems the GPU shared-image path (EGL/Ozone) fails
+						// silently, producing empty frames.
+						const canvasCtx = canvas.getContext("2d")!;
+						const imageData = canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
+						const exportFrame = new VideoFrame(imageData.data.buffer, {
+							format: "RGBA",
+							codedWidth: canvas.width,
+							codedHeight: canvas.height,
 							timestamp,
 							duration: frameDuration,
 							colorSpace: {


### PR DESCRIPTION
## Description
Fix green static output for MP4 export.

## Motivation
On some linux OSs the MP4 output is corrupted.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
#264 

## Testing
```bash
$ npm install
$ npm run build
# run generated AppImage
$ ./release/1.3.0/Openscreen-Linux-1.3.0.AppImage
# export video as MP4
```

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal video export frame construction logic for better stability and control over pixel data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->