### PR TITLE
fix: use correct locale keys in TutorialHelp component (fixes #348)

### DIFF
--- a/src/components/video-editor/TutorialHelp.tsx
+++ b/src/components/video-editor/TutorialHelp.tsx
@@ -37,11 +37,10 @@ export function TutorialHelp() {
 					{/* Explanation */}
 					<div className="bg-white/5 rounded-lg p-4 border border-white/5">
 						<p className="text-slate-300 leading-relaxed">
-							{t("tutorial.explanationBefore")}
-							<span className="text-[#ef4444] font-bold"> {t("tutorial.remove")}</span>
-							{t("tutorial.explanationMiddle")}
-							<span className="text-[#ef4444] font-bold"> {t("tutorial.covered")}</span>
-							{t("tutorial.explanationAfter")}
+							{t("tutorial.explanation")}
+							<span className="text-[#ef4444] font-bold"> {t("tutorial.explanationRemove")}</span>
+							<span className="text-[#ef4444] font-bold"> {t("tutorial.explanationCovered")}</span>
+							{t("tutorial.explanationEnd")}
 						</p>
 					</div>
 					{/* Visual Illustration */}
@@ -115,11 +114,7 @@ export function TutorialHelp() {
 					<div className="grid grid-cols-2 gap-4">
 						<div className="p-3 rounded bg-white/5 border border-white/5">
 							<div className="text-[#ef4444] font-bold mb-1">{t("tutorial.step1Title")}</div>
-							<p className="text-xs text-slate-400">
-								{t("tutorial.step1DescriptionBefore")}
-								<kbd className="bg-white/10 px-1 rounded text-slate-300">T</kbd>
-								{t("tutorial.step1DescriptionAfter")}
-							</p>
+							<p className="text-xs text-slate-400">{t("tutorial.step1Description")}</p>
 						</div>
 						<div className="p-3 rounded bg-white/5 border border-white/5">
 							<div className="text-[#ef4444] font-bold mb-1">{t("tutorial.step2Title")}</div>


### PR DESCRIPTION
## Summary

Fixes **#348** — i18n keys displayed instead of translated text in the 'How Trimming Works' modal on Windows 11.

## Root Cause

 called translation keys that **do not exist** in any locale file:

| Broken key | Used in component |
|---|---|
| `tutorial.explanationBefore` | Explanation paragraph |
| `tutorial.explanationMiddle` | Explanation paragraph |
| `tutorial.explanationAfter` | Explanation paragraph |
| `tutorial.remove` | Explanation paragraph |
| `tutorial.covered` | Explanation paragraph |
| `tutorial.step1DescriptionBefore` | Step 1 description |
| `tutorial.step1DescriptionAfter` | Step 1 description |

The i18n loader's fallback returns the key itself when no translation is found, so users see literal strings like `dialogs.tutorial.explanationBefore` instead of readable text.

## Fix

Replace the non-existent key chain with keys that **already exist** in all locale files (en, zh-CN, es):

- `tutorial.explanation` + `tutorial.explanationRemove` + `tutorial.explanationCovered` + `tutorial.explanationEnd`
- `tutorial.step1Description` (instead of split Before/After keys)

## Files Changed

- `src/components/video-editor/TutorialHelp.tsx` — updated `t()` calls
- No locale file changes needed — all required keys already exist

## Verification

`npx tsc --noEmit` passes with no errors.

Closes #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined translation string organization in the tutorial help component for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->