### PR TITLE
fix: prompt for unsaved changes in new projects

### DIFF
--- a/src/components/video-editor/VideoEditor.test.ts
+++ b/src/components/video-editor/VideoEditor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { hasUnsavedProjectChanges } from "./VideoEditor";
+
+describe("hasUnsavedProjectChanges", () => {
+	it("treats a new unsaved project with edits as dirty", () => {
+		expect(hasUnsavedProjectChanges('{"editor":{"trimRegions":[1]}}', null)).toBe(true);
+	});
+
+	it("treats a saved project with unchanged snapshot as clean", () => {
+		const snapshot = '{"editor":{"trimRegions":[1]}}';
+		expect(hasUnsavedProjectChanges(snapshot, snapshot)).toBe(false);
+	});
+
+	it("treats a saved project with changed snapshot as dirty", () => {
+		expect(
+			hasUnsavedProjectChanges(
+				'{"editor":{"trimRegions":[1,2]}}',
+				'{"editor":{"trimRegions":[1]}}',
+			),
+		).toBe(true);
+	});
+
+	it("treats missing current snapshot as clean", () => {
+		expect(hasUnsavedProjectChanges(null, null)).toBe(false);
+	});
+});

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -60,6 +60,21 @@ import {
 } from "./types";
 import VideoPlayback, { VideoPlaybackRef } from "./VideoPlayback";
 
+export function hasUnsavedProjectChanges(
+	currentProjectSnapshot: string | null,
+	lastSavedSnapshot: string | null,
+): boolean {
+	if (!currentProjectSnapshot) {
+		return false;
+	}
+
+	if (lastSavedSnapshot === null) {
+		return true;
+	}
+
+	return currentProjectSnapshot !== lastSavedSnapshot;
+}
+
 export default function VideoEditor() {
 	const {
 		state: editorState,
@@ -295,12 +310,7 @@ export default function VideoEditor() {
 		gifSizePreset,
 	]);
 
-	const hasUnsavedChanges = Boolean(
-		currentProjectPath &&
-			currentProjectSnapshot &&
-			lastSavedSnapshot &&
-			currentProjectSnapshot !== lastSavedSnapshot,
-	);
+	const hasUnsavedChanges = hasUnsavedProjectChanges(currentProjectSnapshot, lastSavedSnapshot);
 
 	useEffect(() => {
 		async function loadInitialData() {


### PR DESCRIPTION
## Summary

Fix the editor dirty-state logic so new projects that have never been saved still trigger the unsaved-changes prompt after edits.

## Reproduction

A newly loaded recording/session resets both `currentProjectPath` and `lastSavedSnapshot` to `null`. After making edits, the previous dirty-state rule still returned false because it required `currentProjectPath`.

## Patch Summary

- extract dirty-state evaluation into a small helper
- treat a current snapshot with no saved snapshot as unsaved
- add focused unit coverage for new-project and saved-project cases

## Risks

Low. The change is limited to dirty-state calculation and its test coverage.

## Test Coverage

- added `src/components/video-editor/VideoEditor.test.ts`
- confirmed it fails before the fix and passes after the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for unsaved changes detection in the video editor.

* **Refactor**
  * Improved internal logic for detecting unsaved project changes, making the codebase more maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->