### PR TITLE
fix: camera light flashes and turns off when clicking webcam button (…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 *.sw?
 release/**
 *.kiro/
+.claude/
 # npx electron-builder --mac --win
 
 # Playwright

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -436,6 +436,7 @@ export function LaunchWindow() {
 						onClick={async () => {
 							await setWebcamEnabled(!webcamEnabled);
 						}}
+						disabled={recording}
 						title={webcamEnabled ? t("webcam.disableWebcam") : t("webcam.enableWebcam")}
 					>
 						{webcamEnabled

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -104,6 +104,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const discardRecordingId = useRef<number | null>(null);
 	const restarting = useRef(false);
 	const webcamReady = useRef(false);
+	const webcamAcquireId = useRef(0);
 
 	const selectMimeType = () => {
 		const preferred = [
@@ -183,6 +184,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 		let cancelled = false;
 		let acquiredStream: MediaStream | null = null;
+		const thisAcquireId = ++webcamAcquireId.current;
 		webcamReady.current = false;
 
 		const acquire = async () => {
@@ -203,7 +205,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							},
 				});
 
-				if (cancelled) {
+				if (cancelled || thisAcquireId !== webcamAcquireId.current) {
 					stream.getTracks().forEach((track) => {
 						track.onended = null;
 						track.stop();
@@ -499,6 +501,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					});
 				}
 				if (!webcamStream.current) {
+					webcamAcquireId.current++;
 					setWebcamEnabledState(false);
 				}
 			}

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -103,6 +103,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const allowAutoFinalize = useRef(false);
 	const discardRecordingId = useRef<number | null>(null);
 	const restarting = useRef(false);
+	const webcamReady = useRef(false);
 
 	const selectMimeType = () => {
 		const preferred = [
@@ -182,6 +183,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 		let cancelled = false;
 		let acquiredStream: MediaStream | null = null;
+		webcamReady.current = false;
 
 		const acquire = async () => {
 			try {
@@ -217,11 +219,21 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					};
 				});
 				webcamStream.current = stream;
+				webcamReady.current = true;
 			} catch (cameraError) {
 				if (!cancelled) {
 					console.warn("Failed to get webcam access:", cameraError);
 					setWebcamEnabledState(false);
-					toast.error(t("recording.cameraBlocked"));
+					const isDeviceError =
+						cameraError instanceof DOMException &&
+						[
+							"NotFoundError",
+							"DevicesNotFoundError",
+							"OverconstrainedError",
+							"NotReadableError",
+						].includes(cameraError.name);
+					toast.error(t(isDeviceError ? "recording.cameraNotFound" : "recording.cameraBlocked"));
+					webcamReady.current = true;
 				}
 			}
 		};
@@ -230,6 +242,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 		return () => {
 			cancelled = true;
+			webcamReady.current = false;
 			if (acquiredStream) {
 				acquiredStream.getTracks().forEach((track) => track.stop());
 				webcamStream.current = null;
@@ -464,9 +477,26 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
-			if (webcamEnabled && !webcamStream.current) {
-				setWebcamEnabledState(false);
-				toast.error(t("recording.cameraDenied"));
+			if (webcamEnabled) {
+				if (!webcamReady.current) {
+					await new Promise<void>((resolve) => {
+						const interval = setInterval(() => {
+							if (webcamReady.current) {
+								clearInterval(interval);
+								resolve();
+							}
+						}, 50);
+						setTimeout(() => {
+							clearInterval(interval);
+							resolve();
+						}, 5000);
+					});
+				}
+				if (!webcamStream.current) {
+					// The useEffect already showed the appropriate error toast
+					// (cameraNotFound or cameraBlocked), so just disable the state.
+					setWebcamEnabledState(false);
+				}
 			}
 
 			stream.current = new MediaStream();

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -145,10 +145,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			microphoneStream.current.getTracks().forEach((track) => track.stop());
 			microphoneStream.current = null;
 		}
-		if (webcamStream.current) {
-			webcamStream.current.getTracks().forEach((track) => track.stop());
-			webcamStream.current = null;
-		}
 		if (mixingContext.current) {
 			mixingContext.current.close().catch(() => {
 				// Ignore close errors during recorder teardown.
@@ -180,6 +176,66 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		},
 		[t],
 	);
+
+	useEffect(() => {
+		if (!webcamEnabled) return;
+
+		let cancelled = false;
+		let acquiredStream: MediaStream | null = null;
+
+		const acquire = async () => {
+			try {
+				const stream = await navigator.mediaDevices.getUserMedia({
+					audio: false,
+					video: webcamDeviceId
+						? {
+								deviceId: { exact: webcamDeviceId },
+								width: { ideal: WEBCAM_TARGET_WIDTH },
+								height: { ideal: WEBCAM_TARGET_HEIGHT },
+								frameRate: { ideal: WEBCAM_TARGET_FRAME_RATE, max: WEBCAM_TARGET_FRAME_RATE },
+							}
+						: {
+								width: { ideal: WEBCAM_TARGET_WIDTH },
+								height: { ideal: WEBCAM_TARGET_HEIGHT },
+								frameRate: { ideal: WEBCAM_TARGET_FRAME_RATE, max: WEBCAM_TARGET_FRAME_RATE },
+							},
+				});
+
+				if (cancelled) {
+					stream.getTracks().forEach((track) => track.stop());
+					return;
+				}
+
+				acquiredStream = stream;
+				stream.getVideoTracks().forEach((track) => {
+					track.onended = () => {
+						webcamStream.current = null;
+						if (!restarting.current) {
+							setWebcamEnabledState(false);
+							toast.error(t("recording.cameraDisconnected"));
+						}
+					};
+				});
+				webcamStream.current = stream;
+			} catch (cameraError) {
+				if (!cancelled) {
+					console.warn("Failed to get webcam access:", cameraError);
+					setWebcamEnabledState(false);
+					toast.error(t("recording.cameraBlocked"));
+				}
+			}
+		};
+
+		void acquire();
+
+		return () => {
+			cancelled = true;
+			if (acquiredStream) {
+				acquiredStream.getTracks().forEach((track) => track.stop());
+				webcamStream.current = null;
+			}
+		};
+	}, [webcamEnabled, webcamDeviceId, t]);
 
 	const finalizeRecording = useCallback(
 		(
@@ -408,32 +464,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
-			if (webcamEnabled) {
-				try {
-					webcamStream.current = await navigator.mediaDevices.getUserMedia({
-						audio: false,
-						video: webcamDeviceId
-							? {
-									deviceId: { exact: webcamDeviceId },
-									width: { ideal: WEBCAM_TARGET_WIDTH },
-									height: { ideal: WEBCAM_TARGET_HEIGHT },
-									frameRate: { ideal: WEBCAM_TARGET_FRAME_RATE, max: WEBCAM_TARGET_FRAME_RATE },
-								}
-							: {
-									width: { ideal: WEBCAM_TARGET_WIDTH },
-									height: { ideal: WEBCAM_TARGET_HEIGHT },
-									frameRate: { ideal: WEBCAM_TARGET_FRAME_RATE, max: WEBCAM_TARGET_FRAME_RATE },
-								},
-					});
-				} catch (cameraError) {
-					console.warn("Failed to get webcam access:", cameraError);
-					if (webcamStream.current) {
-						webcamStream.current.getTracks().forEach((track) => track.stop());
-						webcamStream.current = null;
-					}
-					setWebcamEnabledState(false);
-					toast.error(t("recording.cameraDenied"));
-				}
+			if (webcamEnabled && !webcamStream.current) {
+				setWebcamEnabledState(false);
+				toast.error(t("recording.cameraDenied"));
 			}
 
 			stream.current = new MediaStream();

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -204,7 +204,10 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				});
 
 				if (cancelled) {
-					stream.getTracks().forEach((track) => track.stop());
+					stream.getTracks().forEach((track) => {
+						track.onended = null;
+						track.stop();
+					});
 					return;
 				}
 
@@ -244,7 +247,10 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			cancelled = true;
 			webcamReady.current = false;
 			if (acquiredStream) {
-				acquiredStream.getTracks().forEach((track) => track.stop());
+				acquiredStream.getTracks().forEach((track) => {
+					track.onended = null;
+					track.stop();
+				});
 				webcamStream.current = null;
 			}
 		};
@@ -493,8 +499,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					});
 				}
 				if (!webcamStream.current) {
-					// The useEffect already showed the appropriate error toast
-					// (cameraNotFound or cameraBlocked), so just disable the state.
 					setWebcamEnabledState(false);
 				}
 			}

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -31,6 +31,7 @@
 		"microphoneDenied": "Microphone access denied. Recording will continue without audio.",
 		"cameraDenied": "Camera access denied. Recording will continue without webcam.",
 		"cameraDisconnected": "Webcam disconnected.",
+		"cameraNotFound": "Camera not found.",
 		"permissionDenied": "Recording permission denied. Please allow screen recording."
 	}
 }

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -30,6 +30,7 @@
 		"systemAudioUnavailable": "System audio not available. Recording without system audio.",
 		"microphoneDenied": "Microphone access denied. Recording will continue without audio.",
 		"cameraDenied": "Camera access denied. Recording will continue without webcam.",
+		"cameraDisconnected": "Webcam disconnected.",
 		"permissionDenied": "Recording permission denied. Please allow screen recording."
 	}
 }

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -31,6 +31,7 @@
 		"microphoneDenied": "Acceso al micrófono denegado. La grabación continuará sin audio.",
 		"cameraDenied": "Acceso a la cámara denegado. La grabación continuará sin cámara web.",
 		"cameraDisconnected": "Cámara web desconectada.",
+		"cameraNotFound": "Cámara no encontrada.",
 		"permissionDenied": "Permiso de grabación denegado. Por favor permite la grabación de pantalla."
 	}
 }

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -30,6 +30,7 @@
 		"systemAudioUnavailable": "Audio del sistema no disponible. Grabando sin audio del sistema.",
 		"microphoneDenied": "Acceso al micrófono denegado. La grabación continuará sin audio.",
 		"cameraDenied": "Acceso a la cámara denegado. La grabación continuará sin cámara web.",
+		"cameraDisconnected": "Cámara web desconectada.",
 		"permissionDenied": "Permiso de grabación denegado. Por favor permite la grabación de pantalla."
 	}
 }

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -31,6 +31,7 @@
 		"microphoneDenied": "麦克风权限被拒绝。录制将继续，但不包含音频。",
 		"cameraDenied": "摄像头权限被拒绝。录制将继续，但不包含摄像头画面。",
 		"cameraDisconnected": "摄像头已断开连接。",
+		"cameraNotFound": "未找到摄像头。",
 		"permissionDenied": "录屏权限被拒绝。请允许屏幕录制。"
 	}
 }

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -30,6 +30,7 @@
 		"systemAudioUnavailable": "系统音频不可用。将在无系统音频的情况下录制。",
 		"microphoneDenied": "麦克风权限被拒绝。录制将继续，但不包含音频。",
 		"cameraDenied": "摄像头权限被拒绝。录制将继续，但不包含摄像头画面。",
+		"cameraDisconnected": "摄像头已断开连接。",
 		"permissionDenied": "录屏权限被拒绝。请允许屏幕录制。"
 	}
 }

--- a/src/lib/requestCameraAccess.ts
+++ b/src/lib/requestCameraAccess.ts
@@ -17,9 +17,7 @@ export async function requestCameraAccess(): Promise<CameraAccessResult> {
 	if (window.electronAPI?.requestCameraAccess) {
 		try {
 			const electronResult = await window.electronAPI.requestCameraAccess();
-			if (!electronResult.success || !electronResult.granted) {
-				return electronResult;
-			}
+			return electronResult;
 		} catch (error) {
 			return {
 				success: false,


### PR DESCRIPTION
## Description

This PR fixes these issues:
1. When clicking the webcam button on the panel, the camera hardware light briefly flashes on for ~1 second then turns off, while the UI button remains enabled.
2. When camera is physically disconnected while recording there is no indication on screen letting the user know the camera was disconnected.


## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fixes #308 


**Screenshot** :

<img width="1454" height="204" alt="image" src="https://github.com/user-attachments/assets/4f1c8b8f-22f6-4e88-912c-0e349e88db67" />


## Testing
1. Open OpenScreen on Windows, click the webcam button on the panel → camera light should turn on and **stay on**
2. Enable webcam, disconnect camera physically (or through the Device Manager) at the start or while recording → button turns off, "Webcam disconnected" toast appears

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webcam toggle is disabled while recording to prevent interruptions.
  * Improved webcam acquisition, cleanup, and recording startup with clearer handling for disconnected, not-found, blocked, or denied camera scenarios.
  * Desktop app camera access failures are now propagated so denials/failures are reported consistently.

* **Documentation**
  * Added English, Spanish, and Chinese messages for camera disconnected and camera-not-found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->