### PR TITLE
Revert "fix: prevent double-finalize race condition in restartRecording on Windos"

### DIFF
--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -573,7 +573,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 		restarting.current = true;
 		discardRecordingId.current = activeRecordingId;
-		allowAutoFinalize.current = false;
 
 		const stopPromises = [
 			new Promise<void>((resolve) => {


### PR DESCRIPTION
Reverts siddharthvaddem/openscreen#293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized screen recorder restart control flow for improved internal state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->