### PR TITLE
fix: prevent double-finalize race condition in restartRecording on Windos

### DIFF
--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -563,6 +563,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 		restarting.current = true;
 		discardRecordingId.current = activeRecordingId;
+		allowAutoFinalize.current = false;
 
 		const stopPromises = [
 			new Promise<void>((resolve) => {


### PR DESCRIPTION
## Description
Fixes a bug where clicking the Restart button in the recording HUD would stop the recording and open the video editor instead of discarding the current recording and starting a fresh one.

## Motivation
On Windows, a race condition caused `finalizeRecording` to be called twice for the same recording session. The second call had no discard protection and would save the footage and open the editor - exactly as if the Stop button had been pressed. This made the Restart button non-functional on Windows.

## Type of Change
Bug Fix

## Related Issue(s)
Fixes #292

## Testing
1. Launch OpenScreen on Windows
2. Select a source and start a screen recording
3. While recording is active, click the Restart button (circular arrow) in the HUD toolbar
4. Verify: the recording restarts - HUD stays visible and a new recording begins
5. Verify: the video editor does NOT open
6. Verify: clicking Stop still works normally and opens the editor as expected

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue with screen recording restart functionality where stopping and restarting recordings could cause unexpected behavior during the restart sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->