### PR TITLE
fix: handle av1 VideoDecoder errors

### DIFF
--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -16,9 +16,10 @@ function buildAV1CodecString(description?: BufferSource): string {
 
 	if (!description) return fallback;
 
-	const bytes = new Uint8Array(
-		description instanceof ArrayBuffer ? description : description.buffer,
-	);
+	const bytes =
+		description instanceof ArrayBuffer
+			? new Uint8Array(description)
+			: new Uint8Array(description.buffer, description.byteOffset, description.byteLength);
 
 	// AV1CodecConfigurationRecord layout (4+ bytes):
 	//   Byte 0: marker (1) | version (7)

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -3,6 +3,51 @@ import type { SpeedRegion, TrimRegion } from "@/components/video-editor/types";
 
 const SOURCE_LOAD_TIMEOUT_MS = 60_000;
 
+/**
+ * Build a full WebCodecs-compatible AV1 codec string from the AV1CodecConfigurationRecord.
+ * web-demuxer may return a bare "av01" when the WASM-side parser fails to read
+ * the extradata (e.g. raw OBU sequence header from WebM instead of ISOBMFF av1C box).
+ * This function parses the record if present, otherwise returns a safe default.
+ *
+ * @see https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-section
+ */
+function buildAV1CodecString(description?: BufferSource): string {
+	const fallback = "av01.0.01M.08";
+
+	if (!description) return fallback;
+
+	const bytes = new Uint8Array(
+		description instanceof ArrayBuffer ? description : description.buffer,
+	);
+
+	// AV1CodecConfigurationRecord layout (4+ bytes):
+	//   Byte 0: marker (1) | version (7)
+	//   Byte 1: seq_profile (3) | seq_level_idx_0 (5)
+	//   Byte 2: seq_tier_0 (1) | high_bitdepth (1) | twelve_bit (1) | ...
+	// The spec says version should be 1, but Chrome/Electron's MediaRecorder
+	// may write version 127 (0xFF first byte). We accept any version as long
+	// as the marker bit is set and the record is long enough.
+	if (bytes.length < 4) return fallback;
+	if (!(bytes[0] & 0x80)) return fallback; // marker bit must be 1
+
+	// Byte 1: seq_profile (3) | seq_level_idx_0 (5)
+	const profile = (bytes[1] >> 5) & 0x07;
+	const level = bytes[1] & 0x1f;
+
+	// Byte 2: seq_tier_0 (1) | high_bitdepth (1) | twelve_bit (1) | monochrome (1) | ...
+	const tier = (bytes[2] >> 7) & 0x01;
+	const highBitdepth = (bytes[2] >> 6) & 0x01;
+	const twelveBit = (bytes[2] >> 5) & 0x01;
+	let bitdepth = 8;
+	if (highBitdepth) bitdepth = twelveBit ? 12 : 10;
+
+	const tierChar = tier ? "H" : "M";
+	const levelStr = level.toString().padStart(2, "0");
+	const bitdepthStr = bitdepth.toString().padStart(2, "0");
+
+	return `av01.${profile}.${levelStr}${tierChar}.${bitdepthStr}`;
+}
+
 export interface DecodedVideoInfo {
 	width: number;
 	height: number;
@@ -183,7 +228,17 @@ export class StreamingVideoDecoder {
 		}
 
 		const decoderConfig = await this.demuxer.getDecoderConfig("video");
-		const codec = this.metadata.codec.toLowerCase();
+
+		// web-demuxer may return a bare "av01" for AV1 in WebM containers when the
+		// extradata isn't in the expected ISOBMFF format. WebCodecs requires the
+		// full parametrized form (e.g. "av01.0.05M.08").
+		if (/^av01$/i.test(decoderConfig.codec)) {
+			decoderConfig.codec = buildAV1CodecString(
+				decoderConfig.description as BufferSource | undefined,
+			);
+		}
+
+		const codec = decoderConfig.codec.toLowerCase();
 		const shouldPreferSoftwareDecode = codec.includes("av01") || codec.includes("av1");
 		const segments = this.splitBySpeed(
 			this.computeSegments(this.metadata.duration, trimRegions),


### PR DESCRIPTION
## Description

Fix AV1 VideoDecoder error during export when recordings use AV1 in WebM containers (the default on Linux). When `web-demuxer` returns a bare "av01" codec string, we now parse the `AV1CodecConfigurationRecord` from the extradata to build the full WebCodecs-compatible codec string (e.g. "av01.0.09M.08").

## Motivation

My export kept crashing :sob:. Chrome/Electron's `MediaRecorder` writes AV1 WebM files with an `AV1CodecConfigurationRecord` whose version field is 127 (`0xFF` first byte) instead of the spec-mandated 1 (`0x81`). The `web-demuxer` library's WASM-side parser (`set_av1_codec_string`) strictly checks `version != 1` and bails early, returning a bare "av01" string rather than the full parametrized form. VideoDecoder.configure() then rejects it with "Unknown or ambiguous codec name", making all AV1 exports fail.

```txt
extradata: FF 09 0C 00
               ↓
web-demuxer: version = 0xFF & 0x7F = 127 ≠ 1 → early return → "av01"
               ↓
VideoDecoder.configure({ codec: "av01" }) → "Unknown or ambiguous codec name"
```

When `getDecoderConfig()` returns a bare "av01", we now parse the extradata ourselves, only requiring the marker bit to be set rather than a strict version check. For the example above this produces "av01.0.09M.08" (Main profile, level 3.1, Main tier, 8-bit). Falls back to "av01.0.01M.08" if extradata is missing or too short.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

None. Discovered while packaging for NixOS.

## Screenshots / Video

N/A: no UI changes. The fix is in the export pipeline (`streamingDecoder.ts`).

## Testing

1. Record a screen capture on Linux (records AV1 in WebM by default)
2. Open the recording in the editor
3. Click Export

Before fix: Export fails with "VideoDecoder Error: Unknown or ambiguous codec name"
After fix: Export completes successfully

You can verify your recording is AV1/WebM with:
`ffprobe -v warning -select_streams v:0 -show_entries stream=codec_name ~/.config/openscreen/recordings/<your-recording>.webm`

If you see `Unknown version 127 of AV1CodecConfigurationRecord found!` in the warnings, your file is affected by this bug.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AV1 codec detection and normalization so players now recognize generic AV1 labels and use a precise codec string when available, improving compatibility and playback reliability for AV1-encoded video.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->