### PR TITLE
fix(editor): track unsaved changes for new projects

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -31,6 +31,8 @@ import { ExportDialog } from "./ExportDialog";
 import PlaybackControls from "./PlaybackControls";
 import {
 	createProjectData,
+	createProjectSnapshot,
+	hasProjectUnsavedChanges,
 	deriveNextId,
 	fromFileUrl,
 	normalizeProjectEditor,
@@ -234,13 +236,11 @@ export default function VideoEditor() {
 				) + 1;
 
 			setLastSavedSnapshot(
-				JSON.stringify(
-					createProjectData(
-						webcamSourcePath
-							? { screenVideoPath: sourcePath, webcamVideoPath: webcamSourcePath }
-							: { screenVideoPath: sourcePath },
-						normalizedEditor,
-					),
+				createProjectSnapshot(
+					webcamSourcePath
+						? { screenVideoPath: sourcePath, webcamVideoPath: webcamSourcePath }
+						: { screenVideoPath: sourcePath },
+					normalizedEditor,
 				),
 			);
 			return true;
@@ -252,8 +252,7 @@ export default function VideoEditor() {
 		if (!currentProjectMedia) {
 			return null;
 		}
-		return JSON.stringify(
-			createProjectData(currentProjectMedia, {
+		return createProjectSnapshot(currentProjectMedia, {
 				wallpaper,
 				shadowIntensity,
 				showBlur,
@@ -274,8 +273,7 @@ export default function VideoEditor() {
 				gifFrameRate,
 				gifLoop,
 				gifSizePreset,
-			}),
-		);
+		});
 	}, [
 		currentProjectMedia,
 		wallpaper,
@@ -300,11 +298,9 @@ export default function VideoEditor() {
 		gifSizePreset,
 	]);
 
-	const hasUnsavedChanges = Boolean(
-		currentProjectPath &&
-			currentProjectSnapshot &&
-			lastSavedSnapshot &&
-			currentProjectSnapshot !== lastSavedSnapshot,
+	const hasUnsavedChanges = hasProjectUnsavedChanges(
+		currentProjectSnapshot,
+		lastSavedSnapshot,
 	);
 
 	useEffect(() => {
@@ -333,7 +329,14 @@ export default function VideoEditor() {
 					setWebcamVideoSourcePath(webcamSourcePath);
 					setWebcamVideoPath(webcamSourcePath ? toFileUrl(webcamSourcePath) : null);
 					setCurrentProjectPath(null);
-					setLastSavedSnapshot(null);
+					setLastSavedSnapshot(
+						createProjectSnapshot(
+							webcamSourcePath
+								? { screenVideoPath: sourcePath, webcamVideoPath: webcamSourcePath }
+								: { screenVideoPath: sourcePath },
+							INITIAL_EDITOR_STATE,
+						),
+					);
 					return;
 				}
 
@@ -345,7 +348,9 @@ export default function VideoEditor() {
 					setWebcamVideoSourcePath(null);
 					setWebcamVideoPath(null);
 					setCurrentProjectPath(null);
-					setLastSavedSnapshot(null);
+					setLastSavedSnapshot(
+						createProjectSnapshot({ screenVideoPath: sourcePath }, INITIAL_EDITOR_STATE),
+					);
 				} else {
 					setError("No video to load. Please record or select a video.");
 				}

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	createProjectData,
+	createProjectSnapshot,
+	hasProjectUnsavedChanges,
 	normalizeProjectEditor,
 	PROJECT_VERSION,
 	resolveProjectMedia,
@@ -64,4 +66,41 @@ describe("projectPersistence media compatibility", () => {
 			normalizeProjectEditor({ webcamMaskShape: "not-a-real-shape" as never }).webcamMaskShape,
 		).toBe("rectangle");
 	});
+});
+
+
+it("creates stable snapshots for identical project state", () => {
+	const media = {
+		screenVideoPath: "/tmp/screen.webm",
+		webcamVideoPath: "/tmp/webcam.webm",
+	};
+	const editor = normalizeProjectEditor({
+		wallpaper: "/wallpapers/wallpaper1.jpg",
+		shadowIntensity: 0,
+		showBlur: false,
+		motionBlurAmount: 0,
+		borderRadius: 0,
+		padding: 50,
+		cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+		zoomRegions: [],
+		trimRegions: [],
+		speedRegions: [],
+		annotationRegions: [],
+		aspectRatio: "16:9",
+		webcamLayoutPreset: "picture-in-picture",
+		webcamMaskShape: "circle",
+		exportQuality: "good",
+		exportFormat: "mp4",
+		gifFrameRate: 15,
+		gifLoop: true,
+		gifSizePreset: "medium",
+	});
+
+	expect(createProjectSnapshot(media, editor)).toBe(createProjectSnapshot(media, editor));
+});
+
+it("detects unsaved changes from differing snapshots", () => {
+	expect(hasProjectUnsavedChanges(null, null)).toBe(false);
+	expect(hasProjectUnsavedChanges("same", "same")).toBe(false);
+	expect(hasProjectUnsavedChanges("current", "baseline")).toBe(true);
 });

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -405,3 +405,21 @@ export function createProjectData(
 		editor,
 	};
 }
+
+export function createProjectSnapshot(
+	media: ProjectMedia,
+	editor: ProjectEditorState,
+): string {
+	return JSON.stringify(createProjectData(media, editor));
+}
+
+export function hasProjectUnsavedChanges(
+	currentSnapshot: string | null,
+	baselineSnapshot: string | null,
+): boolean {
+	return Boolean(
+		currentSnapshot !== null &&
+		baselineSnapshot !== null &&
+		currentSnapshot !== baselineSnapshot,
+	);
+}


### PR DESCRIPTION
## Summary
- stop tying dirty-state detection to `currentProjectPath`
- create a baseline project snapshot for new unsaved sessions so first-save workflows can still trigger the close warning
- extract small snapshot/dirty helpers and add focused regression coverage in `projectPersistence.test.ts`

## Notes
- I attempted to run the targeted Vitest file in this sandbox, but dependency install was blocked by the repo's heavy Electron dependency stack in this environment.
- The patch is intentionally narrow and keeps the close-flow behavior in the main process unchanged.

Closes #311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project snapshot creation and comparison logic for more reliable unsaved change detection.
  * Enhanced project restoration handling when reopening previous sessions.

* **Tests**
  * Added comprehensive unit tests for project persistence utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->