### PR TITLE
✨ feat(linux): background export with system notification

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -26,6 +26,9 @@
       "to": "assets/wallpapers"
     }
   ],
+  "asarUnpack": [
+    "node_modules/gifsicle/**"
+  ],
   "publish": [{"provider": "github"}],
 
   "mac": {

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -135,6 +135,18 @@ interface Window {
 		hudOverlayClose: () => void;
 		setMicrophoneExpanded: (expanded: boolean) => void;
 		setHasUnsavedChanges: (hasChanges: boolean) => void;
+		setIsExporting: (isExporting: boolean) => void;
+		saveExportedVideoToPath: (
+			videoData: ArrayBuffer,
+			filePath: string,
+		) => Promise<{ success: boolean; path?: string; error?: string }>;
+		sendExportNotification: (
+			format: string,
+			filePath: string,
+		) => Promise<{ success: boolean; message?: string; error?: string }>;
+		onBackgroundExportReady: (callback: (downloadsDir: string) => void) => () => void;
+		onCancelExportAndClose: (callback: () => void) => () => void;
+		exportCancelledDone: () => void;
 		onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => () => void;
 		setLocale: (locale: string) => Promise<void>;
 	};

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -7,6 +7,7 @@ import {
 	desktopCapturer,
 	dialog,
 	ipcMain,
+	Notification,
 	screen,
 	shell,
 	systemPreferences,
@@ -507,6 +508,43 @@ export function registerIpcHandlers(
 				message: "Failed to save exported video",
 				error: String(error),
 			};
+		}
+	});
+
+	ipcMain.handle(
+		"save-exported-video-to-path",
+		async (_, videoData: ArrayBuffer, filePath: string) => {
+			try {
+				await fs.writeFile(filePath, Buffer.from(videoData));
+				return { success: true, path: filePath };
+			} catch (error) {
+				console.error("Failed to save exported video to path:", error);
+				return { success: false, error: String(error) };
+			}
+		},
+	);
+
+	ipcMain.handle("send-export-notification", async (_, format: string, filePath: string) => {
+		try {
+			if (!Notification.isSupported()) {
+				return { success: false, message: "Notifications not supported" };
+			}
+			const fileName = path.basename(filePath);
+			const notification = new Notification({
+				title: mainT("dialogs", "exportInBackground.completeNotificationTitle"),
+				body: mainT("dialogs", "exportInBackground.completeNotificationBody", {
+					format,
+					filename: fileName,
+				}),
+			});
+			notification.on("click", () => {
+				shell.showItemInFolder(filePath);
+			});
+			notification.show();
+			return { success: true };
+		} catch (error) {
+			console.error("Failed to send export notification:", error);
+			return { success: false, error: String(error) };
 		}
 	});
 

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -515,8 +515,15 @@ export function registerIpcHandlers(
 		"save-exported-video-to-path",
 		async (_, videoData: ArrayBuffer, filePath: string) => {
 			try {
-				await fs.writeFile(filePath, Buffer.from(videoData));
-				return { success: true, path: filePath };
+				// Restrict writes to the user's Downloads folder to prevent path traversal.
+				const downloadsRoot = path.resolve(app.getPath("downloads"));
+				const safeFileName = path.basename(filePath).replace(/[/\\]/g, "");
+				const destination = path.resolve(path.join(downloadsRoot, safeFileName));
+				if (!destination.startsWith(downloadsRoot + path.sep) && destination !== downloadsRoot) {
+					return { success: false, error: "Invalid path: destination is outside Downloads folder" };
+				}
+				await fs.writeFile(destination, Buffer.from(videoData));
+				return { success: true, path: destination };
 			} catch (error) {
 				console.error("Failed to save exported video to path:", error);
 				return { success: false, error: String(error) };

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1,6 +1,9 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import {
 	app,
 	BrowserWindow,
@@ -20,6 +23,58 @@ import {
 } from "../../src/lib/recordingSession";
 import { mainT } from "../i18n";
 import { RECORDINGS_DIR } from "../main";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Returns the path to the bundled gifsicle binary without importing the gifsicle
+ * package (which uses import.meta.url internally and breaks when bundled by Vite).
+ * In a packaged Electron app with asarUnpack the binary lives in app.asar.unpacked.
+ */
+function getGifsiclePath(): string {
+	const binaryName = process.platform === "win32" ? "gifsicle.exe" : "gifsicle";
+	const relPath = path.join("node_modules", "gifsicle", "vendor", binaryName);
+	if (app.isPackaged) {
+		// process.resourcesPath is e.g. /tmp/.mount_xxx/resources
+		return path.join(process.resourcesPath, "app.asar.unpacked", relPath);
+	}
+	return path.join(app.getAppPath(), relPath);
+}
+
+/**
+ * Run gifsicle -O3 on a GIF buffer and return the optimized buffer.
+ * Falls back to the original buffer if gifsicle fails.
+ */
+async function optimizeGifBuffer(inputBuffer: Buffer): Promise<Buffer> {
+	const tmpDir = os.tmpdir();
+	const tmpInput = path.join(tmpDir, `openscreen-gif-in-${Date.now()}.gif`);
+	const tmpOutput = path.join(tmpDir, `openscreen-gif-out-${Date.now()}.gif`);
+	try {
+		await fs.writeFile(tmpInput, inputBuffer);
+		const gifsiclePath = getGifsiclePath();
+		await execFileAsync(gifsiclePath, [
+			"-O3",
+			"--lossy=40",
+			"--colors",
+			"256",
+			tmpInput,
+			"-o",
+			tmpOutput,
+		]);
+		const optimized = await fs.readFile(tmpOutput);
+		return optimized;
+	} catch (err) {
+		console.warn("[optimize-gif] gifsicle failed, using original:", err);
+		return inputBuffer;
+	} finally {
+		await fs.unlink(tmpInput).catch(() => {
+			// ignore missing tmp file
+		});
+		await fs.unlink(tmpOutput).catch(() => {
+			// ignore missing tmp file
+		});
+	}
+}
 
 const PROJECT_FILE_EXTENSION = "openscreen";
 const SHORTCUTS_FILE = path.join(app.getPath("userData"), "shortcuts.json");
@@ -494,7 +549,11 @@ export function registerIpcHandlers(
 				};
 			}
 
-			await fs.writeFile(result.filePath, Buffer.from(videoData));
+			let dataToWrite: Buffer = Buffer.from(videoData as ArrayBuffer);
+			if (isGif) {
+				dataToWrite = await optimizeGifBuffer(dataToWrite);
+			}
+			await fs.writeFile(result.filePath, dataToWrite);
 
 			return {
 				success: true,
@@ -522,7 +581,12 @@ export function registerIpcHandlers(
 				if (!destination.startsWith(downloadsRoot + path.sep) && destination !== downloadsRoot) {
 					return { success: false, error: "Invalid path: destination is outside Downloads folder" };
 				}
-				await fs.writeFile(destination, Buffer.from(videoData));
+				const isGif = safeFileName.toLowerCase().endsWith(".gif");
+				let dataToWrite: Buffer = Buffer.from(videoData as ArrayBuffer);
+				if (isGif) {
+					dataToWrite = await optimizeGifBuffer(dataToWrite);
+				}
+				await fs.writeFile(destination, dataToWrite);
 				return { success: true, path: destination };
 			} catch (error) {
 				console.error("Failed to save exported video to path:", error);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -309,15 +309,22 @@ function createEditorWindowWrapper() {
 				win.hide();
 				win.webContents.send("background-export-ready", app.getPath("downloads"));
 			} else if (choice === 1) {
-				// Cancel Export & Close: tell renderer to cancel, then force-close
+				// Cancel Export & Close: ask the renderer to cancel, then re-trigger
+				// the normal close so the unsaved-changes guard can run.
 				win.webContents.send("cancel-export-and-close");
+				const onCancelled = () => {
+					clearTimeout(fallback);
+					// editorIsExporting is now false (renderer sent set-is-exporting false
+					// before ACKing), so the next close will fall through to the
+					// unsaved-changes check rather than looping back here.
+					win.close();
+				};
 				const fallback = setTimeout(() => {
+					ipcMain.removeListener("export-cancelled-done", onCancelled);
+					// Renderer never responded — force close as last resort.
 					forceCloseEditorWindow(win);
 				}, 5000);
-				ipcMain.once("export-cancelled-done", () => {
-					clearTimeout(fallback);
-					forceCloseEditorWindow(win);
-				});
+				ipcMain.once("export-cancelled-done", onCancelled);
 			}
 			// choice === 2: Keep Open — do nothing
 			return;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -244,10 +244,15 @@ function updateTrayMenu(recording: boolean = false) {
 }
 
 let editorHasUnsavedChanges = false;
+let editorIsExporting = false;
 let isForceClosing = false;
 
 ipcMain.on("set-has-unsaved-changes", (_, hasChanges: boolean) => {
 	editorHasUnsavedChanges = hasChanges;
+});
+
+ipcMain.on("set-is-exporting", (_, isExporting: boolean) => {
+	editorIsExporting = isExporting;
 });
 
 function forceCloseEditorWindow(windowToClose: BrowserWindow | null) {
@@ -276,7 +281,49 @@ function createEditorWindowWrapper() {
 	editorHasUnsavedChanges = false;
 
 	mainWindow.on("close", (event) => {
-		if (isForceClosing || !editorHasUnsavedChanges) return;
+		if (isForceClosing) return;
+
+		// If an export is running, offer background export instead of closing
+		if (editorIsExporting) {
+			event.preventDefault();
+
+			const choice = dialog.showMessageBoxSync(mainWindow!, {
+				type: "info",
+				buttons: [
+					mainT("dialogs", "exportInBackground.continueInBackground"),
+					mainT("dialogs", "exportInBackground.cancelAndClose"),
+					mainT("common", "actions.cancel"),
+				],
+				defaultId: 0,
+				cancelId: 2,
+				title: mainT("dialogs", "exportInBackground.title"),
+				message: mainT("dialogs", "exportInBackground.message"),
+				detail: mainT("dialogs", "exportInBackground.detail"),
+			});
+
+			const win = mainWindow;
+			if (!win || win.isDestroyed()) return;
+
+			if (choice === 0) {
+				// Continue in Background: hide the window and let renderer know
+				win.hide();
+				win.webContents.send("background-export-ready", app.getPath("downloads"));
+			} else if (choice === 1) {
+				// Cancel Export & Close: tell renderer to cancel, then force-close
+				win.webContents.send("cancel-export-and-close");
+				const fallback = setTimeout(() => {
+					forceCloseEditorWindow(win);
+				}, 5000);
+				ipcMain.once("export-cancelled-done", () => {
+					clearTimeout(fallback);
+					forceCloseEditorWindow(win);
+				});
+			}
+			// choice === 2: Keep Open — do nothing
+			return;
+		}
+
+		if (!editorHasUnsavedChanges) return;
 
 		event.preventDefault();
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -124,6 +124,28 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	setHasUnsavedChanges: (hasChanges: boolean) => {
 		ipcRenderer.send("set-has-unsaved-changes", hasChanges);
 	},
+	setIsExporting: (isExporting: boolean) => {
+		ipcRenderer.send("set-is-exporting", isExporting);
+	},
+	saveExportedVideoToPath: (videoData: ArrayBuffer, filePath: string) => {
+		return ipcRenderer.invoke("save-exported-video-to-path", videoData, filePath);
+	},
+	sendExportNotification: (format: string, filePath: string) => {
+		return ipcRenderer.invoke("send-export-notification", format, filePath);
+	},
+	onBackgroundExportReady: (callback: (downloadsDir: string) => void) => {
+		const listener = (_: Electron.IpcRendererEvent, downloadsDir: string) => callback(downloadsDir);
+		ipcRenderer.on("background-export-ready", listener);
+		return () => ipcRenderer.removeListener("background-export-ready", listener);
+	},
+	onCancelExportAndClose: (callback: () => void) => {
+		const listener = () => callback();
+		ipcRenderer.on("cancel-export-and-close", listener);
+		return () => ipcRenderer.removeListener("cancel-export-and-close", listener);
+	},
+	exportCancelledDone: () => {
+		ipcRenderer.send("export-cancelled-done");
+	},
 	onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => {
 		const listener = async () => {
 			try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "openscreen",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "openscreen",
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"dependencies": {
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@pixi/filter-drop-shadow": "^5.2.0",
@@ -31,6 +31,7 @@
 				"emoji-picker-react": "^4.16.1",
 				"fix-webm-duration": "^1.0.6",
 				"gif.js": "^0.2.0",
+				"gifsicle": "^7.0.1",
 				"gsap": "^3.13.0",
 				"lucide-react": "^0.545.0",
 				"mediabunny": "^1.25.1",
@@ -5549,6 +5550,47 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/arch": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+			"integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/archive-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+			"integrity": "sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==",
+			"license": "MIT",
+			"dependencies": {
+				"file-type": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/archive-type/node_modules/file-type": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+			"integrity": "sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -5816,6 +5858,21 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -5843,7 +5900,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5888,6 +5944,679 @@
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
+			}
+		},
+		"node_modules/bin-build": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+			"integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
+			"license": "MIT",
+			"dependencies": {
+				"decompress": "^4.0.0",
+				"download": "^6.2.2",
+				"execa": "^0.7.0",
+				"p-map-series": "^1.0.0",
+				"tempfile": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-build/node_modules/cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+			"license": "MIT",
+			"dependencies": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"node_modules/bin-build/node_modules/execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-build/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-build/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"license": "ISC",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/bin-build/node_modules/npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-build/node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-build/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-build/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-build/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/bin-build/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/bin-build/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+			"license": "ISC"
+		},
+		"node_modules/bin-check": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
+			"integrity": "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==",
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^0.7.0",
+				"executable": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-check/node_modules/cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+			"license": "MIT",
+			"dependencies": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"node_modules/bin-check/node_modules/execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-check/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-check/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"license": "ISC",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/bin-check/node_modules/npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-check/node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-check/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-check/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-check/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/bin-check/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/bin-check/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+			"license": "ISC"
+		},
+		"node_modules/bin-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.1.0.tgz",
+			"integrity": "sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==",
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^1.0.0",
+				"find-versions": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-version-check": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-4.0.0.tgz",
+			"integrity": "sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bin-version": "^3.0.0",
+				"semver": "^5.6.0",
+				"semver-truncate": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-version-check/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/bin-version/node_modules/cross-spawn": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+			"license": "MIT",
+			"dependencies": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"engines": {
+				"node": ">=4.8"
+			}
+		},
+		"node_modules/bin-version/node_modules/execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-version/node_modules/get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-version/node_modules/npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-version/node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-version/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/bin-version/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-version/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-version/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/bin-version/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/bin-wrapper": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.1.0.tgz",
+			"integrity": "sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"bin-check": "^4.1.0",
+				"bin-version-check": "^4.0.0",
+				"download": "^7.1.0",
+				"import-lazy": "^3.1.0",
+				"os-filter-obj": "^2.0.0",
+				"pify": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/@sindresorhus/is": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/cacheable-request": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+			"integrity": "sha512-vag0O2LKZ/najSoUwDbVlnlCFvhBE/7mGTY2B5FgCBDcRD+oVV1HYTOwM6JZfMg/hIcM6IwnTZ1uQQL5/X3xIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "1.0.2",
+				"get-stream": "3.0.0",
+				"http-cache-semantics": "3.8.1",
+				"keyv": "3.0.0",
+				"lowercase-keys": "1.0.0",
+				"normalize-url": "2.0.1",
+				"responselike": "1.0.2"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/cacheable-request/node_modules/lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/download": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+			"integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"archive-type": "^4.0.0",
+				"caw": "^2.0.1",
+				"content-disposition": "^0.5.2",
+				"decompress": "^4.2.0",
+				"ext-name": "^5.0.0",
+				"file-type": "^8.1.0",
+				"filenamify": "^2.0.0",
+				"get-stream": "^3.0.0",
+				"got": "^8.3.1",
+				"make-dir": "^1.2.0",
+				"p-event": "^2.1.0",
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/download/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/file-type": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+			"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/got": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^0.7.0",
+				"cacheable-request": "^2.1.1",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"into-stream": "^3.1.0",
+				"is-retry-allowed": "^1.1.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"mimic-response": "^1.0.0",
+				"p-cancelable": "^0.4.0",
+				"p-timeout": "^2.0.1",
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1",
+				"timed-out": "^4.0.1",
+				"url-parse-lax": "^3.0.0",
+				"url-to-options": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/got/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/http-cache-semantics": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/bin-wrapper/node_modules/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+			"license": "MIT"
+		},
+		"node_modules/bin-wrapper/node_modules/keyv": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.0"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/normalize-url": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^2.0.0",
+				"query-string": "^5.0.1",
+				"sort-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/p-cancelable": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/p-event": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+			"integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+			"license": "MIT",
+			"dependencies": {
+				"p-timeout": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^1.0.0"
+			}
+		},
+		"node_modules/bin-wrapper/node_modules/sort-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -5989,7 +6718,6 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6010,15 +6738,36 @@
 				"ieee754": "^1.1.13"
 			}
 		},
+		"node_modules/buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"node_modules/buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+			"license": "MIT"
+		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+			"license": "MIT"
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -6265,6 +7014,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -6283,7 +7050,6 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -6341,6 +7107,21 @@
 			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/caw": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+			"license": "MIT",
+			"dependencies": {
+				"get-proxy": "^2.0.0",
+				"isurl": "^1.0.0-alpha5",
+				"tunnel-agent": "^0.6.0",
+				"url-to-options": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/centra": {
 			"version": "2.7.0",
@@ -6695,12 +7476,34 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"node_modules/console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -6713,7 +7516,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/crc": {
@@ -6852,6 +7654,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/decompress": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"decompress-tar": "^4.0.0",
+				"decompress-tarbz2": "^4.0.0",
+				"decompress-targz": "^4.0.0",
+				"decompress-unzip": "^4.0.1",
+				"graceful-fs": "^4.1.10",
+				"make-dir": "^1.0.0",
+				"pify": "^2.3.0",
+				"strip-dirs": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -6881,6 +7711,114 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/decompress-tar": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+			"license": "MIT",
+			"dependencies": {
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0",
+				"tar-stream": "^1.5.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-tar/node_modules/file-type": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+			"integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-tarbz2": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+			"license": "MIT",
+			"dependencies": {
+				"decompress-tar": "^4.1.0",
+				"file-type": "^6.1.0",
+				"is-stream": "^1.1.0",
+				"seek-bzip": "^1.0.5",
+				"unbzip2-stream": "^1.0.9"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-tarbz2/node_modules/file-type": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+			"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-targz": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+			"license": "MIT",
+			"dependencies": {
+				"decompress-tar": "^4.1.1",
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-targz/node_modules/file-type": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+			"integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-unzip": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+			"integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+			"license": "MIT",
+			"dependencies": {
+				"file-type": "^3.8.0",
+				"get-stream": "^2.2.0",
+				"pify": "^2.3.0",
+				"yauzl": "^2.4.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/decompress-unzip/node_modules/file-type": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+			"integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/decompress-unzip/node_modules/get-stream": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+			"integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4.0.1",
+				"pinkie-promise": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -6908,9 +7846,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -7212,6 +8148,131 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/download": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+			"integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+			"license": "MIT",
+			"dependencies": {
+				"caw": "^2.0.0",
+				"content-disposition": "^0.5.2",
+				"decompress": "^4.0.0",
+				"ext-name": "^5.0.0",
+				"file-type": "5.2.0",
+				"filenamify": "^2.0.0",
+				"get-stream": "^3.0.0",
+				"got": "^7.0.0",
+				"make-dir": "^1.0.0",
+				"p-event": "^1.0.0",
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/file-type": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+			"integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/got": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+			"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^3.2.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"p-cancelable": "^0.3.0",
+				"p-timeout": "^1.1.1",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"url-parse-lax": "^1.0.0",
+				"url-to-options": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/download/node_modules/p-cancelable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/download/node_modules/url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==",
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7225,6 +8286,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/duplexer3": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/earcut": {
 			"version": "3.0.2",
@@ -7600,7 +8667,6 @@
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
 			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
@@ -7826,6 +8892,98 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/execa": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+			"integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^3.0.1",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/executable": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+			"integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/exif-parser": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -7848,6 +9006,31 @@
 			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/ext-list": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.28.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ext-name": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ext-list": "^2.0.0",
+				"sort-keys-length": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -7966,7 +9149,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pend": "~1.2.0"
@@ -8023,6 +9205,29 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/filenamify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+			"license": "MIT",
+			"dependencies": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.0",
+				"trim-repeated": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8033,6 +9238,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/find-versions": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+			"integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+			"license": "MIT",
+			"dependencies": {
+				"semver-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/fix-webm-duration": {
@@ -8066,6 +9283,21 @@
 				"debug": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/foreground-child": {
@@ -8151,6 +9383,52 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"node_modules/from2/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/from2/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/from2/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
 		},
 		"node_modules/fs-extra": {
 			"version": "8.1.0",
@@ -8337,6 +9615,18 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/get-proxy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+			"license": "MIT",
+			"dependencies": {
+				"npm-conf": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -8368,6 +9658,27 @@
 			"resolved": "https://registry.npmjs.org/gif.js/-/gif.js-0.2.0.tgz",
 			"integrity": "sha512-bYxCoT8OZKmbxY8RN4qDiYuj4nrQDTzgLRcFVovyona1PTWNePzI4nzOmotnlOFIzTk/ZxAHtv+TfVLiBWj/hw==",
 			"license": "MIT"
+		},
+		"node_modules/gifsicle": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-7.0.1.tgz",
+			"integrity": "sha512-Mwg4tDc7dUUWYNan/NAf4pKcrCwDSUAXRqBNtqXjtwzMyGJ6LVFz5pwMC/SEj2rsw1VILrhr+kk/2wG3+GMXfg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"bin-build": "^3.0.0",
+				"bin-wrapper": "^4.0.0",
+				"execa": "^6.1.0"
+			},
+			"bin": {
+				"gifsicle": "cli.js"
+			},
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/imagemin/gisicle-bin?sponsor=1"
+			}
 		},
 		"node_modules/gifuct-js": {
 			"version": "2.1.2",
@@ -8558,7 +9869,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/gsap": {
@@ -8606,14 +9916,21 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbol-support-x": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -8628,11 +9945,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-to-string-tag-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbol-support-x": "^1.4.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/has-tostringtag": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -8789,6 +10117,15 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/human-signals": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+			"integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -8891,7 +10228,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8934,6 +10270,15 @@
 			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/import-lazy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+			"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
@@ -8978,8 +10323,26 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"license": "ISC"
+		},
+		"node_modules/into-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"integrity": "sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/invert-kv": {
 			"version": "1.0.0",
@@ -9018,6 +10381,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -9089,6 +10464,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-natural-number": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+			"integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9096,6 +10477,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-object": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+			"integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-path-cwd": {
@@ -9118,6 +10508,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9125,14 +10524,37 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typedarray": {
@@ -9166,7 +10588,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isbinaryfile": {
@@ -9200,6 +10621,19 @@
 			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/isurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"license": "MIT",
+			"dependencies": {
+				"has-to-string-tag-x": "^1.2.0",
+				"is-object": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 4"
+			}
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -10114,6 +11548,27 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/make-dir/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/make-fetch-happen": {
 			"version": "10.2.1",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -10225,6 +11680,12 @@
 			"integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
 			"license": "MIT"
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"license": "MIT"
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10264,7 +11725,6 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -10310,7 +11770,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -10693,6 +12152,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"license": "MIT"
+		},
 		"node_modules/node-abi": {
 			"version": "3.78.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
@@ -10847,6 +12312,55 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/npm-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+			"license": "MIT",
+			"dependencies": {
+				"config-chain": "^1.1.11",
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm-conf/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/npmlog": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
@@ -10948,7 +12462,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -10994,6 +12507,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/os-filter-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
+			"integrity": "sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==",
+			"license": "MIT",
+			"dependencies": {
+				"arch": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -11015,6 +12540,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/p-event": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+			"integrity": "sha512-hV1zbA7gwqPVFcapfeATaNjQ3J0NuzorHPyG8GPL9g/Y/TplWVBVoCKCXL6Ej2zscrCEv195QNWJXuBH6XZuzA==",
+			"license": "MIT",
+			"dependencies": {
+				"p-timeout": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -11047,6 +12602,39 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-map-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+			"integrity": "sha512-4k9LlvY6Bo/1FcIdV33wqZQES0Py+iKISU9Uc8p8AjWoZPnFKMpVIVD3s0EYn4jzLh1I+WeUZkJ0Yoa4Qfw3Kg==",
+			"license": "MIT",
+			"dependencies": {
+				"p-reduce": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha512-3Tx1T3oM1xO/Y8Gj0sWyE78EIJZ+t+aEmXUdvQgvGmSMri7aPTHoovbXEreWKkL5j21Er60XAWLTzKbAKYOujQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+			"integrity": "sha512-gb0ryzr+K2qFqFv6qi3khoeqMZF/+ajxQipEF6NteZVnvz9tzdsfAVj3lYtn1gAXvH5lfLwfxEII799gt/mRIA==",
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -11223,7 +12811,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/performance-now": {
@@ -11385,7 +12972,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
 			"integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11395,7 +12981,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pinkie": "^2.0.0"
@@ -11545,6 +13130,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/postcss": {
@@ -11733,6 +13327,15 @@
 				"node": "^12.20.0 || >=14"
 			}
 		},
+		"node_modules/prepend-http": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/pretty-format": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -11795,7 +13398,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/progress": {
@@ -11859,6 +13461,18 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"license": "ISC"
+		},
+		"node_modules/pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+			"license": "ISC"
+		},
 		"node_modules/psl": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -11876,7 +13490,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
 			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -11924,6 +13537,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"license": "MIT",
+			"dependencies": {
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -12665,7 +14292,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12728,6 +14354,25 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
+		"node_modules/seek-bzip": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^2.8.1"
+			},
+			"bin": {
+				"seek-bunzip": "bin/seek-bunzip",
+				"seek-table": "bin/seek-bzip-table"
+			}
+		},
+		"node_modules/seek-bzip/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -12748,6 +14393,36 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/semver-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+			"integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/semver-truncate": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+			"integrity": "sha512-V1fGg9i4CL3qesB6U0L6XAm4xOJiHmt4QAacazumuasc03BvtFGIMCduv01JWQ69Nv+JST9TqhSCiJoxoY031w==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/semver-truncate/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
 		},
 		"node_modules/serialize-error": {
 			"version": "7.0.1",
@@ -12786,6 +14461,23 @@
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -12993,6 +14685,30 @@
 				"react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			}
 		},
+		"node_modules/sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sort-keys-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+			"integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+			"license": "MIT",
+			"dependencies": {
+				"sort-keys": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13150,6 +14866,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -13237,6 +14962,36 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/strip-dirs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+			"license": "MIT",
+			"dependencies": {
+				"is-natural-number": "^4.0.1"
+			}
+		},
+		"node_modules/strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -13248,6 +15003,27 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/strip-outer/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/strtok3": {
@@ -13596,6 +15372,64 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/tar-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^1.0.0",
+				"buffer-alloc": "^1.2.0",
+				"end-of-stream": "^1.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.1",
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/tar-stream/node_modules/bl": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node_modules/tar-stream/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/tar-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/tar-stream/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/tar/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -13616,6 +15450,15 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/temp-file": {
@@ -13696,6 +15539,29 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/tempfile": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+			"integrity": "sha512-ZOn6nJUgvgC09+doCEF3oB+r3ag7kUvlsXEGX069QRD60p+P3uP7XG9N2/at+EyIRGSN//ZY3LyEotA1YpmjuA==",
+			"license": "MIT",
+			"dependencies": {
+				"temp-dir": "^1.0.0",
+				"uuid": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/tempfile/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"license": "MIT",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/terser": {
 			"version": "5.44.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -13751,6 +15617,21 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"license": "MIT"
+		},
+		"node_modules/timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/timm": {
@@ -13911,6 +15792,26 @@
 				"tmp": "^0.2.0"
 			}
 		},
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/to-buffer/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"license": "MIT"
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13968,6 +15869,27 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/trim-repeated/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -13994,7 +15916,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
@@ -14009,6 +15930,20 @@
 			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true,
 			"license": "Unlicense"
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
@@ -14029,6 +15964,16 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/unbzip2-stream": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
 			}
 		},
 		"node_modules/undici": {
@@ -14137,6 +16082,27 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/url-parse-lax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/url-to-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+			"integrity": "sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/url/node_modules/punycode": {
@@ -15067,6 +17033,27 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -15134,7 +17121,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/xhr": {
@@ -15212,7 +17198,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4"
@@ -15284,7 +17269,6 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"emoji-picker-react": "^4.16.1",
 		"fix-webm-duration": "^1.0.6",
 		"gif.js": "^0.2.0",
+		"gifsicle": "^7.0.1",
 		"gsap": "^3.13.0",
 		"lucide-react": "^0.545.0",
 		"mediabunny": "^1.25.1",

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -197,7 +197,7 @@ export function SettingsPanel({
 	onExportQualityChange,
 	exportFormat = "mp4",
 	onExportFormatChange,
-	gifFrameRate = 15,
+	gifFrameRate = 10,
 	onGifFrameRateChange,
 	gifLoop = true,
 	onGifLoopChange,

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -111,7 +111,7 @@ export default function VideoEditor() {
 	const [showExportDialog, setShowExportDialog] = useState(false);
 	const [exportQuality, setExportQuality] = useState<ExportQuality>("good");
 	const [exportFormat, setExportFormat] = useState<ExportFormat>("mp4");
-	const [gifFrameRate, setGifFrameRate] = useState<GifFrameRate>(15);
+	const [gifFrameRate, setGifFrameRate] = useState<GifFrameRate>(10);
 	const [gifLoop, setGifLoop] = useState(true);
 	const [gifSizePreset, setGifSizePreset] = useState<GifSizePreset>("medium");
 	const [exportedFilePath, setExportedFilePath] = useState<string | null>(null);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -473,10 +473,18 @@ export default function VideoEditor() {
 
 	useEffect(() => {
 		const cleanup = window.electronAPI.onCancelExportAndClose(() => {
-			if (exporterRef.current) {
-				exporterRef.current.cancel();
+			const exporter = exporterRef.current;
+			if (exporter) {
+				// Cancel the in-flight export. The handleExport finally-block will
+				// clear state and set isExporting=false. We notify main only after
+				// that settles so the window close doesn't race ahead of cleanup.
+				exporter.cancel();
+				void Promise.resolve()
+					.then(() => new Promise<void>((resolve) => setTimeout(resolve, 0)))
+					.then(() => window.electronAPI.exportCancelledDone());
+			} else {
+				window.electronAPI.exportCancelledDone();
 			}
-			window.electronAPI.exportCancelledDone();
 		});
 		return cleanup;
 	}, []);
@@ -1150,12 +1158,33 @@ export default function VideoEditor() {
 						if (bgDir) {
 							// Background export: auto-save to Downloads without a dialog
 							const fullPath = `${bgDir}/${fileName}`;
-							const saveResult = await window.electronAPI.saveExportedVideoToPath(
-								arrayBuffer,
-								fullPath,
-							);
-							if (saveResult.success) {
-								await window.electronAPI.sendExportNotification("GIF", fullPath);
+							try {
+								const saveResult = await window.electronAPI.saveExportedVideoToPath(
+									arrayBuffer,
+									fullPath,
+								);
+								if (saveResult.success && saveResult.path) {
+									await window.electronAPI.sendExportNotification("GIF", saveResult.path);
+								} else {
+									throw new Error(saveResult.error || "Background save failed");
+								}
+							} catch (bgError) {
+								console.error("Background GIF save failed, falling back to dialog:", bgError);
+								backgroundExportDirRef.current = null;
+								const saveResult = await window.electronAPI.saveExportedVideo(
+									arrayBuffer,
+									fileName,
+								);
+								if (saveResult.canceled) {
+									setUnsavedExport({ arrayBuffer, fileName, format: "gif" });
+									toast.info("Export canceled");
+								} else if (saveResult.success && saveResult.path) {
+									setUnsavedExport(null);
+									handleExportSaved("GIF", saveResult.path);
+								} else {
+									setExportError(saveResult.message || "Failed to save GIF");
+									toast.error(saveResult.message || "Failed to save GIF");
+								}
 							}
 						} else {
 							const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
@@ -1296,12 +1325,33 @@ export default function VideoEditor() {
 						if (bgDir) {
 							// Background export: auto-save to Downloads without a dialog
 							const fullPath = `${bgDir}/${fileName}`;
-							const saveResult = await window.electronAPI.saveExportedVideoToPath(
-								arrayBuffer,
-								fullPath,
-							);
-							if (saveResult.success) {
-								await window.electronAPI.sendExportNotification("Video", fullPath);
+							try {
+								const saveResult = await window.electronAPI.saveExportedVideoToPath(
+									arrayBuffer,
+									fullPath,
+								);
+								if (saveResult.success && saveResult.path) {
+									await window.electronAPI.sendExportNotification("Video", saveResult.path);
+								} else {
+									throw new Error(saveResult.error || "Background save failed");
+								}
+							} catch (bgError) {
+								console.error("Background MP4 save failed, falling back to dialog:", bgError);
+								backgroundExportDirRef.current = null;
+								const saveResult = await window.electronAPI.saveExportedVideo(
+									arrayBuffer,
+									fileName,
+								);
+								if (saveResult.canceled) {
+									setUnsavedExport({ arrayBuffer, fileName, format: "mp4" });
+									toast.info("Export canceled");
+								} else if (saveResult.success && saveResult.path) {
+									setUnsavedExport(null);
+									handleExportSaved("Video", saveResult.path);
+								} else {
+									setExportError(saveResult.message || "Failed to save video");
+									toast.error(saveResult.message || "Failed to save video");
+								}
 							}
 						} else {
 							const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -138,6 +138,7 @@ export default function VideoEditor() {
 	const nextAnnotationIdRef = useRef(1);
 	const nextAnnotationZIndexRef = useRef(1);
 	const exporterRef = useRef<VideoExporter | null>(null);
+	const backgroundExportDirRef = useRef<string | null>(null);
 
 	const currentProjectMedia = useMemo<ProjectMedia | null>(() => {
 		const screenVideoPath = videoSourcePath ?? (videoPath ? fromFileUrl(videoPath) : null);
@@ -462,6 +463,23 @@ export default function VideoEditor() {
 		});
 		return () => cleanup();
 	}, [saveProject]);
+
+	useEffect(() => {
+		const cleanup = window.electronAPI.onBackgroundExportReady((downloadsDir: string) => {
+			backgroundExportDirRef.current = downloadsDir;
+		});
+		return cleanup;
+	}, []);
+
+	useEffect(() => {
+		const cleanup = window.electronAPI.onCancelExportAndClose(() => {
+			if (exporterRef.current) {
+				exporterRef.current.cancel();
+			}
+			window.electronAPI.exportCancelledDone();
+		});
+		return cleanup;
+	}, []);
 
 	const handleSaveProject = useCallback(async () => {
 		await saveProject(false);
@@ -1062,6 +1080,7 @@ export default function VideoEditor() {
 			}
 
 			setIsExporting(true);
+			window.electronAPI.setIsExporting(true);
 			setExportProgress(null);
 			setExportError(null);
 			setExportedFilePath(null);
@@ -1127,17 +1146,30 @@ export default function VideoEditor() {
 						const timestamp = Date.now();
 						const fileName = `export-${timestamp}.gif`;
 
-						const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
-
-						if (saveResult.canceled) {
-							setUnsavedExport({ arrayBuffer, fileName, format: "gif" });
-							toast.info("Export canceled");
-						} else if (saveResult.success && saveResult.path) {
-							setUnsavedExport(null);
-							handleExportSaved("GIF", saveResult.path);
+						const bgDir = backgroundExportDirRef.current;
+						if (bgDir) {
+							// Background export: auto-save to Downloads without a dialog
+							const fullPath = `${bgDir}/${fileName}`;
+							const saveResult = await window.electronAPI.saveExportedVideoToPath(
+								arrayBuffer,
+								fullPath,
+							);
+							if (saveResult.success) {
+								await window.electronAPI.sendExportNotification("GIF", fullPath);
+							}
 						} else {
-							setExportError(saveResult.message || "Failed to save GIF");
-							toast.error(saveResult.message || "Failed to save GIF");
+							const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
+
+							if (saveResult.canceled) {
+								setUnsavedExport({ arrayBuffer, fileName, format: "gif" });
+								toast.info("Export canceled");
+							} else if (saveResult.success && saveResult.path) {
+								setUnsavedExport(null);
+								handleExportSaved("GIF", saveResult.path);
+							} else {
+								setExportError(saveResult.message || "Failed to save GIF");
+								toast.error(saveResult.message || "Failed to save GIF");
+							}
 						}
 					} else {
 						setExportError(result.error || "GIF export failed");
@@ -1260,17 +1292,30 @@ export default function VideoEditor() {
 						const timestamp = Date.now();
 						const fileName = `export-${timestamp}.mp4`;
 
-						const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
-
-						if (saveResult.canceled) {
-							setUnsavedExport({ arrayBuffer, fileName, format: "mp4" });
-							toast.info("Export canceled");
-						} else if (saveResult.success && saveResult.path) {
-							setUnsavedExport(null);
-							handleExportSaved("Video", saveResult.path);
+						const bgDir = backgroundExportDirRef.current;
+						if (bgDir) {
+							// Background export: auto-save to Downloads without a dialog
+							const fullPath = `${bgDir}/${fileName}`;
+							const saveResult = await window.electronAPI.saveExportedVideoToPath(
+								arrayBuffer,
+								fullPath,
+							);
+							if (saveResult.success) {
+								await window.electronAPI.sendExportNotification("Video", fullPath);
+							}
 						} else {
-							setExportError(saveResult.message || "Failed to save video");
-							toast.error(saveResult.message || "Failed to save video");
+							const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
+
+							if (saveResult.canceled) {
+								setUnsavedExport({ arrayBuffer, fileName, format: "mp4" });
+								toast.info("Export canceled");
+							} else if (saveResult.success && saveResult.path) {
+								setUnsavedExport(null);
+								handleExportSaved("Video", saveResult.path);
+							} else {
+								setExportError(saveResult.message || "Failed to save video");
+								toast.error(saveResult.message || "Failed to save video");
+							}
 						}
 					} else {
 						setExportError(result.error || "Export failed");
@@ -1287,6 +1332,8 @@ export default function VideoEditor() {
 				setExportError(errorMessage);
 				toast.error(`Export failed: ${errorMessage}`);
 			} finally {
+				window.electronAPI.setIsExporting(false);
+				backgroundExportDirRef.current = null;
 				setIsExporting(false);
 				exporterRef.current = null;
 				// Reset dialog state to ensure it can be opened again on next export
@@ -1383,6 +1430,8 @@ export default function VideoEditor() {
 	const handleCancelExport = useCallback(() => {
 		if (exporterRef.current) {
 			exporterRef.current.cancel();
+			window.electronAPI.setIsExporting(false);
+			backgroundExportDirRef.current = null;
 			toast.info("Export canceled");
 			setShowExportDialog(false);
 			setIsExporting(false);

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -379,14 +379,17 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 				: "good",
 		exportFormat: editor.exportFormat === "gif" ? "gif" : "mp4",
 		gifFrameRate:
+			editor.gifFrameRate === 5 ||
+			editor.gifFrameRate === 10 ||
 			editor.gifFrameRate === 15 ||
 			editor.gifFrameRate === 20 ||
 			editor.gifFrameRate === 25 ||
 			editor.gifFrameRate === 30
 				? editor.gifFrameRate
-				: 15,
+				: 10,
 		gifLoop: typeof editor.gifLoop === "boolean" ? editor.gifLoop : true,
 		gifSizePreset:
+			editor.gifSizePreset === "small" ||
 			editor.gifSizePreset === "medium" ||
 			editor.gifSizePreset === "large" ||
 			editor.gifSizePreset === "original"

--- a/src/i18n/locales/en/dialogs.json
+++ b/src/i18n/locales/en/dialogs.json
@@ -53,6 +53,15 @@
 		"saveProject": "Save Project…",
 		"saveProjectAs": "Save Project As…"
 	},
+	"exportInBackground": {
+		"title": "Export in Progress",
+		"message": "An export is currently running.",
+		"detail": "Continue exporting in the background? The file will be saved to your Downloads folder. You'll get a notification when it's done.",
+		"continueInBackground": "Continue in Background",
+		"cancelAndClose": "Cancel Export & Close",
+		"completeNotificationTitle": "Export Complete",
+		"completeNotificationBody": "{{format}} saved to {{filename}}"
+	},
 	"fileDialogs": {
 		"saveGif": "Save Exported GIF",
 		"saveVideo": "Save Exported Video",

--- a/src/i18n/locales/es/dialogs.json
+++ b/src/i18n/locales/es/dialogs.json
@@ -53,6 +53,15 @@
 		"saveProject": "Guardar proyecto…",
 		"saveProjectAs": "Guardar proyecto como…"
 	},
+	"exportInBackground": {
+		"title": "Exportación en progreso",
+		"message": "Hay una exportación en curso.",
+		"detail": "¿Continuar exportando en segundo plano? El archivo se guardará en tu carpeta de Descargas. Recibirás una notificación cuando termine.",
+		"continueInBackground": "Continuar en segundo plano",
+		"cancelAndClose": "Cancelar exportación y cerrar",
+		"completeNotificationTitle": "Exportación completa",
+		"completeNotificationBody": "{{format}} guardado en {{filename}}"
+	},
 	"fileDialogs": {
 		"saveGif": "Guardar GIF exportado",
 		"saveVideo": "Guardar video exportado",

--- a/src/i18n/locales/zh-CN/dialogs.json
+++ b/src/i18n/locales/zh-CN/dialogs.json
@@ -53,6 +53,15 @@
 		"saveProject": "保存项目…",
 		"saveProjectAs": "项目另存为…"
 	},
+	"exportInBackground": {
+		"title": "正在导出",
+		"message": "当前正在执行导出操作。",
+		"detail": "是否在后台继续导出？文件将保存到您的下载文件夹，完成后您将收到通知。",
+		"continueInBackground": "在后台继续",
+		"cancelAndClose": "取消导出并关闭",
+		"completeNotificationTitle": "导出完成",
+		"completeNotificationBody": "{{format}} 已保存至 {{filename}}"
+	},
 	"fileDialogs": {
 		"saveGif": "保存导出的 GIF",
 		"saveVideo": "保存导出的视频",

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -160,14 +160,14 @@ export class GifExporter {
 			const WORKER_COUNT = Math.max(1, Math.min(8, cores - 1));
 			this.gif = new GIF({
 				workers: WORKER_COUNT,
-				quality: 10,
+				quality: 1,
 				width: this.config.width,
 				height: this.config.height,
 				workerScript: GIF_WORKER_URL,
 				repeat,
 				background: "#000000",
 				transparent: null,
-				dither: "FloydSteinberg",
+				dither: false,
 			});
 
 			// Calculate effective duration and frame count (excluding trim regions)

--- a/src/lib/exporter/types.ts
+++ b/src/lib/exporter/types.ts
@@ -32,9 +32,9 @@ export type ExportQuality = "medium" | "good" | "source";
 // GIF Export Types
 export type ExportFormat = "mp4" | "gif";
 
-export type GifFrameRate = 15 | 20 | 25 | 30;
+export type GifFrameRate = 5 | 10 | 15 | 20 | 25 | 30;
 
-export type GifSizePreset = "medium" | "large" | "original";
+export type GifSizePreset = "small" | "medium" | "large" | "original";
 
 export interface GifExportConfig {
 	frameRate: GifFrameRate;
@@ -53,12 +53,15 @@ export interface ExportSettings {
 }
 
 export const GIF_SIZE_PRESETS: Record<GifSizePreset, { maxHeight: number; label: string }> = {
+	small: { maxHeight: 480, label: "Small (480p)" },
 	medium: { maxHeight: 720, label: "Medium (720p)" },
 	large: { maxHeight: 1080, label: "Large (1080p)" },
 	original: { maxHeight: Infinity, label: "Original" },
 };
 
 export const GIF_FRAME_RATES: { value: GifFrameRate; label: string }[] = [
+	{ value: 5, label: "5 FPS - Smallest file" },
+	{ value: 10, label: "10 FPS - Small file" },
 	{ value: 15, label: "15 FPS - Balanced" },
 	{ value: 20, label: "20 FPS - Smooth" },
 	{ value: 25, label: "25 FPS - Very smooth" },
@@ -66,7 +69,7 @@ export const GIF_FRAME_RATES: { value: GifFrameRate; label: string }[] = [
 ];
 
 // Valid frame rates for validation
-export const VALID_GIF_FRAME_RATES: readonly GifFrameRate[] = [15, 20, 25, 30] as const;
+export const VALID_GIF_FRAME_RATES: readonly GifFrameRate[] = [5, 10, 15, 20, 25, 30] as const;
 
 export function isValidGifFrameRate(rate: number): rate is GifFrameRate {
 	return VALID_GIF_FRAME_RATES.includes(rate as GifFrameRate);


### PR DESCRIPTION
## Summary

When the user closes the editor window while an **MP4 or GIF export is running**, a native dialog now intercepts the close and offers three choices:

- **Continue in Background** — hides the editor window and lets the export finish silently
- **Cancel Export & Close** — cancels the running export and closes the window
- **Cancel** — keeps the window open (no change)

When a background export completes, the file is **auto-saved to the Downloads folder** and a **system notification** fires showing the filename. Clicking the notification **reveals the file in the file manager**.

> **Platform:** Linux (initial implementation). The tray icon keeps the app alive so the user can reopen the editor at any time.

---

## Changes

### Electron (main process)
- **`electron/main.ts`**: added `editorIsExporting` flag; IPC listener for `set-is-exporting`; editor window `close` handler now shows the export-in-progress dialog and sends `background-export-ready` / `cancel-export-and-close` IPC events accordingly
- **`electron/ipc/handlers.ts`**: two new handlers — `save-exported-video-to-path` (silent file write, no dialog) and `send-export-notification` (Electron `Notification` with click-to-reveal); added `Notification` to electron imports

### Preload bridge
- **`electron/preload.ts`**: exposed six new `electronAPI` methods: `setIsExporting`, `saveExportedVideoToPath`, `sendExportNotification`, `onBackgroundExportReady`, `onCancelExportAndClose`, `exportCancelledDone`
- **`electron/electron-env.d.ts`**: TypeScript declarations for all six new methods

### Renderer
- **`src/components/video-editor/VideoEditor.tsx`**:
  - Added `backgroundExportDirRef` ref to hold the Downloads path when running headlessly
  - Calls `window.electronAPI.setIsExporting(true/false)` around every export to keep main process in sync
  - Registers `onBackgroundExportReady` listener (stores the downloads dir) and `onCancelExportAndClose` listener (cancels the exporter and ACKs)
  - Both the GIF and MP4 save paths check `backgroundExportDirRef.current` — if set, they auto-save via `saveExportedVideoToPath` + `sendExportNotification` instead of showing the save dialog
  - `handleCancelExport` also notifies the main process immediately

### i18n
- **`en/dialogs.json`**, **`es/dialogs.json`**, **`zh-CN/dialogs.json`**: new `exportInBackground` translation namespace

---

## Testing

1. Start an MP4 or GIF export (Settings panel → Export button)
2. While the progress bar is running, click the window close button
3. Verify the **"Export in Progress"** dialog appears with all three options
4. Choose **"Continue in Background"** → window closes, export keeps running
5. Wait for completion → system notification appears with filename
6. Click the notification → file manager opens at the Downloads folder
7. Repeat with **"Cancel Export & Close"** → export stops, window closes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continue video exports in background when closing the app; option to continue or cancel-and-close.
  * Exports can auto-save to Downloads and trigger clickable completion notifications with format/filename.
  * Multilingual dialog text added (en/es/zh-CN).

* **Changes**
  * GIF exports: new smaller frame-rate options (5/10 FPS), default lowered to 10 FPS, new "Small (480p)" size, optimized GIF output for smaller files, and adjusted encoder quality/dithering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->