### PR TITLE
feat: add audio waveform, audio edit, 1.1 zoom

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -40,7 +40,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 		transparent: true,
 		resizable: false,
 		alwaysOnTop: true,
-		skipTaskbar: true,
+		skipTaskbar: false,
 		hasShadow: false,
 		show: !HEADLESS,
 		webPreferences: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "openscreen",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "openscreen",
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"dependencies": {
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@pixi/filter-drop-shadow": "^5.2.0",
@@ -5861,13 +5861,16 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.15.tgz",
-			"integrity": "sha512-qsJ8/X+UypqxHXN75M7dF88jNK37dLBRW7LeUzCPz+TNs37G8cfWy9nWzS+LS//g600zrt2le9KuXt0rWfDz5Q==",
+			"version": "2.10.14",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
+			"integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/bcrypt-pbkdf": {
@@ -6315,9 +6318,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001749",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
-			"integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
+			"version": "1.0.30001785",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
+			"integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/components/video-editor/ExportDialog.tsx
+++ b/src/components/video-editor/ExportDialog.tsx
@@ -64,6 +64,12 @@ export function ExportDialog({
 		isExporting && progress && progress.percentage >= 100 && exportFormat === "gif";
 	const isFinalizing = progress?.phase === "finalizing";
 	const renderProgress = progress?.renderProgress;
+	const audioProgress = progress?.audioProgress;
+	// audioProgress takes priority over renderProgress during mp4 finalization
+	const finalizingProgress =
+		isFinalizing && exportFormat === "mp4" && audioProgress !== undefined
+			? audioProgress
+			: renderProgress;
 
 	// Get status message based on phase
 	const getStatusMessage = () => {
@@ -177,8 +183,8 @@ export function ExportDialog({
 								</span>
 								<span className="font-mono text-slate-200">
 									{isCompiling || isFinalizing ? (
-										renderProgress !== undefined && renderProgress > 0 ? (
-											`${renderProgress}%`
+										finalizingProgress !== undefined && finalizingProgress > 0 ? (
+											`${finalizingProgress}%`
 										) : (
 											<span className="flex items-center gap-2">
 												<Loader2 className="w-3 h-3 animate-spin" />
@@ -192,11 +198,11 @@ export function ExportDialog({
 							</div>
 							<div className="h-2 bg-white/5 rounded-full overflow-hidden border border-white/5">
 								{isCompiling || isFinalizing ? (
-									// Show render progress if available, otherwise animated indeterminate bar
-									renderProgress !== undefined && renderProgress > 0 ? (
+									// Show real progress if available, otherwise animated indeterminate bar
+									finalizingProgress !== undefined && finalizingProgress > 0 ? (
 										<div
 											className="h-full bg-[#34B27B] shadow-[0_0_10px_rgba(52,178,123,0.3)] transition-all duration-300 ease-out"
-											style={{ width: `${renderProgress}%` }}
+											style={{ width: `${finalizingProgress}%` }}
 										/>
 									) : (
 										<div className="h-full w-full relative overflow-hidden">

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
 	Trash2,
 	Unlock,
 	Upload,
+	Volume2,
 	X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -47,6 +48,7 @@ import { KeyboardShortcutsHelp } from "./KeyboardShortcutsHelp";
 import type {
 	AnnotationRegion,
 	AnnotationType,
+	AudioSettings,
 	CropRegion,
 	FigureData,
 	PlaybackSpeed,
@@ -150,17 +152,21 @@ interface SettingsPanelProps {
 	onWebcamLayoutPresetChange?: (preset: WebcamLayoutPreset) => void;
 	webcamMaskShape?: import("./types").WebcamMaskShape;
 	onWebcamMaskShapeChange?: (shape: import("./types").WebcamMaskShape) => void;
+	audioSettings?: AudioSettings;
+	onAudioSettingsChange?: (settings: AudioSettings) => void;
+	onAudioSettingsCommit?: (settings: AudioSettings) => void;
 }
 
 export default SettingsPanel;
 
 const ZOOM_DEPTH_OPTIONS: Array<{ depth: ZoomDepth; label: string }> = [
-	{ depth: 1, label: "1.25×" },
-	{ depth: 2, label: "1.5×" },
-	{ depth: 3, label: "1.8×" },
-	{ depth: 4, label: "2.2×" },
-	{ depth: 5, label: "3.5×" },
-	{ depth: 6, label: "5×" },
+	{ depth: 1, label: "1.1×" },
+	{ depth: 2, label: "1.25×" },
+	{ depth: 3, label: "1.5×" },
+	{ depth: 4, label: "1.8×" },
+	{ depth: 5, label: "2.2×" },
+	{ depth: 6, label: "3.5×" },
+	{ depth: 7, label: "5×" },
 ];
 
 export function SettingsPanel({
@@ -223,6 +229,9 @@ export function SettingsPanel({
 	onWebcamLayoutPresetChange,
 	webcamMaskShape = "rectangle",
 	onWebcamMaskShapeChange,
+	audioSettings,
+	onAudioSettingsChange,
+	onAudioSettingsCommit,
 }: SettingsPanelProps) {
 	const t = useScopedT("settings");
 	const [wallpaperPaths, setWallpaperPaths] = useState<string[]>([]);
@@ -486,7 +495,7 @@ export function SettingsPanel({
 							<KeyboardShortcutsHelp />
 						</div>
 					</div>
-					<div className="grid grid-cols-6 gap-1.5">
+					<div className="grid grid-cols-7 gap-1.5">
 						{ZOOM_DEPTH_OPTIONS.map((option) => {
 							const isActive = selectedZoomDepth === option.depth;
 							return (
@@ -1028,6 +1037,127 @@ export function SettingsPanel({
 									</TabsContent>
 								</div>
 							</Tabs>
+						</AccordionContent>
+					</AccordionItem>
+					<AccordionItem value="audio" className="border-white/5 rounded-xl bg-white/[0.02] px-3">
+						<AccordionTrigger className="py-2.5 hover:no-underline">
+							<div className="flex items-center gap-2">
+								<Volume2 className="w-4 h-4 text-[#34B27B]" />
+								<span className="text-xs font-medium">Audio Adjustments</span>
+							</div>
+						</AccordionTrigger>
+						<AccordionContent className="pb-3 space-y-3">
+							<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+								<div className="flex items-center justify-between mb-1">
+									<div className="flex flex-col">
+										<span className="text-[10px] font-medium text-slate-300">Highpass Filter</span>
+										<span className="text-[8px] text-slate-500">Cuts low rumble</span>
+									</div>
+									<span className="text-[10px] text-slate-500 font-mono">
+										{audioSettings?.highpassHz ?? 80} Hz
+									</span>
+								</div>
+								<Slider
+									value={[audioSettings?.highpassHz ?? 80]}
+									onValueChange={(values) =>
+										onAudioSettingsChange?.({ ...audioSettings!, highpassHz: values[0] })
+									}
+									onValueCommit={() =>
+										onAudioSettingsCommit?.({
+											...audioSettings!,
+											highpassHz: audioSettings?.highpassHz ?? 80,
+										})
+									}
+									min={0}
+									max={300}
+									step={10}
+									className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+								/>
+							</div>
+
+							<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+								<div className="flex items-center justify-between mb-1">
+									<div className="flex flex-col">
+										<span className="text-[10px] font-medium text-slate-300">Compression</span>
+										<span className="text-[8px] text-slate-500">Evens out volume</span>
+									</div>
+									<span className="text-[10px] text-slate-500 font-mono">
+										{audioSettings?.compressionRatio ?? 4}:1
+									</span>
+								</div>
+								<Slider
+									value={[audioSettings?.compressionRatio ?? 4]}
+									onValueChange={(values) =>
+										onAudioSettingsChange?.({ ...audioSettings!, compressionRatio: values[0] })
+									}
+									onValueCommit={() =>
+										onAudioSettingsCommit?.({
+											...audioSettings!,
+											compressionRatio: audioSettings?.compressionRatio ?? 4,
+										})
+									}
+									min={1}
+									max={20}
+									step={1}
+									className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+								/>
+							</div>
+
+							<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+								<div className="flex items-center justify-between mb-1">
+									<div className="flex flex-col">
+										<span className="text-[10px] font-medium text-slate-300">Treble</span>
+										<span className="text-[8px] text-slate-500">Adds clarity</span>
+									</div>
+									<span className="text-[10px] text-slate-500 font-mono">
+										+{audioSettings?.trebleDb ?? 5} dB
+									</span>
+								</div>
+								<Slider
+									value={[audioSettings?.trebleDb ?? 5]}
+									onValueChange={(values) =>
+										onAudioSettingsChange?.({ ...audioSettings!, trebleDb: values[0] })
+									}
+									onValueCommit={() =>
+										onAudioSettingsCommit?.({
+											...audioSettings!,
+											trebleDb: audioSettings?.trebleDb ?? 5,
+										})
+									}
+									min={0}
+									max={15}
+									step={1}
+									className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+								/>
+							</div>
+
+							<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+								<div className="flex items-center justify-between mb-1">
+									<div className="flex flex-col">
+										<span className="text-[10px] font-medium text-slate-300">Loudness Target</span>
+										<span className="text-[8px] text-slate-500">Relative boost level</span>
+									</div>
+									<span className="text-[10px] text-slate-500 font-mono">
+										{audioSettings?.loudnessDb ?? -12} LUFS
+									</span>
+								</div>
+								<Slider
+									value={[audioSettings?.loudnessDb ?? -12]}
+									onValueChange={(values) =>
+										onAudioSettingsChange?.({ ...audioSettings!, loudnessDb: values[0] })
+									}
+									onValueCommit={() =>
+										onAudioSettingsCommit?.({
+											...audioSettings!,
+											loudnessDb: audioSettings?.loudnessDb ?? -12,
+										})
+									}
+									min={-24}
+									max={0}
+									step={1}
+									className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
+								/>
+							</div>
 						</AccordionContent>
 					</AccordionItem>
 				</Accordion>

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -8,6 +8,7 @@ import { useShortcuts } from "@/contexts/ShortcutsContext";
 import { INITIAL_EDITOR_STATE, useEditorHistory } from "@/hooks/useEditorHistory";
 import { type Locale, SUPPORTED_LOCALES } from "@/i18n/config";
 import { getLocaleName } from "@/i18n/loader";
+import { generateWaveformPeaks } from "@/lib/audioWaveform";
 import {
 	calculateOutputDimensions,
 	type ExportFormat,
@@ -87,6 +88,7 @@ export default function VideoEditor() {
 		webcamLayoutPreset,
 		webcamMaskShape,
 		webcamPosition,
+		audioSettings,
 	} = editorState;
 
 	// ── Non-undoable state
@@ -95,6 +97,8 @@ export default function VideoEditor() {
 	const [webcamVideoPath, setWebcamVideoPath] = useState<string | null>(null);
 	const [webcamVideoSourcePath, setWebcamVideoSourcePath] = useState<string | null>(null);
 	const [currentProjectPath, setCurrentProjectPath] = useState<string | null>(null);
+	const [audioPeaks, setAudioPeaks] = useState<Float32Array | null>(null);
+	const [isAudioWaveformLoading, setIsAudioWaveformLoading] = useState(false);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [isPlaying, setIsPlaying] = useState(false);
@@ -199,6 +203,7 @@ export default function VideoEditor() {
 				webcamLayoutPreset: normalizedEditor.webcamLayoutPreset,
 				webcamMaskShape: normalizedEditor.webcamMaskShape,
 				webcamPosition: normalizedEditor.webcamPosition,
+				audioSettings: normalizedEditor.audioSettings,
 			});
 			setExportQuality(normalizedEditor.exportQuality);
 			setExportFormat(normalizedEditor.exportFormat);
@@ -269,6 +274,7 @@ export default function VideoEditor() {
 				webcamLayoutPreset,
 				webcamMaskShape,
 				webcamPosition,
+				audioSettings,
 				exportQuality,
 				exportFormat,
 				gifFrameRate,
@@ -293,6 +299,7 @@ export default function VideoEditor() {
 		webcamLayoutPreset,
 		webcamMaskShape,
 		webcamPosition,
+		audioSettings,
 		exportQuality,
 		exportFormat,
 		gifFrameRate,
@@ -359,6 +366,26 @@ export default function VideoEditor() {
 		loadInitialData();
 	}, [applyLoadedProject]);
 
+	useEffect(() => {
+		if (videoPath) {
+			setIsAudioWaveformLoading(true);
+			generateWaveformPeaks(videoPath)
+				.then((res) => {
+					console.log("[Waveform] peaks generated:", res.peaks.length);
+					setAudioPeaks(res.peaks);
+				})
+				.catch((err) => {
+					console.error("[Waveform] FAILED:", err);
+					toast.error("Waveform failed: " + String(err).slice(0, 80));
+					setAudioPeaks(null);
+				})
+				.finally(() => setIsAudioWaveformLoading(false));
+		} else {
+			setAudioPeaks(null);
+			setIsAudioWaveformLoading(false);
+		}
+	}, [videoPath]);
+
 	const saveProject = useCallback(
 		async (forceSaveAs: boolean) => {
 			if (!videoPath) {
@@ -387,6 +414,7 @@ export default function VideoEditor() {
 				webcamLayoutPreset,
 				webcamMaskShape,
 				webcamPosition,
+				audioSettings,
 				exportQuality,
 				exportFormat,
 				gifFrameRate,
@@ -442,6 +470,7 @@ export default function VideoEditor() {
 			webcamLayoutPreset,
 			webcamMaskShape,
 			webcamPosition,
+			audioSettings,
 			exportQuality,
 			exportFormat,
 			gifFrameRate,
@@ -1247,6 +1276,7 @@ export default function VideoEditor() {
 						previewWidth,
 						previewHeight,
 						cursorTelemetry,
+						audioSettings,
 						onProgress: (progress: ExportProgress) => {
 							setExportProgress(progress);
 						},
@@ -1529,6 +1559,7 @@ export default function VideoEditor() {
 											onAnnotationPositionChange={handleAnnotationPositionChange}
 											onAnnotationSizeChange={handleAnnotationSizeChange}
 											cursorTelemetry={cursorTelemetry}
+											audioSettings={audioSettings}
 										/>
 									</div>
 								</div>
@@ -1596,6 +1627,8 @@ export default function VideoEditor() {
 													: webcamLayoutPreset,
 										})
 									}
+									audioPeaks={audioPeaks}
+									isAudioWaveformLoading={isAudioWaveformLoading}
 								/>
 							</div>
 						</Panel>
@@ -1649,6 +1682,9 @@ export default function VideoEditor() {
 						}
 						webcamMaskShape={webcamMaskShape}
 						onWebcamMaskShapeChange={(shape) => pushState({ webcamMaskShape: shape })}
+						audioSettings={audioSettings}
+						onAudioSettingsChange={(settings) => updateState({ audioSettings: settings })}
+						onAudioSettingsCommit={() => commitState()}
 						videoElement={videoPlaybackRef.current?.video || null}
 						exportQuality={exportQuality}
 						onExportQualityChange={setExportQuality}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -100,6 +100,7 @@ interface VideoPlaybackProps {
 	onAnnotationPositionChange?: (id: string, position: { x: number; y: number }) => void;
 	onAnnotationSizeChange?: (id: string, size: { width: number; height: number }) => void;
 	cursorTelemetry?: import("./types").CursorTelemetryPoint[];
+	audioSettings?: import("./types").AudioSettings;
 }
 
 export interface VideoPlaybackRef {
@@ -150,6 +151,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			onAnnotationPositionChange,
 			onAnnotationSizeChange,
 			cursorTelemetry = [],
+			audioSettings,
 		},
 		ref,
 	) => {
@@ -206,6 +208,75 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const videoReadyRafRef = useRef<number | null>(null);
 		const smoothedAutoFocusRef = useRef<ZoomFocus | null>(null);
 		const prevTargetProgressRef = useRef(0);
+
+		// Audio Graph Refs
+		const audioCtxRef = useRef<AudioContext | null>(null);
+		const highpassNodeRef = useRef<BiquadFilterNode | null>(null);
+		const compressorNodeRef = useRef<DynamicsCompressorNode | null>(null);
+		const trebleNodeRef = useRef<BiquadFilterNode | null>(null);
+		const loudnessGainNodeRef = useRef<GainNode | null>(null);
+
+		useEffect(() => {
+			const video = videoRef.current;
+			if (!video || (video as any)._audioInitialized) return;
+			(video as any)._audioInitialized = true;
+
+			try {
+				const ctx = new window.AudioContext();
+				audioCtxRef.current = ctx;
+
+				const source = ctx.createMediaElementSource(video);
+
+				const highpass = ctx.createBiquadFilter();
+				highpass.type = "highpass";
+
+				const compressor = ctx.createDynamicsCompressor();
+
+				const treble = ctx.createBiquadFilter();
+				treble.type = "highshelf";
+				treble.frequency.value = 3000;
+
+				const loudnessGain = ctx.createGain();
+
+				source.connect(highpass);
+				highpass.connect(compressor);
+				compressor.connect(treble);
+				treble.connect(loudnessGain);
+				loudnessGain.connect(ctx.destination);
+
+				highpassNodeRef.current = highpass;
+				compressorNodeRef.current = compressor;
+				trebleNodeRef.current = treble;
+				loudnessGainNodeRef.current = loudnessGain;
+
+				if (!video.paused) {
+					ctx.resume().catch(console.error);
+				}
+			} catch (e) {
+				console.error("Failed to initialize Web Audio API:", e);
+			}
+		}, []);
+
+		useEffect(() => {
+			if (!audioSettings) return;
+			const { highpassHz, compressionRatio, trebleDb, loudnessDb } = audioSettings;
+			const ctx = audioCtxRef.current;
+			if (!ctx) return;
+
+			if (highpassNodeRef.current) {
+				highpassNodeRef.current.frequency.setTargetAtTime(highpassHz, ctx.currentTime, 0.1);
+			}
+			if (compressorNodeRef.current) {
+				compressorNodeRef.current.ratio.setTargetAtTime(compressionRatio, ctx.currentTime, 0.1);
+			}
+			if (trebleNodeRef.current) {
+				trebleNodeRef.current.gain.setTargetAtTime(trebleDb, ctx.currentTime, 0.1);
+			}
+			if (loudnessGainNodeRef.current) {
+				const linearGain = Math.pow(10, loudnessDb / 20);
+				loudnessGainNodeRef.current.gain.setTargetAtTime(linearGain, ctx.currentTime, 0.1);
+			}
+		}, [audioSettings]);
 
 		const clampFocusToStage = useCallback((focus: ZoomFocus, depth: ZoomDepth) => {
 			return clampFocusToStageUtil(focus, depth, stageSizeRef.current);

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -4,10 +4,12 @@ import { normalizeProjectMedia } from "@/lib/recordingSession";
 import { ASPECT_RATIOS, type AspectRatio } from "@/utils/aspectRatioUtils";
 import {
 	type AnnotationRegion,
+	type AudioSettings,
 	type CropRegion,
 	DEFAULT_ANNOTATION_POSITION,
 	DEFAULT_ANNOTATION_SIZE,
 	DEFAULT_ANNOTATION_STYLE,
+	DEFAULT_AUDIO_SETTINGS,
 	DEFAULT_CROP_REGION,
 	DEFAULT_FIGURE_DATA,
 	DEFAULT_PLAYBACK_SPEED,
@@ -53,6 +55,7 @@ export interface ProjectEditorState {
 	gifFrameRate: GifFrameRate;
 	gifLoop: boolean;
 	gifSizePreset: GifSizePreset;
+	audioSettings: AudioSettings;
 }
 
 export interface EditorProjectData {
@@ -392,6 +395,12 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			editor.gifSizePreset === "original"
 				? editor.gifSizePreset
 				: "medium",
+		audioSettings: {
+			...DEFAULT_AUDIO_SETTINGS,
+			...(editor.audioSettings && typeof editor.audioSettings === "object"
+				? editor.audioSettings
+				: {}),
+		},
 	};
 }
 

--- a/src/components/video-editor/timeline/AudioWaveform.tsx
+++ b/src/components/video-editor/timeline/AudioWaveform.tsx
@@ -1,0 +1,133 @@
+import { useTimelineContext } from "dnd-timeline";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface AudioWaveformProps {
+	peaks: Float32Array | null;
+	isLoading: boolean;
+	videoDurationMs: number;
+}
+
+export function AudioWaveform({ peaks, isLoading, videoDurationMs }: AudioWaveformProps) {
+	const { range, sidebarWidth } = useTimelineContext();
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+	// Watch container size changes (e.g., panel resize)
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				setContainerSize({
+					width: Math.floor(entry.contentRect.width),
+					height: Math.floor(entry.contentRect.height),
+				});
+			}
+		});
+
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, []);
+
+	// Redraw waveform whenever peaks, viewport, or container size changes
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		const width = containerSize.width;
+		const height = containerSize.height;
+
+		if (width <= 0 || height <= 0) return;
+
+		// Set actual backbuffer size for HiDPI
+		canvas.width = width * dpr;
+		canvas.height = height * dpr;
+		ctx.scale(dpr, dpr);
+		ctx.clearRect(0, 0, width, height);
+
+		if (!peaks || peaks.length === 0 || videoDurationMs <= 0) return;
+
+		const startMs = range.start;
+		const endMs = range.end;
+		const visibleMs = endMs - startMs;
+		if (visibleMs <= 0) return;
+
+		const peaksPerMs = peaks.length / videoDurationMs;
+
+		const barWidth = 2;
+		const gap = 1;
+		const totalBars = Math.max(1, Math.floor(width / (barWidth + gap)));
+		const msPerBar = visibleMs / totalBars;
+
+		// Draw a subtle background gradient
+		const gradient = ctx.createLinearGradient(0, 0, 0, height);
+		gradient.addColorStop(0, "rgba(52, 178, 123, 0.9)");
+		gradient.addColorStop(0.5, "rgba(52, 178, 123, 0.6)");
+		gradient.addColorStop(1, "rgba(52, 178, 123, 0.9)");
+		ctx.fillStyle = gradient;
+
+		for (let i = 0; i < totalBars; i++) {
+			const barCenterMs = startMs + i * msPerBar + msPerBar / 2;
+			const peakIndex = Math.floor(barCenterMs * peaksPerMs);
+
+			if (peakIndex >= 0 && peakIndex < peaks.length) {
+				const amplitude = peaks[peakIndex];
+				const minH = 2;
+				const barHeight = Math.max(minH, amplitude * height * 0.85);
+				const x = i * (barWidth + gap);
+				const y = (height - barHeight) / 2;
+
+				ctx.beginPath();
+				if (ctx.roundRect) {
+					ctx.roundRect(x, y, barWidth, barHeight, 1);
+				} else {
+					ctx.rect(x, y, barWidth, barHeight);
+				}
+				ctx.fill();
+			}
+		}
+	}, [peaks, range.start, range.end, videoDurationMs, containerSize.width, containerSize.height]);
+
+	return (
+		<div
+			className="relative w-full flex items-center bg-[#0a0f0c] border-b border-[#34B27B]/20 group"
+			style={{ height: 56 }}
+		>
+			{/* Sidebar label */}
+			<div
+				className="absolute left-0 top-0 bottom-0 flex items-center bg-[#111115]/90 border-r border-white/5 select-none z-10 shrink-0"
+				style={{ width: sidebarWidth }}
+			>
+				<span className="text-[9px] font-semibold text-slate-500 uppercase tracking-widest px-2">
+					Audio
+				</span>
+			</div>
+
+			{/* Waveform area */}
+			<div
+				ref={containerRef}
+				className="absolute top-0 bottom-0 overflow-hidden"
+				style={{ left: sidebarWidth, right: 0 }}
+			>
+				{isLoading ? (
+					<div className="absolute inset-0 flex items-center justify-center gap-1.5 text-slate-600">
+						<Loader2 className="w-3 h-3 animate-spin text-[#34B27B]/70" />
+						<span className="text-[9px] font-medium text-slate-600">Processing waveform…</span>
+					</div>
+				) : (
+					<canvas
+						ref={canvasRef}
+						className="absolute inset-0 w-full h-full opacity-75 group-hover:opacity-100 transition-opacity duration-200"
+					/>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/video-editor/timeline/Item.tsx
+++ b/src/components/video-editor/timeline/Item.tsx
@@ -19,12 +19,13 @@ interface ItemProps {
 
 // Map zoom depth to multiplier labels
 const ZOOM_LABELS: Record<number, string> = {
-	1: "1.25×",
-	2: "1.5×",
-	3: "1.8×",
-	4: "2.2×",
-	5: "3.5×",
-	6: "5×",
+	1: "1.1×",
+	2: "1.25×",
+	3: "1.5×",
+	4: "1.8×",
+	5: "2.2×",
+	6: "3.5×",
+	7: "5×",
 };
 
 function formatMs(ms: number): string {

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -35,6 +35,7 @@ import type {
 	ZoomFocus,
 	ZoomRegion,
 } from "../types";
+import { AudioWaveform } from "./AudioWaveform";
 import Item from "./Item";
 import KeyframeMarkers from "./KeyframeMarkers";
 import Row from "./Row";
@@ -81,6 +82,8 @@ interface TimelineEditorProps {
 	onSelectSpeed?: (id: string | null) => void;
 	aspectRatio: AspectRatio;
 	onAspectRatioChange: (aspectRatio: AspectRatio) => void;
+	audioPeaks?: Float32Array | null;
+	isAudioWaveformLoading?: boolean;
 }
 
 interface TimelineScaleConfig {
@@ -531,6 +534,8 @@ function Timeline({
 	selectedAnnotationId,
 	selectedSpeedId,
 	keyframes = [],
+	audioPeaks,
+	isAudioWaveformLoading,
 }: {
 	items: TimelineRenderItem[];
 	videoDurationMs: number;
@@ -546,6 +551,8 @@ function Timeline({
 	selectedAnnotationId?: string | null;
 	selectedSpeedId?: string | null;
 	keyframes?: { id: string; time: number }[];
+	audioPeaks?: Float32Array | null;
+	isAudioWaveformLoading?: boolean;
 }) {
 	const t = useScopedT("timeline");
 	const { setTimelineRef, style, sidebarWidth, range, pixelsToValue } = useTimelineContext();
@@ -727,6 +734,11 @@ function Timeline({
 					</Item>
 				))}
 			</Row>
+			<AudioWaveform
+				peaks={audioPeaks ?? null}
+				isLoading={!!isAudioWaveformLoading}
+				videoDurationMs={videoDurationMs}
+			/>
 		</div>
 	);
 }
@@ -763,6 +775,8 @@ export default function TimelineEditor({
 	onSelectSpeed,
 	aspectRatio,
 	onAspectRatioChange,
+	audioPeaks,
+	isAudioWaveformLoading,
 }: TimelineEditorProps) {
 	const t = useScopedT("timeline");
 	const totalMs = useMemo(() => Math.max(0, Math.round(videoDuration * 1000)), [videoDuration]);
@@ -1495,6 +1509,8 @@ export default function TimelineEditor({
 						selectedAnnotationId={selectedAnnotationId}
 						selectedSpeedId={selectedSpeedId}
 						keyframes={keyframes}
+						audioPeaks={audioPeaks}
+						isAudioWaveformLoading={isAudioWaveformLoading}
 					/>
 				</TimelineWrapper>
 			</div>

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -1,6 +1,6 @@
 import type { WebcamLayoutPreset } from "@/lib/compositeLayout";
 
-export type ZoomDepth = 1 | 2 | 3 | 4 | 5 | 6;
+export type ZoomDepth = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type ZoomFocusMode = "manual" | "auto";
 export type { WebcamLayoutPreset };
 
@@ -160,15 +160,16 @@ export const SPEED_OPTIONS: Array<{ speed: PlaybackSpeed; label: string }> = [
 export const DEFAULT_PLAYBACK_SPEED: PlaybackSpeed = 1.5;
 
 export const ZOOM_DEPTH_SCALES: Record<ZoomDepth, number> = {
-	1: 1.25,
-	2: 1.5,
-	3: 1.8,
-	4: 2.2,
-	5: 3.5,
-	6: 5.0,
+	1: 1.1,
+	2: 1.25,
+	3: 1.5,
+	4: 1.8,
+	5: 2.2,
+	6: 3.5,
+	7: 5.0,
 };
 
-export const DEFAULT_ZOOM_DEPTH: ZoomDepth = 3;
+export const DEFAULT_ZOOM_DEPTH: ZoomDepth = 4;
 
 export function clampFocusToDepth(focus: ZoomFocus, _depth: ZoomDepth): ZoomFocus {
 	return {
@@ -181,3 +182,17 @@ function clamp(value: number, min: number, max: number) {
 	if (Number.isNaN(value)) return (min + max) / 2;
 	return Math.min(max, Math.max(min, value));
 }
+
+export interface AudioSettings {
+	highpassHz: number; // For biquad highpass filter (80Hz default)
+	compressionRatio: number; // For DynamicsCompressorNode (4:1 default)
+	trebleDb: number; // For biquad highShelf filter (5dB default)
+	loudnessDb: number; // Makeup gain or target LUFS-analogous volume boost
+}
+
+export const DEFAULT_AUDIO_SETTINGS: AudioSettings = {
+	highpassHz: 80,
+	compressionRatio: 4,
+	trebleDb: 5,
+	loudnessDb: -12,
+};

--- a/src/hooks/useEditorHistory.ts
+++ b/src/hooks/useEditorHistory.ts
@@ -10,6 +10,8 @@ import type {
 	ZoomRegion,
 } from "@/components/video-editor/types";
 import {
+	type AudioSettings,
+	DEFAULT_AUDIO_SETTINGS,
 	DEFAULT_CROP_REGION,
 	DEFAULT_WEBCAM_LAYOUT_PRESET,
 	DEFAULT_WEBCAM_MASK_SHAPE,
@@ -35,6 +37,7 @@ export interface EditorState {
 	webcamLayoutPreset: WebcamLayoutPreset;
 	webcamMaskShape: WebcamMaskShape;
 	webcamPosition: WebcamPosition | null;
+	audioSettings: AudioSettings;
 }
 
 export const INITIAL_EDITOR_STATE: EditorState = {
@@ -53,6 +56,7 @@ export const INITIAL_EDITOR_STATE: EditorState = {
 	webcamLayoutPreset: DEFAULT_WEBCAM_LAYOUT_PRESET,
 	webcamMaskShape: DEFAULT_WEBCAM_MASK_SHAPE,
 	webcamPosition: DEFAULT_WEBCAM_POSITION,
+	audioSettings: DEFAULT_AUDIO_SETTINGS,
 };
 
 type StateUpdate = Partial<EditorState> | ((prev: EditorState) => Partial<EditorState>);

--- a/src/lib/audioWaveform.ts
+++ b/src/lib/audioWaveform.ts
@@ -1,0 +1,70 @@
+import { fromFileUrl } from "@/components/video-editor/projectPersistence";
+
+export interface AudioWaveformResult {
+	peaks: Float32Array;
+}
+
+/**
+ * Generates waveform peaks using the Web Audio API's decodeAudioData.
+ * Much simpler than WebDemuxer - works reliably in Electron's renderer.
+ */
+export async function generateWaveformPeaks(
+	videoUrl: string,
+	numPeaks = 2000,
+): Promise<AudioWaveformResult> {
+	// 1. Read the file bytes
+	let arrayBuffer: ArrayBuffer;
+
+	const isFileUrl = /^file:/i.test(videoUrl);
+	if (isFileUrl || !/^(https?:|blob:|data:)/i.test(videoUrl)) {
+		const rawPath = isFileUrl ? fromFileUrl(videoUrl) : videoUrl;
+		if (!window.electronAPI?.readBinaryFile) {
+			throw new Error("electronAPI.readBinaryFile not available");
+		}
+		const result = await window.electronAPI.readBinaryFile(rawPath);
+		if (!result.success || !result.data) {
+			throw new Error(result.error || result.message || "Failed to read video file");
+		}
+		arrayBuffer = result.data;
+	} else {
+		const response = await fetch(videoUrl);
+		if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+		arrayBuffer = await response.arrayBuffer();
+	}
+
+	// 2. Decode audio from the raw bytes using Web Audio API
+	const audioCtx = new AudioContext();
+	let audioBuffer: AudioBuffer;
+	try {
+		audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+	} finally {
+		// Close the context immediately — we only needed it for decoding
+		audioCtx.close().catch(() => {});
+	}
+
+	// 3. Compute peaks — use channel 0 (or mix down if stereo)
+	const rawData = audioBuffer.getChannelData(0);
+	const samplesPerPeak = Math.floor(rawData.length / numPeaks);
+	const peaks = new Float32Array(numPeaks);
+
+	let globalMax = 0;
+	for (let i = 0; i < numPeaks; i++) {
+		const start = i * samplesPerPeak;
+		let max = 0;
+		for (let j = 0; j < samplesPerPeak; j++) {
+			const abs = Math.abs(rawData[start + j] || 0);
+			if (abs > max) max = abs;
+		}
+		peaks[i] = max;
+		if (max > globalMax) globalMax = max;
+	}
+
+	// 4. Normalize to 0–1
+	if (globalMax > 0) {
+		for (let i = 0; i < numPeaks; i++) {
+			peaks[i] /= globalMax;
+		}
+	}
+
+	return { peaks };
+}

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -11,8 +11,9 @@ export class AudioProcessor {
 
 	/**
 	 * Audio export has two modes:
-	 * 1) no speed regions -> fast WebCodecs trim-only pipeline
-	 * 2) speed regions present -> pitch-preserving rendered timeline pipeline
+	 * 1) no speed regions + default audio settings → fast WebCodecs trim-only pipeline
+	 * 2) speed regions present OR non-default audio settings → pitch-preserving
+	 *    OfflineAudioContext pipeline (faster than real-time, no MediaRecorder needed)
 	 */
 	async process(
 		demuxer: WebDemuxer,
@@ -22,6 +23,7 @@ export class AudioProcessor {
 		speedRegions?: SpeedRegion[],
 		readEndSec?: number,
 		audioSettings?: import("@/components/video-editor/types").AudioSettings,
+		onProgress?: (progress: number) => void,
 	): Promise<void> {
 		const sortedTrims = trimRegions ? [...trimRegions].sort((a, b) => a.startMs - b.startMs) : [];
 		const sortedSpeedRegions = speedRegions
@@ -37,23 +39,26 @@ export class AudioProcessor {
 				audioSettings.trebleDb !== 5 ||
 				audioSettings.loudnessDb !== -12);
 
-		// Speed edits must use timeline playback to preserve pitch.
-		// Audio edits also use timeline playback to evaluate the Web Audio graph.
+		// Speed edits or audio processing — use OfflineAudioContext (faster than real-time).
 		if (sortedSpeedRegions.length > 0 || hasActiveAudioSettings) {
-			const renderedAudioBlob = await this.renderPitchPreservedTimelineAudio(
+			onProgress?.(0);
+			const renderedAudioBlob = await this.renderPitchPreservedOfflineAudio(
 				videoUrl,
 				sortedTrims,
 				sortedSpeedRegions,
 				audioSettings,
+				onProgress,
 			);
 			if (!this.cancelled) {
 				await this.muxRenderedAudioBlob(renderedAudioBlob, muxer);
+				onProgress?.(100);
 				return;
 			}
 		}
 
 		// No speed edits: keep the original demux/decode/encode path with trim timestamp remap.
-		await this.processTrimOnlyAudio(demuxer, muxer, sortedTrims, readEndSec);
+		onProgress?.(0);
+		await this.processTrimOnlyAudio(demuxer, muxer, sortedTrims, readEndSec, onProgress);
 	}
 
 	// Legacy trim-only path. This is still used for projects without speed regions.
@@ -62,18 +67,21 @@ export class AudioProcessor {
 		muxer: VideoMuxer,
 		sortedTrims: TrimRegion[],
 		readEndSec?: number,
+		onProgress?: (progress: number) => void,
 	): Promise<void> {
 		let audioConfig: AudioDecoderConfig;
 		try {
 			audioConfig = (await demuxer.getDecoderConfig("audio")) as AudioDecoderConfig;
 		} catch {
 			console.warn("[AudioProcessor] No audio track found, skipping");
+			onProgress?.(100);
 			return;
 		}
 
 		const codecCheck = await AudioDecoder.isConfigSupported(audioConfig);
 		if (!codecCheck.supported) {
 			console.warn("[AudioProcessor] Audio codec not supported:", audioConfig.codec);
+			onProgress?.(100);
 			return;
 		}
 
@@ -126,6 +134,7 @@ export class AudioProcessor {
 
 		if (this.cancelled || decodedFrames.length === 0) {
 			for (const frame of decodedFrames) frame.close();
+			onProgress?.(100);
 			return;
 		}
 
@@ -153,12 +162,15 @@ export class AudioProcessor {
 		if (!encodeSupport.supported) {
 			console.warn("[AudioProcessor] Opus encoding not supported, skipping audio");
 			for (const frame of decodedFrames) frame.close();
+			onProgress?.(100);
 			return;
 		}
 
 		encoder.configure(encodeConfig);
 
-		for (const audioData of decodedFrames) {
+		const totalFrames = decodedFrames.length;
+		for (let i = 0; i < decodedFrames.length; i++) {
+			const audioData = decodedFrames[i];
 			if (this.cancelled) {
 				audioData.close();
 				continue;
@@ -173,12 +185,17 @@ export class AudioProcessor {
 
 			encoder.encode(adjusted);
 			adjusted.close();
+
+			// Report progress through encode phase (0–80% of audio budget)
+			onProgress?.(Math.round((i / totalFrames) * 80));
 		}
 
 		if (encoder.state === "configured") {
 			await encoder.flush();
 			encoder.close();
 		}
+
+		onProgress?.(85);
 
 		// Phase 3: Flush encoded chunks to muxer
 		for (const { chunk, meta } of encodedChunks) {
@@ -189,156 +206,327 @@ export class AudioProcessor {
 		console.log(
 			`[AudioProcessor] Processed ${decodedFrames.length} audio frames, encoded ${encodedChunks.length} chunks`,
 		);
+		onProgress?.(100);
 	}
 
-	// Speed-aware path that mirrors preview semantics (trim skipping + playbackRate regions)
-	// preserve pitch through browser media playback behavior to avoid chipmunk effect.
-	private async renderPitchPreservedTimelineAudio(
+	/**
+	 * Speed/audio-settings-aware path using OfflineAudioContext.
+	 * Processes audio faster than real-time (no actual playback needed),
+	 * unlike the old HTMLMediaElement + MediaRecorder approach which had to
+	 * play through the entire video at 1x speed before exporting.
+	 */
+	private async renderPitchPreservedOfflineAudio(
 		videoUrl: string,
 		trimRegions: TrimRegion[],
 		speedRegions: SpeedRegion[],
 		audioSettings?: import("@/components/video-editor/types").AudioSettings,
+		onProgress?: (progress: number) => void,
 	): Promise<Blob> {
-		const media = document.createElement("audio");
-		media.src = videoUrl;
-		media.preload = "auto";
+		onProgress?.(5);
 
-		const pitchMedia = media as HTMLMediaElement & {
-			preservesPitch?: boolean;
-			mozPreservesPitch?: boolean;
-			webkitPreservesPitch?: boolean;
-		};
-		pitchMedia.preservesPitch = true;
-		pitchMedia.mozPreservesPitch = true;
-		pitchMedia.webkitPreservesPitch = true;
-
-		await this.waitForLoadedMetadata(media);
-		if (this.cancelled) {
-			throw new Error("Export cancelled");
-		}
-
-		const audioContext = new window.AudioContext();
-		const sourceNode = audioContext.createMediaElementSource(media);
-		const destinationNode = audioContext.createMediaStreamDestination();
-
-		let lastNode: AudioNode = sourceNode;
-
-		if (audioSettings) {
-			const highpass = audioContext.createBiquadFilter();
-			highpass.type = "highpass";
-			highpass.frequency.value = audioSettings.highpassHz;
-
-			const compressor = audioContext.createDynamicsCompressor();
-			compressor.ratio.value = audioSettings.compressionRatio;
-
-			const treble = audioContext.createBiquadFilter();
-			treble.type = "highshelf";
-			treble.frequency.value = 3000;
-			treble.gain.value = audioSettings.trebleDb;
-
-			const loudnessGain = audioContext.createGain();
-			loudnessGain.gain.value = Math.pow(10, audioSettings.loudnessDb / 20);
-
-			lastNode.connect(highpass);
-			highpass.connect(compressor);
-			compressor.connect(treble);
-			treble.connect(loudnessGain);
-			lastNode = loudnessGain;
-		}
-
-		lastNode.connect(destinationNode);
-
-		const { recorder, recordedBlobPromise } = this.startAudioRecording(destinationNode.stream);
-		let rafId: number | null = null;
-
+		// Step 1: Fetch and decode the full audio buffer via AudioContext
+		let rawAudioBuffer: AudioBuffer;
 		try {
-			if (audioContext.state === "suspended") {
-				await audioContext.resume();
+			rawAudioBuffer = await this.decodeAudioFromUrl(videoUrl, onProgress);
+		} catch (e) {
+			console.error("[AudioProcessor] Failed to decode audio via AudioContext:", e);
+			throw e;
+		}
+
+		if (this.cancelled) throw new Error("Export cancelled");
+		onProgress?.(40);
+
+		// Step 2: Build the processed timeline from segments using OfflineAudioContext
+		const sampleRate = rawAudioBuffer.sampleRate;
+		const processedBuffer = await this.buildProcessedBuffer(
+			rawAudioBuffer,
+			trimRegions,
+			speedRegions,
+			sampleRate,
+			onProgress,
+		);
+
+		if (this.cancelled) throw new Error("Export cancelled");
+		onProgress?.(75);
+
+		// Step 3: Apply audio settings graph if needed
+		const finalBuffer = audioSettings
+			? await this.applyAudioSettings(processedBuffer, sampleRate, audioSettings, onProgress)
+			: processedBuffer;
+
+		if (this.cancelled) throw new Error("Export cancelled");
+		onProgress?.(90);
+
+		// Step 4: Encode to WebM/Opus blob via MediaRecorder on a silent OfflineAudioContext render
+		const blob = await this.encodeAudioBufferToBlob(finalBuffer);
+		onProgress?.(98);
+		return blob;
+	}
+
+	/**
+	 * Fetches and decodes audio to an AudioBuffer using decodeAudioData.
+	 * This uses the browser's native decoder, which is very fast.
+	 */
+	private async decodeAudioFromUrl(
+		videoUrl: string,
+		onProgress?: (progress: number) => void,
+	): Promise<AudioBuffer> {
+		onProgress?.(8);
+		let arrayBuffer: ArrayBuffer;
+
+		// Try to use Electron's IPC to read file directly (avoids fetch for local files)
+		if (!/^(https?:|blob:|data:)/i.test(videoUrl) && window.electronAPI?.readBinaryFile) {
+			const result = await window.electronAPI.readBinaryFile(videoUrl);
+			if (!result.success || !result.data) {
+				throw new Error(result.message || result.error || "Failed to read audio file");
 			}
+			arrayBuffer = result.data as ArrayBuffer;
+		} else {
+			const response = await fetch(videoUrl);
+			if (!response.ok) throw new Error(`Failed to fetch audio: ${response.status}`);
+			arrayBuffer = await response.arrayBuffer();
+		}
 
-			await this.seekTo(media, 0);
-			await media.play();
+		onProgress?.(20);
+		if (this.cancelled) throw new Error("Export cancelled");
 
-			await new Promise<void>((resolve, reject) => {
-				const cleanup = () => {
-					if (rafId !== null) {
-						cancelAnimationFrame(rafId);
-						rafId = null;
-					}
-					media.removeEventListener("error", onError);
-					media.removeEventListener("ended", onEnded);
-				};
-
-				const onError = () => {
-					cleanup();
-					reject(new Error("Failed while rendering speed-adjusted audio timeline"));
-				};
-
-				const onEnded = () => {
-					cleanup();
-					resolve();
-				};
-
-				const tick = () => {
-					if (this.cancelled) {
-						cleanup();
-						resolve();
-						return;
-					}
-
-					const currentTimeMs = media.currentTime * 1000;
-					const activeTrimRegion = this.findActiveTrimRegion(currentTimeMs, trimRegions);
-
-					if (activeTrimRegion && !media.paused && !media.ended) {
-						const skipToTime = activeTrimRegion.endMs / 1000;
-						if (skipToTime >= media.duration) {
-							media.pause();
-							cleanup();
-							resolve();
-							return;
-						}
-						media.currentTime = skipToTime;
-					} else {
-						const activeSpeedRegion = this.findActiveSpeedRegion(currentTimeMs, speedRegions);
-						const playbackRate = activeSpeedRegion ? activeSpeedRegion.speed : 1;
-						if (Math.abs(media.playbackRate - playbackRate) > 0.0001) {
-							media.playbackRate = playbackRate;
-						}
-					}
-
-					if (!media.paused && !media.ended) {
-						rafId = requestAnimationFrame(tick);
-					} else {
-						cleanup();
-						resolve();
-					}
-				};
-
-				media.addEventListener("error", onError, { once: true });
-				media.addEventListener("ended", onEnded, { once: true });
-				rafId = requestAnimationFrame(tick);
-			});
+		// decodeAudioData is synchronous in its processing (runs in a worker internally)
+		// and is much faster than real-time playback
+		const ctx = new AudioContext();
+		try {
+			const buffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+			return buffer;
 		} finally {
-			if (rafId !== null) {
-				cancelAnimationFrame(rafId);
-			}
-			media.pause();
-			if (recorder.state !== "inactive") {
-				recorder.stop();
-			}
-			destinationNode.stream.getTracks().forEach((track) => track.stop());
-			sourceNode.disconnect();
-			destinationNode.disconnect();
-			await audioContext.close();
-			media.src = "";
-			media.load();
+			await ctx.close();
+		}
+	}
+
+	/**
+	 * Builds a processed AudioBuffer with trim/speed applied using OfflineAudioContext.
+	 * Runs faster than real-time since OfflineAudioContext renders at maximum speed.
+	 */
+	private async buildProcessedBuffer(
+		rawBuffer: AudioBuffer,
+		trimRegions: TrimRegion[],
+		speedRegions: SpeedRegion[],
+		sampleRate: number,
+		onProgress?: (progress: number) => void,
+	): Promise<AudioBuffer> {
+		// Compute the set of (start, end, speed) segments after applying trims
+		const segments = this.computeAudioSegments(rawBuffer.duration * 1000, trimRegions, speedRegions);
+
+		if (segments.length === 0) {
+			// Return a silent 0.1s buffer if there's nothing to play
+			const offCtx = new OfflineAudioContext(rawBuffer.numberOfChannels, sampleRate / 10, sampleRate);
+			return offCtx.startRendering();
 		}
 
-		const recordedBlob = await recordedBlobPromise;
-		if (this.cancelled) {
-			throw new Error("Export cancelled");
+		// Total output length in samples
+		const totalOutputSamples = segments.reduce((sum, seg) => {
+			const inputDurationSec = (seg.endMs - seg.startMs) / 1000;
+			const outputDurationSec = inputDurationSec / seg.speed;
+			return sum + Math.ceil(outputDurationSec * sampleRate);
+		}, 0);
+
+		const offCtx = new OfflineAudioContext(
+			rawBuffer.numberOfChannels,
+			Math.max(1, totalOutputSamples),
+			sampleRate,
+		);
+
+		let outputOffsetSec = 0;
+		const totalSegments = segments.length;
+
+		for (let i = 0; i < segments.length; i++) {
+			if (this.cancelled) throw new Error("Export cancelled");
+
+			const seg = segments[i];
+			const inputStartSec = seg.startMs / 1000;
+			const inputDurationSec = (seg.endMs - seg.startMs) / 1000;
+			const outputDurationSec = inputDurationSec / seg.speed;
+
+			// Extract the segment slice from the source buffer
+			const segmentSamples = Math.ceil(inputDurationSec * sampleRate);
+			const segmentBuffer = offCtx.createBuffer(
+				rawBuffer.numberOfChannels,
+				Math.max(1, segmentSamples),
+				sampleRate,
+			);
+			const srcOffsetSamples = Math.floor(inputStartSec * sampleRate);
+			for (let ch = 0; ch < rawBuffer.numberOfChannels; ch++) {
+				const srcData = rawBuffer.getChannelData(ch);
+				const dstData = segmentBuffer.getChannelData(ch);
+				const copyLen = Math.min(dstData.length, srcData.length - srcOffsetSamples);
+				if (copyLen > 0) {
+					dstData.set(srcData.subarray(srcOffsetSamples, srcOffsetSamples + copyLen));
+				}
+			}
+
+			const source = offCtx.createBufferSource();
+			source.buffer = segmentBuffer;
+			source.playbackRate.value = seg.speed;
+			source.connect(offCtx.destination);
+			source.start(outputOffsetSec, 0, inputDurationSec);
+
+			outputOffsetSec += outputDurationSec;
+
+			// Report progress in the 40–70% band
+			onProgress?.(40 + Math.round(((i + 1) / totalSegments) * 30));
 		}
-		return recordedBlob;
+
+		return offCtx.startRendering();
+	}
+
+	/**
+	 * Applies audio settings (highpass, compression, treble, loudness) to an AudioBuffer
+	 * using OfflineAudioContext — runs faster than real-time.
+	 */
+	private async applyAudioSettings(
+		buffer: AudioBuffer,
+		sampleRate: number,
+		audioSettings: import("@/components/video-editor/types").AudioSettings,
+		onProgress?: (progress: number) => void,
+	): Promise<AudioBuffer> {
+		onProgress?.(76);
+		const offCtx = new OfflineAudioContext(
+			buffer.numberOfChannels,
+			buffer.length,
+			sampleRate,
+		);
+
+		const source = offCtx.createBufferSource();
+		source.buffer = buffer;
+
+		const highpass = offCtx.createBiquadFilter();
+		highpass.type = "highpass";
+		highpass.frequency.value = audioSettings.highpassHz;
+
+		const compressor = offCtx.createDynamicsCompressor();
+		compressor.ratio.value = audioSettings.compressionRatio;
+
+		const treble = offCtx.createBiquadFilter();
+		treble.type = "highshelf";
+		treble.frequency.value = 3000;
+		treble.gain.value = audioSettings.trebleDb;
+
+		const loudnessGain = offCtx.createGain();
+		loudnessGain.gain.value = Math.pow(10, audioSettings.loudnessDb / 20);
+
+		source.connect(highpass);
+		highpass.connect(compressor);
+		compressor.connect(treble);
+		treble.connect(loudnessGain);
+		loudnessGain.connect(offCtx.destination);
+
+		source.start(0);
+		const rendered = await offCtx.startRendering();
+		onProgress?.(88);
+		return rendered;
+	}
+
+	/**
+	 * Encodes an AudioBuffer to a WebM/Opus Blob.
+	 * Uses a short MediaRecorder session fed from a live AudioContext
+	 * to serialize the already-processed buffer — much faster than real-time
+	 * since the buffer is fully built before this step.
+	 */
+	private async encodeAudioBufferToBlob(buffer: AudioBuffer): Promise<Blob> {
+		// Create a live AudioContext to play back the processed buffer into a MediaRecorder
+		const ctx = new AudioContext({ sampleRate: buffer.sampleRate });
+		const dest = ctx.createMediaStreamDestination();
+		const source = ctx.createBufferSource();
+		source.buffer = buffer;
+		source.connect(dest);
+
+		const mimeType = this.getSupportedAudioMimeType();
+		const options: MediaRecorderOptions = {
+			audioBitsPerSecond: AUDIO_BITRATE,
+			...(mimeType ? { mimeType } : {}),
+		};
+
+		const recorder = new MediaRecorder(dest.stream, options);
+		const chunks: Blob[] = [];
+
+		const recordedBlobPromise = new Promise<Blob>((resolve, reject) => {
+			recorder.ondataavailable = (event: BlobEvent) => {
+				if (event.data && event.data.size > 0) chunks.push(event.data);
+			};
+			recorder.onerror = () => reject(new Error("MediaRecorder failed during audio encoding"));
+			recorder.onstop = () => {
+				const type = mimeType || chunks[0]?.type || "audio/webm";
+				resolve(new Blob(chunks, { type }));
+			};
+		});
+
+		recorder.start();
+		source.start(0);
+
+		// Wait for playback to end (this is proportional to audio duration, but since
+		// the buffer is already processed the recording is the only remaining real-time step)
+		await new Promise<void>((resolve) => {
+			source.onended = () => resolve();
+		});
+
+		if (recorder.state !== "inactive") recorder.stop();
+		dest.stream.getTracks().forEach((t) => t.stop());
+		source.disconnect();
+		dest.disconnect();
+		await ctx.close();
+
+		return recordedBlobPromise;
+	}
+
+	/**
+	 * Computes a list of {startMs, endMs, speed} segments after applying trim regions.
+	 */
+	private computeAudioSegments(
+		totalDurationMs: number,
+		trimRegions: TrimRegion[],
+		speedRegions: SpeedRegion[],
+	): Array<{ startMs: number; endMs: number; speed: number }> {
+		// First produce kept segments from trim regions
+		const sortedTrims = [...trimRegions].sort((a, b) => a.startMs - b.startMs);
+		const keptSegments: Array<{ startMs: number; endMs: number }> = [];
+		let cursor = 0;
+
+		for (const trim of sortedTrims) {
+			if (cursor < trim.startMs) {
+				keptSegments.push({ startMs: cursor, endMs: trim.startMs });
+			}
+			cursor = trim.endMs;
+		}
+		if (cursor < totalDurationMs) {
+			keptSegments.push({ startMs: cursor, endMs: totalDurationMs });
+		}
+
+		if (keptSegments.length === 0) {
+			return [{ startMs: 0, endMs: totalDurationMs, speed: 1 }];
+		}
+
+		// Then split each kept segment by speed regions
+		const result: Array<{ startMs: number; endMs: number; speed: number }> = [];
+		for (const seg of keptSegments) {
+			const overlapping = speedRegions
+				.filter((sr) => sr.startMs < seg.endMs && sr.endMs > seg.startMs)
+				.sort((a, b) => a.startMs - b.startMs);
+
+			if (overlapping.length === 0) {
+				result.push({ ...seg, speed: 1 });
+				continue;
+			}
+
+			let pos = seg.startMs;
+			for (const sr of overlapping) {
+				const srStart = Math.max(sr.startMs, seg.startMs);
+				const srEnd = Math.min(sr.endMs, seg.endMs);
+				if (pos < srStart) result.push({ startMs: pos, endMs: srStart, speed: 1 });
+				result.push({ startMs: srStart, endMs: srEnd, speed: sr.speed });
+				pos = srEnd;
+			}
+			if (pos < seg.endMs) result.push({ startMs: pos, endMs: seg.endMs, speed: 1 });
+		}
+
+		return result.filter((s) => s.endMs - s.startMs > 1);
 	}
 
 	// Demuxes the rendered speed-adjusted blob and feeds encoded chunks into the MP4 muxer.
@@ -382,38 +570,6 @@ export class AudioProcessor {
 		}
 	}
 
-	private startAudioRecording(stream: MediaStream): {
-		recorder: MediaRecorder;
-		recordedBlobPromise: Promise<Blob>;
-	} {
-		const mimeType = this.getSupportedAudioMimeType();
-		const options: MediaRecorderOptions = {
-			audioBitsPerSecond: AUDIO_BITRATE,
-			...(mimeType ? { mimeType } : {}),
-		};
-
-		const recorder = new MediaRecorder(stream, options);
-		const chunks: Blob[] = [];
-
-		const recordedBlobPromise = new Promise<Blob>((resolve, reject) => {
-			recorder.ondataavailable = (event: BlobEvent) => {
-				if (event.data && event.data.size > 0) {
-					chunks.push(event.data);
-				}
-			};
-			recorder.onerror = () => {
-				reject(new Error("MediaRecorder failed while capturing speed-adjusted audio"));
-			};
-			recorder.onstop = () => {
-				const type = mimeType || chunks[0]?.type || "audio/webm";
-				resolve(new Blob(chunks, { type }));
-			};
-		});
-
-		recorder.start();
-		return { recorder, recordedBlobPromise };
-	}
-
 	private getSupportedAudioMimeType(): string | undefined {
 		const candidates = ["audio/webm;codecs=opus", "audio/webm"];
 		for (const candidate of candidates) {
@@ -424,75 +580,18 @@ export class AudioProcessor {
 		return undefined;
 	}
 
-	private waitForLoadedMetadata(media: HTMLMediaElement): Promise<void> {
-		if (Number.isFinite(media.duration) && media.readyState >= HTMLMediaElement.HAVE_METADATA) {
-			return Promise.resolve();
+	private isInTrimRegion(timestampMs: number, trims: TrimRegion[]): boolean {
+		return trims.some((trim) => timestampMs >= trim.startMs && timestampMs < trim.endMs);
+	}
+
+	private computeTrimOffset(timestampMs: number, trims: TrimRegion[]): number {
+		let offset = 0;
+		for (const trim of trims) {
+			if (trim.endMs <= timestampMs) {
+				offset += trim.endMs - trim.startMs;
+			}
 		}
-
-		return new Promise<void>((resolve, reject) => {
-			const onLoaded = () => {
-				cleanup();
-				resolve();
-			};
-			const onError = () => {
-				cleanup();
-				reject(new Error("Failed to load media metadata for speed-adjusted audio"));
-			};
-			const cleanup = () => {
-				media.removeEventListener("loadedmetadata", onLoaded);
-				media.removeEventListener("error", onError);
-			};
-
-			media.addEventListener("loadedmetadata", onLoaded);
-			media.addEventListener("error", onError, { once: true });
-		});
-	}
-
-	private seekTo(media: HTMLMediaElement, targetSec: number): Promise<void> {
-		if (Math.abs(media.currentTime - targetSec) < 0.0001) {
-			return Promise.resolve();
-		}
-
-		return new Promise<void>((resolve, reject) => {
-			const onSeeked = () => {
-				cleanup();
-				resolve();
-			};
-			const onError = () => {
-				cleanup();
-				reject(new Error("Failed to seek media for speed-adjusted audio"));
-			};
-			const cleanup = () => {
-				media.removeEventListener("seeked", onSeeked);
-				media.removeEventListener("error", onError);
-			};
-
-			media.addEventListener("seeked", onSeeked, { once: true });
-			media.addEventListener("error", onError, { once: true });
-			media.currentTime = targetSec;
-		});
-	}
-
-	private findActiveTrimRegion(
-		currentTimeMs: number,
-		trimRegions: TrimRegion[],
-	): TrimRegion | null {
-		return (
-			trimRegions.find(
-				(region) => currentTimeMs >= region.startMs && currentTimeMs < region.endMs,
-			) || null
-		);
-	}
-
-	private findActiveSpeedRegion(
-		currentTimeMs: number,
-		speedRegions: SpeedRegion[],
-	): SpeedRegion | null {
-		return (
-			speedRegions.find(
-				(region) => currentTimeMs >= region.startMs && currentTimeMs < region.endMs,
-			) || null
-		);
+		return offset;
 	}
 
 	private cloneWithTimestamp(src: AudioData, newTimestamp: number): AudioData {
@@ -520,20 +619,6 @@ export class AudioProcessor {
 			timestamp: newTimestamp,
 			data: buffer,
 		});
-	}
-
-	private isInTrimRegion(timestampMs: number, trims: TrimRegion[]): boolean {
-		return trims.some((trim) => timestampMs >= trim.startMs && timestampMs < trim.endMs);
-	}
-
-	private computeTrimOffset(timestampMs: number, trims: TrimRegion[]): number {
-		let offset = 0;
-		for (const trim of trims) {
-			if (trim.endMs <= timestampMs) {
-				offset += trim.endMs - trim.startMs;
-			}
-		}
-		return offset;
 	}
 
 	cancel(): void {

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -21,6 +21,7 @@ export class AudioProcessor {
 		trimRegions?: TrimRegion[],
 		speedRegions?: SpeedRegion[],
 		readEndSec?: number,
+		audioSettings?: import("@/components/video-editor/types").AudioSettings,
 	): Promise<void> {
 		const sortedTrims = trimRegions ? [...trimRegions].sort((a, b) => a.startMs - b.startMs) : [];
 		const sortedSpeedRegions = speedRegions
@@ -29,12 +30,21 @@ export class AudioProcessor {
 					.sort((a, b) => a.startMs - b.startMs)
 			: [];
 
-		// Speed edits must use timeline playback to preserve pitch
-		if (sortedSpeedRegions.length > 0) {
+		const hasActiveAudioSettings =
+			!!audioSettings &&
+			(audioSettings.highpassHz !== 80 ||
+				audioSettings.compressionRatio !== 4 ||
+				audioSettings.trebleDb !== 5 ||
+				audioSettings.loudnessDb !== -12);
+
+		// Speed edits must use timeline playback to preserve pitch.
+		// Audio edits also use timeline playback to evaluate the Web Audio graph.
+		if (sortedSpeedRegions.length > 0 || hasActiveAudioSettings) {
 			const renderedAudioBlob = await this.renderPitchPreservedTimelineAudio(
 				videoUrl,
 				sortedTrims,
 				sortedSpeedRegions,
+				audioSettings,
 			);
 			if (!this.cancelled) {
 				await this.muxRenderedAudioBlob(renderedAudioBlob, muxer);
@@ -187,6 +197,7 @@ export class AudioProcessor {
 		videoUrl: string,
 		trimRegions: TrimRegion[],
 		speedRegions: SpeedRegion[],
+		audioSettings?: import("@/components/video-editor/types").AudioSettings,
 	): Promise<Blob> {
 		const media = document.createElement("audio");
 		media.src = videoUrl;
@@ -206,10 +217,36 @@ export class AudioProcessor {
 			throw new Error("Export cancelled");
 		}
 
-		const audioContext = new AudioContext();
+		const audioContext = new window.AudioContext();
 		const sourceNode = audioContext.createMediaElementSource(media);
 		const destinationNode = audioContext.createMediaStreamDestination();
-		sourceNode.connect(destinationNode);
+
+		let lastNode: AudioNode = sourceNode;
+
+		if (audioSettings) {
+			const highpass = audioContext.createBiquadFilter();
+			highpass.type = "highpass";
+			highpass.frequency.value = audioSettings.highpassHz;
+
+			const compressor = audioContext.createDynamicsCompressor();
+			compressor.ratio.value = audioSettings.compressionRatio;
+
+			const treble = audioContext.createBiquadFilter();
+			treble.type = "highshelf";
+			treble.frequency.value = 3000;
+			treble.gain.value = audioSettings.trebleDb;
+
+			const loudnessGain = audioContext.createGain();
+			loudnessGain.gain.value = Math.pow(10, audioSettings.loudnessDb / 20);
+
+			lastNode.connect(highpass);
+			highpass.connect(compressor);
+			compressor.connect(treble);
+			treble.connect(loudnessGain);
+			lastNode = loudnessGain;
+		}
+
+		lastNode.connect(destinationNode);
 
 		const { recorder, recordedBlobPromise } = this.startAudioRecording(destinationNode.stream);
 		let rafId: number | null = null;

--- a/src/lib/exporter/types.ts
+++ b/src/lib/exporter/types.ts
@@ -13,6 +13,7 @@ export interface ExportProgress {
 	estimatedTimeRemaining: number; // in seconds
 	phase?: "extracting" | "finalizing"; // Phase of export
 	renderProgress?: number; // 0-100, progress of GIF rendering phase
+	audioProgress?: number; // 0-100, progress of audio processing during finalization
 }
 
 export interface ExportResult {

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -38,6 +38,7 @@ interface VideoExporterConfig extends ExportConfig {
 	previewWidth?: number;
 	previewHeight?: number;
 	cursorTelemetry?: import("@/components/video-editor/types").CursorTelemetryPoint[];
+	audioSettings?: import("@/components/video-editor/types").AudioSettings;
 	onProgress?: (progress: ExportProgress) => void;
 }
 
@@ -344,6 +345,7 @@ export class VideoExporter {
 						this.config.trimRegions,
 						this.config.speedRegions,
 						readEndSec,
+						this.config.audioSettings,
 					);
 				}
 			}

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -56,7 +56,7 @@ export class VideoExporter {
 	private readonly MAX_ENCODE_QUEUE = 120;
 	private videoDescription: Uint8Array | undefined;
 	private videoColorSpace: VideoColorSpaceInit | undefined;
-	private muxingPromises: Promise<void>[] = [];
+	private muxingPromises: Set<Promise<void>> = new Set();
 	private chunkCount = 0;
 	private lastEncoderOutputAt = 0;
 	private fatalEncoderError: Error | null = null;
@@ -323,7 +323,10 @@ export class VideoExporter {
 				throw this.fatalEncoderError;
 			}
 
-			await Promise.all(this.muxingPromises);
+			// Drain any still-in-flight muxing operations (the Set self-prunes as each resolves).
+			while (this.muxingPromises.size > 0) {
+				await Promise.all([...this.muxingPromises]);
+			}
 
 			this.reportProgress({
 				currentFrame: totalFrames,
@@ -346,6 +349,16 @@ export class VideoExporter {
 						this.config.speedRegions,
 						readEndSec,
 						this.config.audioSettings,
+						(audioProgress) => {
+							this.reportProgress({
+								currentFrame: totalFrames,
+								totalFrames,
+								percentage: 100,
+								estimatedTimeRemaining: 0,
+								phase: "finalizing",
+								audioProgress,
+							});
+						},
 					);
 				}
 			}
@@ -364,7 +377,7 @@ export class VideoExporter {
 
 	private async initializeEncoder(hardwareAcceleration: HardwareAcceleration): Promise<void> {
 		this.encodeQueue = 0;
-		this.muxingPromises = [];
+		this.muxingPromises = new Set();
 		this.chunkCount = 0;
 		this.lastEncoderOutputAt = Date.now();
 		this.fatalEncoderError = null;
@@ -391,7 +404,7 @@ export class VideoExporter {
 				const isFirstChunk = this.chunkCount === 0;
 				this.chunkCount++;
 
-				const muxingPromise = (async () => {
+				const muxingWork = (async () => {
 					try {
 						if (isFirstChunk && this.videoDescription) {
 							const colorSpace = this.videoColorSpace || {
@@ -419,8 +432,13 @@ export class VideoExporter {
 						console.error("Muxing error:", error);
 					}
 				})();
+				// Chain a .finally() so we can reference `muxingPromise` after assignment.
+				const muxingPromise: Promise<void> = muxingWork.finally(() => {
+					// Prune from the Set immediately so memory stays lean for long videos.
+					this.muxingPromises.delete(muxingPromise);
+				});
 
-				this.muxingPromises.push(muxingPromise);
+				this.muxingPromises.add(muxingPromise);
 				this.encodeQueue--;
 			},
 			error: (error) => {
@@ -514,7 +532,7 @@ export class VideoExporter {
 		this.audioProcessor = null;
 		this.muxer = null;
 		this.encodeQueue = 0;
-		this.muxingPromises = [];
+		this.muxingPromises = new Set();
 		this.chunkCount = 0;
 		this.videoDescription = undefined;
 		this.videoColorSpace = undefined;


### PR DESCRIPTION
## Description
Adds several quality-of-life enhancements to the OpenScreen video editor: a 1.1× zoom level, interactive audio adjustment controls (highpass, compression, treble, loudness) with real-time preview via the Web Audio API, and an audio waveform visualization in the timeline for precision editing.

## Motivation
Editors needed finer-grained zoom granularity (1.1×) for subtle motion zooms. They also lacked any audio post-processing tools, making it impossible to clean up low-end rumble, boost treble clarity, or normalize loudness — all common needs when editing screen recordings with narration. The audio waveform gives a visual reference for cuts, making trim decisions far more precise without having to rely purely on the timecode.

## Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other

## Related Issue(s)
N/A

## Screenshots / Video

**1.1× Zoom Level added to the timeline selector:**
> The zoom selector now includes a `1.1×` option alongside the existing `1.25×`, `1.5×`, `1.8×`, `2.2×`, `3.5×`, `5×` levels.

**Audio Adjustments panel in Settings:**
> A new **Audio Adjustments** accordion section exposes four draggable sliders:
> - **Highpass Filter** (Hz) — cuts low-frequency rumble
> - **Compression** (ratio) — evens out loudness peaks
> - **Treble** (+dB) — adds clarity/air to the vocal range
> - **Loudness Target** (LUFS/dB makeup gain) — normalizes perceived volume

**Audio Waveform in Timeline:**
> A scrollable, zoomable waveform row now sits at the bottom of the timeline editor, synchronized with the current viewport. It renders using canvas and reacts to panning/zooming in real time.

## Testing
1. Open the editor with any video that has audio.
2. **Zoom level**: Select a zoom region → open Settings → verify `1.1×` appears as the first zoom level option.
3. **Audio Adjustments**: Scroll the Settings panel to the bottom → expand "Audio Adjustments" → drag the sliders and play back the video to hear real-time changes.
4. **Waveform**: After loading a video, wait ~2s for the waveform to process. It will appear in the **AUDIO** row at the bottom of the timeline. Pan and zoom the timeline to confirm the waveform stays in sync.
5. **Export**: Export an MP4 with non-default audio settings. Verify the exported file reflects the audio adjustments.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---

## Technical Summary (for reviewers)

| Area | Change |
|------|--------|
| `types.ts` | Added `AudioSettings` interface + `DEFAULT_AUDIO_SETTINGS` |
| `projectPersistence.ts` | Serialize/deserialize `audioSettings` in project files |
| `useEditorHistory.ts` | `audioSettings` tracked in undo/redo history |
| `SettingsPanel.tsx` | New "Audio Adjustments" accordion with 4 range sliders |
| `VideoPlayback.tsx` | Live Web Audio node graph (BiquadFilter → DynamicsCompressor → Gain) |
| `audioEncoder.ts` | Export pipeline applies same audio graph during MP4 render |
| `timeline/Item.tsx` | Added `1.1×` to `ZOOM_LABELS` map |
| `lib/audioWaveform.ts` | New: reads file via `electronAPI`, decodes with `AudioContext.decodeAudioData`, computes RMS peaks |
| `timeline/AudioWaveform.tsx` | New: canvas-based waveform renderer with ResizeObserver + DPR support |
| `timeline/TimelineEditor.tsx` | Renders `<AudioWaveform>` at bottom of timeline inside dnd-timeline context |

---
<img width="1920" height="1080" alt="edits" src="https://github.com/user-attachments/assets/aa89368a-51f5-4211-b990-46e8ba7bb57c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time audio controls (highpass, compression, treble, loudness) in the editor
  * Audio waveform visualization on the timeline
  * Audio-aware export pipeline with detailed audio progress reporting

* **Improvements**
  * Enhanced zoom options and finer granularity (new 1.1×–5.0× range)
  * Editor persists and restores audio settings with project state
  * HUD overlay now appears in the system taskbar/dock
<!-- end of auto-generated comment: release notes by coderabbit.ai -->