### PR TITLE
feat(security): exfiltration prevention, CSP & macOS hardening

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -29,7 +29,9 @@
   "publish": [{"provider": "github"}],
 
   "mac": {
-    "hardenedRuntime": false,
+    "hardenedRuntime": true,
+    "entitlements": "entitlements.mac.plist",
+    "entitlementsInherit": "entitlements.mac.inherit.plist",
     "target": [
       {
         "target": "dmg",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -218,6 +218,28 @@ function isTrustedMediaPath(filePath: string): boolean {
 	return trustedRoots.some((root) => normalized === root || normalized.startsWith(root + path.sep));
 }
 
+async function isTrustedMediaPathRealpath(filePath: string): Promise<boolean> {
+	if (!isTrustedMediaPath(filePath)) {
+		return false;
+	}
+	try {
+		const realTarget = await fs.realpath(filePath);
+		return isTrustedMediaPath(realTarget);
+	} catch {
+		// File doesn't exist yet (write path) or inaccessible — fall back to logical check
+		return isTrustedMediaPath(filePath);
+	}
+}
+
+function sanitizeFileName(fileName: string): string {
+	// Strip any path separators and parent-directory references to prevent traversal
+	const baseName = path.basename(fileName);
+	if (!baseName || baseName === "." || baseName === "..") {
+		throw new Error("Invalid file name");
+	}
+	return baseName;
+}
+
 function isAllowedExternalUrl(url: string): boolean {
 	if (!url || typeof url !== "string") {
 		return false;
@@ -247,6 +269,10 @@ async function loadRecordedSessionForVideoPath(
 ): Promise<RecordingSession | null> {
 	const normalizedVideoPath = normalizeVideoSourcePath(videoPath);
 	if (!normalizedVideoPath) {
+		return null;
+	}
+
+	if (!isTrustedMediaPath(normalizedVideoPath)) {
 		return null;
 	}
 
@@ -286,12 +312,14 @@ async function storeRecordedSessionFiles(payload: StoreRecordedSessionInput) {
 		typeof payload.createdAt === "number" && Number.isFinite(payload.createdAt)
 			? payload.createdAt
 			: Date.now();
-	const screenVideoPath = resolveRecordingOutputPath(payload.screen.fileName);
+	const safeScreenFileName = sanitizeFileName(payload.screen.fileName);
+	const screenVideoPath = path.join(RECORDINGS_DIR, safeScreenFileName);
 	await fs.writeFile(screenVideoPath, Buffer.from(payload.screen.videoData));
 
 	let webcamVideoPath: string | undefined;
 	if (payload.webcam) {
-		webcamVideoPath = resolveRecordingOutputPath(payload.webcam.fileName);
+		const safeWebcamFileName = sanitizeFileName(payload.webcam.fileName);
+		webcamVideoPath = path.join(RECORDINGS_DIR, safeWebcamFileName);
 		await fs.writeFile(webcamVideoPath, Buffer.from(payload.webcam.videoData));
 	}
 
@@ -517,7 +545,7 @@ export function registerIpcHandlers(
 				return { success: false, message: "Invalid file path" };
 			}
 
-			if (!isTrustedMediaPath(normalizedPath)) {
+			if (!(await isTrustedMediaPathRealpath(normalizedPath))) {
 				return {
 					success: false,
 					message: "Access denied: path is outside trusted media directories",
@@ -568,11 +596,7 @@ export function registerIpcHandlers(
 			return { success: true, samples: [] };
 		}
 
-		if (!isPathAllowed(targetVideoPath)) {
-			console.warn(
-				"[get-cursor-telemetry] Rejected path outside allowed directories:",
-				targetVideoPath,
-			);
+		if (!isTrustedMediaPath(targetVideoPath)) {
 			return { success: true, samples: [] };
 		}
 
@@ -909,13 +933,15 @@ export function registerIpcHandlers(
 			: { success: false };
 	});
 
-	ipcMain.handle("set-current-video-path", async (_, path: string) => {
-		const normalizedPath = normalizeVideoSourcePath(path);
-		if (!normalizedPath || !isPathAllowed(normalizedPath)) {
-			return { success: false, message: "Video path has not been approved" };
+	ipcMain.handle("set-current-video-path", async (_, videoPath: string) => {
+		const normalizedVideoPath = normalizeVideoSourcePath(videoPath);
+		if (!normalizedVideoPath || !isTrustedMediaPath(normalizedVideoPath)) {
+			return {
+				success: false,
+				message: "Access denied: path is outside trusted media directories",
+			};
 		}
-
-		const restoredSession = await loadRecordedSessionForVideoPath(normalizedPath);
+		const restoredSession = await loadRecordedSessionForVideoPath(videoPath);
 		if (restoredSession) {
 			// Approve all media paths from the restored session so they can be read later
 			approveFilePath(restoredSession.screenVideoPath);
@@ -925,7 +951,7 @@ export function registerIpcHandlers(
 			setCurrentRecordingSessionState(restoredSession);
 		} else {
 			setCurrentRecordingSessionState({
-				screenVideoPath: normalizedPath,
+				screenVideoPath: normalizedVideoPath,
 				createdAt: Date.now(),
 			});
 		}

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -203,6 +203,33 @@ function isTrustedProjectPath(filePath?: string | null) {
 	return normalizePath(filePath) === normalizePath(currentProjectPath);
 }
 
+function isTrustedMediaPath(filePath: string): boolean {
+	if (!filePath || typeof filePath !== "string") {
+		return false;
+	}
+	const normalized = normalizePath(filePath);
+
+	const trustedRoots: string[] = [normalizePath(RECORDINGS_DIR)];
+
+	if (currentProjectPath) {
+		trustedRoots.push(normalizePath(path.dirname(currentProjectPath)));
+	}
+
+	return trustedRoots.some((root) => normalized === root || normalized.startsWith(root + path.sep));
+}
+
+function isAllowedExternalUrl(url: string): boolean {
+	if (!url || typeof url !== "string") {
+		return false;
+	}
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === "https:" || parsed.protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
 function setCurrentRecordingSessionState(session: RecordingSession | null) {
 	currentRecordingSession = session;
 }
@@ -490,12 +517,11 @@ export function registerIpcHandlers(
 				return { success: false, message: "Invalid file path" };
 			}
 
-			if (!isPathAllowed(normalizedPath)) {
-				console.warn(
-					"[read-binary-file] Rejected path outside allowed directories:",
-					normalizedPath,
-				);
-				return { success: false, message: "Access denied: path outside allowed directories" };
+			if (!isTrustedMediaPath(normalizedPath)) {
+				return {
+					success: false,
+					message: "Access denied: path is outside trusted media directories",
+				};
 			}
 
 			const data = await fs.readFile(normalizedPath);
@@ -599,6 +625,9 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("open-external-url", async (_, url: string) => {
 		try {
+			if (!isAllowedExternalUrl(url)) {
+				return { success: false, error: "URL scheme not allowed" };
+			}
 			await shell.openExternal(url);
 			return { success: true };
 		} catch (error) {
@@ -707,7 +736,12 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("reveal-in-folder", async (_, filePath: string) => {
 		try {
-			// shell.showItemInFolder doesn't return a value, it throws on error
+			if (!isTrustedMediaPath(filePath)) {
+				return {
+					success: false,
+					error: "Access denied: path is outside trusted media directories",
+				};
+			}
 			shell.showItemInFolder(filePath);
 			return { success: true };
 		} catch (error) {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -24,143 +24,7 @@ import { RECORDINGS_DIR } from "../main";
 const PROJECT_FILE_EXTENSION = "openscreen";
 const SHORTCUTS_FILE = path.join(app.getPath("userData"), "shortcuts.json");
 const RECORDING_SESSION_SUFFIX = ".session.json";
-const ALLOWED_IMPORT_VIDEO_EXTENSIONS = new Set([".webm", ".mp4", ".mov", ".avi", ".mkv"]);
-
-/**
- * Paths explicitly approved by the user via file picker dialogs or project loads.
- * These are added at runtime when the user selects files from outside the default directories.
- */
-const approvedPaths = new Set<string>();
-
-function approveFilePath(filePath: string): void {
-	approvedPaths.add(path.resolve(filePath));
-}
-
-function getAllowedReadDirs(): string[] {
-	return [RECORDINGS_DIR];
-}
-
-function isPathWithinDir(filePath: string, dirPath: string): boolean {
-	const resolved = path.resolve(filePath);
-	const resolvedDir = path.resolve(dirPath);
-	return resolved === resolvedDir || resolved.startsWith(resolvedDir + path.sep);
-}
-
-function isPathAllowed(filePath: string): boolean {
-	const resolved = path.resolve(filePath);
-	if (approvedPaths.has(resolved)) return true;
-	return getAllowedReadDirs().some((dir) => isPathWithinDir(resolved, dir));
-}
-
-function hasAllowedImportVideoExtension(filePath: string): boolean {
-	return ALLOWED_IMPORT_VIDEO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
-}
-
-async function approveReadableVideoPath(
-	filePath?: string | null,
-	trustedDirs?: string[],
-): Promise<string | null> {
-	const normalizedPath = normalizeVideoSourcePath(filePath);
-	if (!normalizedPath) {
-		return null;
-	}
-
-	if (isPathAllowed(normalizedPath)) {
-		return normalizedPath;
-	}
-
-	if (!hasAllowedImportVideoExtension(normalizedPath)) {
-		return null;
-	}
-
-	// When called with trustedDirs (e.g. from project load), only auto-approve
-	// paths within those directories. This prevents malicious project files from
-	// approving reads to arbitrary filesystem locations.
-	if (trustedDirs) {
-		const resolved = path.resolve(normalizedPath);
-		const withinTrusted = trustedDirs.some((dir) => isPathWithinDir(resolved, dir));
-		if (!withinTrusted) {
-			return null;
-		}
-	}
-
-	try {
-		const stats = await fs.stat(normalizedPath);
-		if (!stats.isFile()) {
-			return null;
-		}
-	} catch {
-		return null;
-	}
-
-	approveFilePath(normalizedPath);
-	return normalizedPath;
-}
-
-function resolveRecordingOutputPath(fileName: string): string {
-	const trimmed = fileName.trim();
-	if (!trimmed) {
-		throw new Error("Invalid recording file name");
-	}
-
-	const parsedPath = path.parse(trimmed);
-	const hasTraversalSegments = trimmed.split(/[\\/]+/).some((segment) => segment === "..");
-	const isNestedPath =
-		parsedPath.dir !== "" ||
-		path.isAbsolute(trimmed) ||
-		trimmed.includes("/") ||
-		trimmed.includes("\\");
-	if (hasTraversalSegments || isNestedPath || parsedPath.base !== trimmed) {
-		throw new Error("Recording file name must not contain path segments");
-	}
-
-	return path.join(RECORDINGS_DIR, parsedPath.base);
-}
-
-async function getApprovedProjectSession(
-	project: unknown,
-	projectFilePath?: string,
-): Promise<RecordingSession | null> {
-	if (!project || typeof project !== "object") {
-		return null;
-	}
-
-	const rawProject = project as { media?: unknown; videoPath?: unknown };
-	const media: ProjectMedia | null =
-		normalizeProjectMedia(rawProject.media) ??
-		(typeof rawProject.videoPath === "string"
-			? {
-					screenVideoPath: normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
-				}
-			: null);
-
-	if (!media) {
-		return null;
-	}
-
-	// Only auto-approve media paths within the project's directory or RECORDINGS_DIR.
-	// This prevents crafted project files from approving reads to arbitrary locations.
-	const trustedDirs = [RECORDINGS_DIR];
-	if (projectFilePath) {
-		trustedDirs.push(path.dirname(path.resolve(projectFilePath)));
-	}
-
-	const screenVideoPath = await approveReadableVideoPath(media.screenVideoPath, trustedDirs);
-	if (!screenVideoPath) {
-		throw new Error("Project references an invalid or unsupported screen video path");
-	}
-
-	const webcamVideoPath = media.webcamVideoPath
-		? await approveReadableVideoPath(media.webcamVideoPath, trustedDirs)
-		: undefined;
-	if (media.webcamVideoPath && !webcamVideoPath) {
-		throw new Error("Project references an invalid or unsupported webcam video path");
-	}
-
-	return webcamVideoPath
-		? { screenVideoPath, webcamVideoPath, createdAt: Date.now() }
-		: { screenVideoPath, createdAt: Date.now() };
-}
+const ALLOWED_EXTERNAL_DOMAINS: string[] = ["github.com"];
 
 type SelectedSource = {
 	name: string;
@@ -652,6 +516,15 @@ export function registerIpcHandlers(
 			if (!isAllowedExternalUrl(url)) {
 				return { success: false, error: "URL scheme not allowed" };
 			}
+
+			const parsedUrl = new URL(url);
+			const isAllowedDomain = ALLOWED_EXTERNAL_DOMAINS.some(
+				(domain) => parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`),
+			);
+			if (!isAllowedDomain) {
+				return { success: false, error: "Domain not in allowlist" };
+			}
+
 			await shell.openExternal(url);
 			return { success: true };
 		} catch (error) {
@@ -774,7 +647,14 @@ export function registerIpcHandlers(
 			// This might happen if the file was moved or deleted after export,
 			// or if the path is somehow invalid for showItemInFolder
 			try {
-				const openPathResult = await shell.openPath(path.dirname(filePath));
+				const dir = path.dirname(filePath);
+				if (!isTrustedMediaPath(dir)) {
+					return {
+						success: false,
+						error: "Fallback directory is outside trusted media directories",
+					};
+				}
+				const openPathResult = await shell.openPath(dir);
 				if (openPathResult) {
 					// openPath returned an error message
 					return { success: false, error: openPathResult };

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -648,7 +648,7 @@ export function registerIpcHandlers(
 			// or if the path is somehow invalid for showItemInFolder
 			try {
 				const dir = path.dirname(filePath);
-				if (!isTrustedMediaPath(dir)) {
+				if (!(await isTrustedMediaPathRealpath(dir))) {
 					return {
 						success: false,
 						error: "Fallback directory is outside trusted media directories",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -25,6 +25,115 @@ const PROJECT_FILE_EXTENSION = "openscreen";
 const SHORTCUTS_FILE = path.join(app.getPath("userData"), "shortcuts.json");
 const RECORDING_SESSION_SUFFIX = ".session.json";
 const ALLOWED_EXTERNAL_DOMAINS: string[] = ["github.com"];
+const ALLOWED_IMPORT_VIDEO_EXTENSIONS = new Set([".webm", ".mp4", ".mov", ".avi", ".mkv"]);
+
+/**
+ * Paths explicitly approved by the user via file picker dialogs or project loads.
+ * These are added at runtime when the user selects files from outside the default directories.
+ */
+const approvedPaths = new Set<string>();
+
+function approveFilePath(filePath: string): void {
+	approvedPaths.add(path.resolve(filePath));
+}
+
+function isPathWithinDir(filePath: string, dirPath: string): boolean {
+	const resolved = path.resolve(filePath);
+	const resolvedDir = path.resolve(dirPath);
+	return resolved === resolvedDir || resolved.startsWith(resolvedDir + path.sep);
+}
+
+function isPathAllowed(filePath: string): boolean {
+	const resolved = path.resolve(filePath);
+	if (approvedPaths.has(resolved)) return true;
+	return [RECORDINGS_DIR].some((dir) => isPathWithinDir(resolved, dir));
+}
+
+function hasAllowedImportVideoExtension(filePath: string): boolean {
+	return ALLOWED_IMPORT_VIDEO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+async function approveReadableVideoPath(
+	filePath?: string | null,
+	trustedDirs?: string[],
+): Promise<string | null> {
+	const normalizedPath = normalizeVideoSourcePath(filePath);
+	if (!normalizedPath) {
+		return null;
+	}
+
+	if (isPathAllowed(normalizedPath)) {
+		return normalizedPath;
+	}
+
+	if (!hasAllowedImportVideoExtension(normalizedPath)) {
+		return null;
+	}
+
+	if (trustedDirs) {
+		const resolved = path.resolve(normalizedPath);
+		const withinTrusted = trustedDirs.some((dir) => isPathWithinDir(resolved, dir));
+		if (!withinTrusted) {
+			return null;
+		}
+	}
+
+	try {
+		const stats = await fs.stat(normalizedPath);
+		if (!stats.isFile()) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	approveFilePath(normalizedPath);
+	return normalizedPath;
+}
+
+async function getApprovedProjectSession(
+	project: unknown,
+	projectFilePath?: string,
+): Promise<RecordingSession | null> {
+	if (!project || typeof project !== "object") {
+		return null;
+	}
+
+	const rawProject = project as { media?: unknown; videoPath?: unknown };
+	const media: ProjectMedia | null =
+		normalizeProjectMedia(rawProject.media) ??
+		(typeof rawProject.videoPath === "string"
+			? {
+					screenVideoPath: normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
+				}
+			: null);
+
+	if (!media) {
+		return null;
+	}
+
+	// Only auto-approve media paths within the project's directory or RECORDINGS_DIR.
+	const trustedDirs = [RECORDINGS_DIR];
+	if (projectFilePath) {
+		trustedDirs.push(path.dirname(path.resolve(projectFilePath)));
+	}
+
+	const screenVideoPath = await approveReadableVideoPath(media.screenVideoPath, trustedDirs);
+	if (!screenVideoPath) {
+		throw new Error("Project references an invalid or unsupported screen video path");
+	}
+
+	const webcamVideoPath = media.webcamVideoPath
+		? await approveReadableVideoPath(media.webcamVideoPath, trustedDirs)
+		: undefined;
+	if (media.webcamVideoPath && !webcamVideoPath) {
+		throw new Error("Project references an invalid or unsupported webcam video path");
+	}
+
+	return webcamVideoPath
+		? { screenVideoPath, webcamVideoPath, createdAt: Date.now() }
+		: { screenVideoPath, createdAt: Date.now() };
+}
 
 type SelectedSource = {
 	name: string;
@@ -574,6 +683,7 @@ export function registerIpcHandlers(
 			}
 
 			await fs.writeFile(result.filePath, Buffer.from(videoData));
+			approveFilePath(result.filePath);
 
 			return {
 				success: true,
@@ -633,7 +743,7 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("reveal-in-folder", async (_, filePath: string) => {
 		try {
-			if (!isTrustedMediaPath(filePath)) {
+			if (!isPathAllowed(filePath)) {
 				return {
 					success: false,
 					error: "Access denied: path is outside trusted media directories",
@@ -815,7 +925,7 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("set-current-video-path", async (_, videoPath: string) => {
 		const normalizedVideoPath = normalizeVideoSourcePath(videoPath);
-		if (!normalizedVideoPath || !isTrustedMediaPath(normalizedVideoPath)) {
+		if (!normalizedVideoPath || !isPathAllowed(normalizedVideoPath)) {
 			return {
 				success: false,
 				message: "Access denied: path is outside trusted media directories",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,12 @@ import {
 } from "electron";
 import { mainT, setMainLocale } from "./i18n";
 import { registerIpcHandlers } from "./ipc/handlers";
-import { createEditorWindow, createHudOverlayWindow, createSourceSelectorWindow } from "./windows";
+import {
+	createEditorWindow,
+	createHudOverlayWindow,
+	createSourceSelectorWindow,
+	registerMediaProtocol,
+} from "./windows";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -336,6 +341,9 @@ app.on("activate", () => {
 
 // Register all IPC handlers when app is ready
 app.whenReady().then(async () => {
+	// Register custom protocol for safe local media loading
+	registerMediaProtocol();
+
 	// Allow microphone/media permission checks
 	session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
 		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -344,6 +344,30 @@ app.whenReady().then(async () => {
 	// Register custom protocol for safe local media loading
 	registerMediaProtocol();
 
+	// Enforce Content Security Policy on all renderer windows
+	const VITE_DEV_URL = process.env["VITE_DEV_SERVER_URL"];
+	const cspDirectives = [
+		"default-src 'self' app-media:",
+		"script-src 'self'" + (VITE_DEV_URL ? ` ${VITE_DEV_URL}` : ""),
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		"font-src 'self' https://fonts.gstatic.com",
+		"img-src 'self' app-media: data: blob:",
+		"media-src 'self' app-media: blob:",
+		"connect-src 'self' https://fonts.googleapis.com" +
+			(VITE_DEV_URL ? ` ${VITE_DEV_URL} ws://localhost:*` : ""),
+		"frame-src 'none'",
+		"object-src 'none'",
+	].join("; ");
+
+	session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+		callback({
+			responseHeaders: {
+				...details.responseHeaders,
+				"Content-Security-Policy": [cspDirectives],
+			},
+		});
+	});
+
 	// Allow microphone/media permission checks
 	session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
 		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { app, BrowserWindow, ipcMain, net, protocol, screen } from "electron";
@@ -11,9 +12,8 @@ const RENDERER_DIST = path.join(APP_ROOT, "dist");
 const HEADLESS = process.env["HEADLESS"] === "true";
 
 export function registerMediaProtocol() {
-	protocol.handle("app-media", (request) => {
+	protocol.handle("app-media", async (request) => {
 		const url = new URL(request.url);
-		// The pathname is the absolute file path, percent-encoded
 		let filePath: string;
 		try {
 			filePath = decodeURIComponent(url.pathname);
@@ -34,17 +34,33 @@ export function registerMediaProtocol() {
 				: path.join(APP_ROOT, "public", "assets"),
 		);
 
-		const isTrusted =
-			resolved === recordingsRoot ||
-			resolved.startsWith(recordingsRoot + path.sep) ||
-			resolved === assetsRoot ||
-			resolved.startsWith(assetsRoot + path.sep);
+		function isUnderTrustedRoot(candidate: string): boolean {
+			return (
+				candidate === recordingsRoot ||
+				candidate.startsWith(recordingsRoot + path.sep) ||
+				candidate === assetsRoot ||
+				candidate.startsWith(assetsRoot + path.sep)
+			);
+		}
 
-		if (!isTrusted) {
+		// Check logical path first
+		if (!isUnderTrustedRoot(resolved)) {
 			return new Response("Forbidden", { status: 403 });
 		}
 
-		return net.fetch(pathToFileURL(resolved).toString());
+		// Resolve symlinks to prevent escaping trusted roots via symlink
+		let realResolved: string;
+		try {
+			realResolved = await fs.realpath(resolved);
+		} catch {
+			return new Response("Not Found", { status: 404 });
+		}
+
+		if (!isUnderTrustedRoot(realResolved)) {
+			return new Response("Forbidden", { status: 403 });
+		}
+
+		return net.fetch(pathToFileURL(realResolved).toString());
 	});
 }
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { BrowserWindow, ipcMain, screen } from "electron";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { app, BrowserWindow, ipcMain, net, protocol, screen } from "electron";
+import { RECORDINGS_DIR } from "./main";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -8,6 +9,44 @@ const APP_ROOT = path.join(__dirname, "..");
 const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];
 const RENDERER_DIST = path.join(APP_ROOT, "dist");
 const HEADLESS = process.env["HEADLESS"] === "true";
+
+export function registerMediaProtocol() {
+	protocol.handle("app-media", (request) => {
+		const url = new URL(request.url);
+		// The pathname is the absolute file path, percent-encoded
+		let filePath: string;
+		try {
+			filePath = decodeURIComponent(url.pathname);
+		} catch {
+			return new Response("Invalid path", { status: 400 });
+		}
+
+		// On Windows, pathname starts with / before drive letter: /C:/...
+		if (process.platform === "win32" && filePath.startsWith("/")) {
+			filePath = filePath.slice(1);
+		}
+
+		const resolved = path.resolve(filePath);
+		const recordingsRoot = path.resolve(RECORDINGS_DIR);
+		const assetsRoot = path.resolve(
+			app.isPackaged
+				? path.join(process.resourcesPath, "assets")
+				: path.join(APP_ROOT, "public", "assets"),
+		);
+
+		const isTrusted =
+			resolved === recordingsRoot ||
+			resolved.startsWith(recordingsRoot + path.sep) ||
+			resolved === assetsRoot ||
+			resolved.startsWith(assetsRoot + path.sep);
+
+		if (!isTrusted) {
+			return new Response("Forbidden", { status: 403 });
+		}
+
+		return net.fetch(pathToFileURL(resolved).toString());
+	});
+}
 
 let hudOverlayWindow: BrowserWindow | null = null;
 
@@ -97,7 +136,6 @@ export function createEditorWindow(): BrowserWindow {
 			preload: path.join(__dirname, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
-			webSecurity: false,
 			backgroundThrottling: false,
 		},
 	});

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -106,6 +106,20 @@ export function createHudOverlayWindow(): BrowserWindow {
 		},
 	});
 
+	// Block renderer-initiated popups
+	win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+	// Block renderer-initiated navigation to external URLs
+	win.webContents.on("will-navigate", (event, url) => {
+		const allowedOrigins = VITE_DEV_SERVER_URL
+			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
+			: ["file://", "app-media://"];
+		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
+		if (!isAllowed) {
+			event.preventDefault();
+		}
+	});
+
 	win.webContents.on("did-finish-load", () => {
 		win?.webContents.send("main-process-message", new Date().toLocaleString());
 	});
@@ -159,6 +173,20 @@ export function createEditorWindow(): BrowserWindow {
 	// Maximize the window by default
 	win.maximize();
 
+	// Block renderer-initiated popups
+	win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+	// Block renderer-initiated navigation to external URLs
+	win.webContents.on("will-navigate", (event, url) => {
+		const allowedOrigins = VITE_DEV_SERVER_URL
+			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
+			: ["file://", "app-media://"];
+		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
+		if (!isAllowed) {
+			event.preventDefault();
+		}
+	});
+
 	win.webContents.on("did-finish-load", () => {
 		win?.webContents.send("main-process-message", new Date().toLocaleString());
 	});
@@ -194,6 +222,20 @@ export function createSourceSelectorWindow(): BrowserWindow {
 			nodeIntegration: false,
 			contextIsolation: true,
 		},
+	});
+
+	// Block renderer-initiated popups
+	win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+	// Block renderer-initiated navigation to external URLs
+	win.webContents.on("will-navigate", (event, url) => {
+		const allowedOrigins = VITE_DEV_SERVER_URL
+			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
+			: ["file://", "app-media://"];
+		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
+		if (!isAllowed) {
+			event.preventDefault();
+		}
 	});
 
 	if (VITE_DEV_SERVER_URL) {

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -11,6 +11,24 @@ const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];
 const RENDERER_DIST = path.join(APP_ROOT, "dist");
 const HEADLESS = process.env["HEADLESS"] === "true";
 
+function isAllowedNavigation(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		// Allow app-media:// custom protocol
+		if (parsed.protocol === "app-media:") return true;
+		// Allow file:// only for local paths (not UNC/network)
+		if (parsed.protocol === "file:" && !parsed.hostname) return true;
+		// In dev mode, allow exact Vite dev server origin
+		if (VITE_DEV_SERVER_URL) {
+			const devOrigin = new URL(VITE_DEV_SERVER_URL).origin;
+			if (parsed.origin === devOrigin) return true;
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
 export function registerMediaProtocol() {
 	protocol.handle("app-media", async (request) => {
 		const url = new URL(request.url);
@@ -111,11 +129,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 
 	// Block renderer-initiated navigation to external URLs
 	win.webContents.on("will-navigate", (event, url) => {
-		const allowedOrigins = VITE_DEV_SERVER_URL
-			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
-			: ["file://", "app-media://"];
-		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
-		if (!isAllowed) {
+		if (!isAllowedNavigation(url)) {
 			event.preventDefault();
 		}
 	});
@@ -178,11 +192,7 @@ export function createEditorWindow(): BrowserWindow {
 
 	// Block renderer-initiated navigation to external URLs
 	win.webContents.on("will-navigate", (event, url) => {
-		const allowedOrigins = VITE_DEV_SERVER_URL
-			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
-			: ["file://", "app-media://"];
-		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
-		if (!isAllowed) {
+		if (!isAllowedNavigation(url)) {
 			event.preventDefault();
 		}
 	});
@@ -229,11 +239,7 @@ export function createSourceSelectorWindow(): BrowserWindow {
 
 	// Block renderer-initiated navigation to external URLs
 	win.webContents.on("will-navigate", (event, url) => {
-		const allowedOrigins = VITE_DEV_SERVER_URL
-			? [VITE_DEV_SERVER_URL, "file://", "app-media://"]
-			: ["file://", "app-media://"];
-		const isAllowed = allowedOrigins.some((origin) => url.startsWith(origin));
-		if (!isAllowed) {
+		if (!isAllowedNavigation(url)) {
 			event.preventDefault();
 		}
 	});

--- a/entitlements.mac.inherit.plist
+++ b/entitlements.mac.inherit.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' app-media:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' app-media: data: blob:; media-src 'self' app-media: blob:; connect-src 'self' https://fonts.googleapis.com; frame-src 'none'; object-src 'none';" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1146,10 +1146,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 						return;
 					}
 
-					// If it's an absolute web/http or file path, use as-is
+					// If it's an absolute web/http, file, or app-media path, use as-is
 					if (
 						wallpaper.startsWith("http") ||
 						wallpaper.startsWith("file://") ||
+						wallpaper.startsWith("app-media://") ||
 						wallpaper.startsWith("/")
 					) {
 						// If it's an absolute server path (starts with '/'), resolve via getAssetPath as well
@@ -1185,6 +1186,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const isImageUrl = Boolean(
 			resolvedWallpaper &&
 				(resolvedWallpaper.startsWith("file://") ||
+					resolvedWallpaper.startsWith("app-media://") ||
 					resolvedWallpaper.startsWith("http") ||
 					resolvedWallpaper.startsWith("/") ||
 					resolvedWallpaper.startsWith("data:")),

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -32,6 +32,7 @@ import {
 	getNativeAspectRatioValue,
 } from "@/utils/aspectRatioUtils";
 import { AnnotationOverlay } from "./AnnotationOverlay";
+import { isAllowedWallpaperValue, WALLPAPER_PATHS } from "./projectPersistence";
 import {
 	type AnnotationRegion,
 	type SpeedRegion,
@@ -1120,6 +1121,13 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 					if (!wallpaper) {
 						const def = await getAssetPath("wallpapers/wallpaper1.jpg");
 						if (mounted) setResolvedWallpaper(def);
+						return;
+					}
+
+					// Reject disallowed wallpaper values (e.g., external http URLs)
+					if (!isAllowedWallpaperValue(wallpaper)) {
+						const defaultPath = await getAssetPath(WALLPAPER_PATHS[0].replace(/^\//, ""));
+						if (mounted) setResolvedWallpaper(defaultPath);
 						return;
 					}
 

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -23,6 +23,38 @@ describe("projectPersistence media compatibility", () => {
 		});
 	});
 
+	it("rejects projects without valid media", () => {
+		const project = {
+			version: 1,
+			editor: {},
+		};
+		expect(validateProjectData(project)).toBe(false);
+		expect(resolveProjectMedia(project)).toBeNull();
+	});
+
+	it("rejects non-object candidates", () => {
+		expect(validateProjectData(null)).toBe(false);
+		expect(validateProjectData("string")).toBe(false);
+		expect(validateProjectData(42)).toBe(false);
+		expect(validateProjectData(undefined)).toBe(false);
+	});
+
+	it("rejects projects without version number", () => {
+		const project = {
+			videoPath: "/tmp/screen.webm",
+			editor: {},
+		};
+		expect(validateProjectData(project)).toBe(false);
+	});
+
+	it("rejects projects without editor state", () => {
+		const project = {
+			version: 1,
+			videoPath: "/tmp/screen.webm",
+		};
+		expect(validateProjectData(project)).toBe(false);
+	});
+
 	it("creates version 2 projects with explicit media", () => {
 		const project = createProjectData(
 			{

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -138,22 +138,37 @@ it("detects unsaved changes from differing snapshots", () => {
 });
 
 describe("isAllowedWallpaperValue", () => {
-	it("allows local asset paths", () => {
+	it("allows known wallpaper asset paths", () => {
 		expect(isAllowedWallpaperValue("/wallpapers/wallpaper1.jpg")).toBe(true);
-		expect(isAllowedWallpaperValue("/assets/bg.png")).toBe(true);
+		expect(isAllowedWallpaperValue("/wallpapers/wallpaper18.jpg")).toBe(true);
+		expect(isAllowedWallpaperValue("/wallpapers/custom.png")).toBe(true);
+		expect(isAllowedWallpaperValue("/wallpapers/bg.webp")).toBe(true);
+	});
+
+	it("rejects arbitrary local paths", () => {
+		expect(isAllowedWallpaperValue("/etc/passwd")).toBe(false);
+		expect(isAllowedWallpaperValue("/arbitrary/path")).toBe(false);
+		expect(isAllowedWallpaperValue("/%2e%2e/secret")).toBe(false);
+		expect(isAllowedWallpaperValue("/wallpapers/../../../etc/passwd")).toBe(false);
 	});
 
 	it("allows app-media:// URLs", () => {
 		expect(isAllowedWallpaperValue("app-media:///path/to/wallpaper.jpg")).toBe(true);
 	});
 
-	it("allows data: URIs", () => {
+	it("allows data: image URIs", () => {
 		expect(isAllowedWallpaperValue("data:image/png;base64,abc123")).toBe(true);
+		expect(isAllowedWallpaperValue("data:image/jpeg;base64,xyz")).toBe(true);
+	});
+
+	it("rejects non-image data: URIs", () => {
+		expect(isAllowedWallpaperValue("data:text/html,<script>alert(1)</script>")).toBe(false);
 	});
 
 	it("allows color hex values", () => {
 		expect(isAllowedWallpaperValue("#ff0000")).toBe(true);
 		expect(isAllowedWallpaperValue("#000")).toBe(true);
+		expect(isAllowedWallpaperValue("#aabbccdd")).toBe(true);
 	});
 
 	it("allows gradient strings", () => {

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -3,6 +3,7 @@ import {
 	createProjectData,
 	createProjectSnapshot,
 	hasProjectUnsavedChanges,
+	isAllowedWallpaperValue,
 	normalizeProjectEditor,
 	PROJECT_VERSION,
 	resolveProjectMedia,
@@ -134,4 +135,69 @@ it("detects unsaved changes from differing snapshots", () => {
 	expect(hasProjectUnsavedChanges(null, null)).toBe(false);
 	expect(hasProjectUnsavedChanges("same", "same")).toBe(false);
 	expect(hasProjectUnsavedChanges("current", "baseline")).toBe(true);
+});
+
+describe("isAllowedWallpaperValue", () => {
+	it("allows local asset paths", () => {
+		expect(isAllowedWallpaperValue("/wallpapers/wallpaper1.jpg")).toBe(true);
+		expect(isAllowedWallpaperValue("/assets/bg.png")).toBe(true);
+	});
+
+	it("allows app-media:// URLs", () => {
+		expect(isAllowedWallpaperValue("app-media:///path/to/wallpaper.jpg")).toBe(true);
+	});
+
+	it("allows data: URIs", () => {
+		expect(isAllowedWallpaperValue("data:image/png;base64,abc123")).toBe(true);
+	});
+
+	it("allows color hex values", () => {
+		expect(isAllowedWallpaperValue("#ff0000")).toBe(true);
+		expect(isAllowedWallpaperValue("#000")).toBe(true);
+	});
+
+	it("allows gradient strings", () => {
+		expect(isAllowedWallpaperValue("linear-gradient(to right, #000, #fff)")).toBe(true);
+		expect(isAllowedWallpaperValue("radial-gradient(circle, #000, #fff)")).toBe(true);
+	});
+
+	it("rejects http URLs", () => {
+		expect(isAllowedWallpaperValue("http://evil.com/image.jpg")).toBe(false);
+		expect(isAllowedWallpaperValue("https://evil.com/track?user=123")).toBe(false);
+	});
+
+	it("rejects other dangerous schemes", () => {
+		expect(isAllowedWallpaperValue("javascript:alert(1)")).toBe(false);
+		expect(isAllowedWallpaperValue("file:///etc/passwd")).toBe(false);
+		expect(isAllowedWallpaperValue("blob:https://example.com/uuid")).toBe(false);
+	});
+
+	it("rejects empty/invalid inputs", () => {
+		expect(isAllowedWallpaperValue("")).toBe(false);
+		expect(isAllowedWallpaperValue(null as unknown as string)).toBe(false);
+		expect(isAllowedWallpaperValue(undefined as unknown as string)).toBe(false);
+	});
+});
+
+describe("normalizeProjectEditor wallpaper sanitization", () => {
+	it("strips external HTTP wallpaper URLs and uses default", () => {
+		const result = normalizeProjectEditor({
+			wallpaper: "https://evil.com/tracking-pixel.png",
+		});
+		expect(result.wallpaper).toBe("/wallpapers/wallpaper1.jpg");
+	});
+
+	it("preserves valid local wallpaper paths", () => {
+		const result = normalizeProjectEditor({
+			wallpaper: "/wallpapers/wallpaper5.jpg",
+		});
+		expect(result.wallpaper).toBe("/wallpapers/wallpaper5.jpg");
+	});
+
+	it("preserves data: URI wallpapers", () => {
+		const result = normalizeProjectEditor({
+			wallpaper: "data:image/png;base64,iVBOR",
+		});
+		expect(result.wallpaper).toBe("data:image/png;base64,iVBOR");
+	});
 });

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -78,15 +78,18 @@ export function isAllowedWallpaperValue(wallpaper: string): boolean {
 	if (!wallpaper || typeof wallpaper !== "string") {
 		return false;
 	}
-	// Allow: local asset paths (/wallpapers/...), app-media:// URLs, data: URIs,
-	// color hex values (#...), gradients (linear-gradient(...), radial-gradient(...))
-	if (wallpaper.startsWith("/")) return true;
+	// Allow only known local wallpaper asset paths (no arbitrary / paths)
+	if (/^\/wallpapers\/[^/]+\.(jpg|jpeg|png|webp)$/i.test(wallpaper)) return true;
+	// Allow app-media:// URLs (validated by the custom protocol handler)
 	if (wallpaper.startsWith("app-media://")) return true;
-	if (wallpaper.startsWith("data:")) return true;
-	if (wallpaper.startsWith("#")) return true;
-	if (wallpaper.startsWith("linear-gradient")) return true;
-	if (wallpaper.startsWith("radial-gradient")) return true;
-	// Reject everything else: http://, https://, file://, javascript:, blob:, etc.
+	// Allow data: URIs (user-uploaded custom wallpapers)
+	if (wallpaper.startsWith("data:image/")) return true;
+	// Allow color hex values
+	if (/^#[0-9a-fA-F]{3,8}$/.test(wallpaper)) return true;
+	// Allow CSS gradients
+	if (wallpaper.startsWith("linear-gradient(")) return true;
+	if (wallpaper.startsWith("radial-gradient(")) return true;
+	// Reject everything else
 	return false;
 }
 

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -74,6 +74,22 @@ function isFileUrl(value: string): boolean {
 	return /^file:\/\//i.test(value);
 }
 
+export function isAllowedWallpaperValue(wallpaper: string): boolean {
+	if (!wallpaper || typeof wallpaper !== "string") {
+		return false;
+	}
+	// Allow: local asset paths (/wallpapers/...), app-media:// URLs, data: URIs,
+	// color hex values (#...), gradients (linear-gradient(...), radial-gradient(...))
+	if (wallpaper.startsWith("/")) return true;
+	if (wallpaper.startsWith("app-media://")) return true;
+	if (wallpaper.startsWith("data:")) return true;
+	if (wallpaper.startsWith("#")) return true;
+	if (wallpaper.startsWith("linear-gradient")) return true;
+	if (wallpaper.startsWith("radial-gradient")) return true;
+	// Reject everything else: http://, https://, file://, javascript:, blob:, etc.
+	return false;
+}
+
 function encodePathSegments(pathname: string, keepWindowsDrive = false): string {
 	return pathname
 		.split("/")
@@ -327,7 +343,10 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 	const cropHeight = clamp(rawCropHeight, 0.01, 1 - cropY);
 
 	return {
-		wallpaper: typeof editor.wallpaper === "string" ? editor.wallpaper : WALLPAPER_PATHS[0],
+		wallpaper:
+			typeof editor.wallpaper === "string" && isAllowedWallpaperValue(editor.wallpaper)
+				? editor.wallpaper
+				: WALLPAPER_PATHS[0],
 		shadowIntensity: typeof editor.shadowIntensity === "number" ? editor.shadowIntensity : 0,
 		showBlur: typeof editor.showBlur === "boolean" ? editor.showBlur : false,
 		motionBlurAmount: isFiniteNumber(editor.motionBlurAmount)

--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+// These constants mirror the ones in useScreenRecorder.ts
+const BITRATE_4K = 45_000_000;
+const BITRATE_QHD = 28_000_000;
+const BITRATE_BASE = 18_000_000;
+const HIGH_FRAME_RATE_THRESHOLD = 60;
+const HIGH_FRAME_RATE_BOOST = 1.7;
+const FOUR_K_PIXELS = 3840 * 2160;
+const QHD_PIXELS = 2560 * 1440;
+
+// Replicate the fixed computeBitrate logic for testing
+function computeBitrate(width: number, height: number, frameRate: number) {
+	const pixels = width * height;
+	const highFrameRateBoost = frameRate >= HIGH_FRAME_RATE_THRESHOLD ? HIGH_FRAME_RATE_BOOST : 1;
+
+	if (pixels >= FOUR_K_PIXELS) {
+		return Math.round(BITRATE_4K * highFrameRateBoost);
+	}
+	if (pixels >= QHD_PIXELS) {
+		return Math.round(BITRATE_QHD * highFrameRateBoost);
+	}
+	return Math.round(BITRATE_BASE * highFrameRateBoost);
+}
+
+describe("computeBitrate", () => {
+	it("applies high frame rate boost only when frame rate meets threshold", () => {
+		const bitrate30fps = computeBitrate(1920, 1080, 30);
+		const bitrate60fps = computeBitrate(1920, 1080, 60);
+
+		expect(bitrate30fps).toBe(BITRATE_BASE); // No boost at 30fps
+		expect(bitrate60fps).toBe(Math.round(BITRATE_BASE * HIGH_FRAME_RATE_BOOST)); // Boost at 60fps
+		expect(bitrate60fps).toBeGreaterThan(bitrate30fps);
+	});
+
+	it("selects correct base bitrate for resolution tiers", () => {
+		const bitrate4k = computeBitrate(3840, 2160, 30);
+		const bitrateQhd = computeBitrate(2560, 1440, 30);
+		const bitrateHd = computeBitrate(1920, 1080, 30);
+
+		expect(bitrate4k).toBe(BITRATE_4K);
+		expect(bitrateQhd).toBe(BITRATE_QHD);
+		expect(bitrateHd).toBe(BITRATE_BASE);
+	});
+
+	it("does not apply boost below threshold frame rate", () => {
+		const bitrate59fps = computeBitrate(3840, 2160, 59);
+		expect(bitrate59fps).toBe(BITRATE_4K); // No boost
+	});
+});

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -531,14 +531,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					? { audioBitsPerSecond: systemAudioTrack ? AUDIO_BITRATE_SYSTEM : AUDIO_BITRATE_VOICE }
 					: {}),
 			});
-			screenRecorder.current.recorder.addEventListener(
-				"error",
-				() => {
-					setRecording(false);
-				},
-				{ once: true },
-			);
-
 			if (webcamStream.current) {
 				webcamRecorder.current = createRecorderHandle(webcamStream.current, {
 					mimeType,
@@ -559,6 +551,31 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			const activeWebcamRecorder = webcamRecorder.current;
 			const activeRecordingId = recordingId.current;
 			if (activeScreenRecorder) {
+				activeScreenRecorder.recorder.addEventListener(
+					"error",
+					() => {
+						if (screenRecorder.current === activeScreenRecorder) {
+							screenRecorder.current = null;
+						}
+						if (webcamRecorder.current === activeWebcamRecorder) {
+							webcamRecorder.current = null;
+						}
+						if (activeWebcamRecorder?.recorder.state === "recording") {
+							try {
+								activeWebcamRecorder.recorder.stop();
+							} catch {
+								// Webcam recorder may already be stopped.
+							}
+						}
+						teardownMedia();
+						setRecording(false);
+						window.electronAPI?.setRecordingState(false);
+						if (finalizingRecordingId.current === activeRecordingId) {
+							finalizingRecordingId.current = null;
+						}
+					},
+					{ once: true },
+				);
 				activeScreenRecorder.recorder.addEventListener(
 					"stop",
 					() => {

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -554,6 +554,8 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				activeScreenRecorder.recorder.addEventListener(
 					"error",
 					() => {
+						// Suppress auto-finalize to prevent the stop listener from racing this cleanup
+						allowAutoFinalize.current = false;
 						if (screenRecorder.current === activeScreenRecorder) {
 							screenRecorder.current = null;
 						}

--- a/src/lib/assetPath.ts
+++ b/src/lib/assetPath.ts
@@ -7,10 +7,6 @@ function encodeRelativeAssetPath(relativePath: string): string {
 		.join("/");
 }
 
-function ensureTrailingSlash(value: string): string {
-	return value.endsWith("/") ? value : `${value}/`;
-}
-
 export async function getAssetPath(relativePath: string): Promise<string> {
 	const encodedRelativePath = encodeRelativeAssetPath(relativePath);
 
@@ -28,7 +24,10 @@ export async function getAssetPath(relativePath: string): Promise<string> {
 			if (window.electronAPI && typeof window.electronAPI.getAssetBasePath === "function") {
 				const base = await window.electronAPI.getAssetBasePath();
 				if (base) {
-					return new URL(encodedRelativePath, ensureTrailingSlash(base)).toString();
+					// Convert file:// base to app-media:// for safe local loading
+					const baseUrl = new URL(base);
+					const mediaUrl = `app-media://${baseUrl.pathname}${encodedRelativePath}`;
+					return mediaUrl;
 				}
 			}
 		}

--- a/src/lib/compositeLayout.test.ts
+++ b/src/lib/compositeLayout.test.ts
@@ -78,25 +78,6 @@ describe("computeCompositeLayout", () => {
 		expect(layout?.screenCover).toBe(true);
 	});
 
-	it("bounds the vertical-stack layout within maxContentSize when webcam is present", () => {
-		const layout = computeCompositeLayout({
-			canvasSize: { width: 1920, height: 1080 },
-			maxContentSize: { width: 1536, height: 864 },
-			screenSize: { width: 1920, height: 1080 },
-			webcamSize: { width: 1280, height: 720 },
-			layoutPreset: "vertical-stack",
-		});
-
-		expect(layout).not.toBeNull();
-		// Screen and webcam should be bounded within maxContentSize, not filling the canvas
-		expect(layout!.screenRect.width).toBeLessThanOrEqual(1536);
-		expect(layout!.screenRect.height + (layout!.webcamRect?.height ?? 0)).toBeLessThanOrEqual(
-			864 + 1,
-		); // +1 for rounding
-		// Should be centered in canvas
-		expect(layout!.screenRect.x).toBeGreaterThan(0);
-	});
-
 	it("forces circular and square masks to use square dimensions", () => {
 		const circularLayout = computeCompositeLayout({
 			canvasSize: { width: 1920, height: 1080 },

--- a/src/lib/compositeLayout.test.ts
+++ b/src/lib/compositeLayout.test.ts
@@ -78,6 +78,25 @@ describe("computeCompositeLayout", () => {
 		expect(layout?.screenCover).toBe(true);
 	});
 
+	it("bounds the vertical-stack layout within maxContentSize when webcam is present", () => {
+		const layout = computeCompositeLayout({
+			canvasSize: { width: 1920, height: 1080 },
+			maxContentSize: { width: 1536, height: 864 },
+			screenSize: { width: 1920, height: 1080 },
+			webcamSize: { width: 1280, height: 720 },
+			layoutPreset: "vertical-stack",
+		});
+
+		expect(layout).not.toBeNull();
+		// Screen and webcam should be bounded within maxContentSize, not filling the canvas
+		expect(layout!.screenRect.width).toBeLessThanOrEqual(1536);
+		expect(layout!.screenRect.height + (layout!.webcamRect?.height ?? 0)).toBeLessThanOrEqual(
+			864 + 1,
+		); // +1 for rounding
+		// Should be centered in canvas
+		expect(layout!.screenRect.x).toBeGreaterThan(0);
+	});
+
 	it("forces circular and square masks to use square dimensions", () => {
 		const circularLayout = computeCompositeLayout({
 			canvasSize: { width: 1920, height: 1080 },

--- a/src/lib/customFonts.test.ts
+++ b/src/lib/customFonts.test.ts
@@ -27,12 +27,18 @@ describe("isValidGoogleFontsUrl", () => {
 
 describe("font URL CSS injection prevention", () => {
 	it("injection characters would be caught by the character blocklist", () => {
-		// These characters are blocked in loadFont() via /['";)\\]/
-		const dangerousChars = ["'", '"', ";", ")", "\\"];
+		// These characters are blocked in loadFont() via /['")\\ ]/
+		// Semicolons are allowed (used in Google Fonts weight lists like wght@400;700)
+		const dangerousChars = ["'", '"', ")", "\\", " "];
 		for (const char of dangerousChars) {
 			const url = `https://fonts.googleapis.com/css2?family=Roboto${char}`;
-			// Even if the URL passes domain validation, the char check in loadFont blocks it
-			expect(/['";)\\]/.test(url)).toBe(true);
+			expect(/['")\\ ]/.test(url)).toBe(true);
 		}
+	});
+
+	it("allows semicolons in Google Fonts weight lists", () => {
+		const url = "https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap";
+		// Semicolons should NOT be blocked — they're used for weight lists
+		expect(/['")\\ ]/.test(url)).toBe(false);
 	});
 });

--- a/src/lib/customFonts.test.ts
+++ b/src/lib/customFonts.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isValidGoogleFontsUrl } from "./customFonts";
+
+describe("isValidGoogleFontsUrl", () => {
+	it("accepts valid Google Fonts URLs", () => {
+		expect(isValidGoogleFontsUrl("https://fonts.googleapis.com/css2?family=Roboto")).toBe(true);
+		expect(
+			isValidGoogleFontsUrl(
+				"https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap",
+			),
+		).toBe(true);
+		expect(isValidGoogleFontsUrl("https://fonts.googleapis.com/css?family=Lato")).toBe(true);
+	});
+
+	it("rejects non-Google-Fonts URLs", () => {
+		expect(isValidGoogleFontsUrl("https://evil.com/css2?family=Roboto")).toBe(false);
+		expect(isValidGoogleFontsUrl("https://fonts.googleapis.com/css2")).toBe(false); // no family param
+		expect(isValidGoogleFontsUrl("http://fonts.googleapis.com/css2?family=Roboto")).toBe(false); // http not https
+	});
+
+	it("rejects malformed inputs", () => {
+		expect(isValidGoogleFontsUrl("")).toBe(false);
+		expect(isValidGoogleFontsUrl("not-a-url")).toBe(false);
+		expect(isValidGoogleFontsUrl("javascript:alert(1)")).toBe(false);
+	});
+});
+
+describe("font URL CSS injection prevention", () => {
+	it("injection characters would be caught by the character blocklist", () => {
+		// These characters are blocked in loadFont() via /['";)\\]/
+		const dangerousChars = ["'", '"', ";", ")", "\\"];
+		for (const char of dangerousChars) {
+			const url = `https://fonts.googleapis.com/css2?family=Roboto${char}`;
+			// Even if the URL passes domain validation, the char check in loadFont blocks it
+			expect(/['";)\\]/.test(url)).toBe(true);
+		}
+	});
+});

--- a/src/lib/customFonts.ts
+++ b/src/lib/customFonts.ts
@@ -189,7 +189,11 @@ export function parseFontFamilyFromImport(importUrl: string): string | null {
 export function isValidGoogleFontsUrl(url: string): boolean {
 	try {
 		const urlObj = new URL(url);
-		return urlObj.hostname === "fonts.googleapis.com" && urlObj.searchParams.has("family");
+		return (
+			urlObj.protocol === "https:" &&
+			urlObj.hostname === "fonts.googleapis.com" &&
+			urlObj.searchParams.has("family")
+		);
 	} catch {
 		return false;
 	}

--- a/src/lib/customFonts.ts
+++ b/src/lib/customFonts.ts
@@ -82,8 +82,8 @@ export function loadFont(font: CustomFont): Promise<void> {
 				return;
 			}
 
-			// Reject CSS injection characters
-			if (/['";)\\]/.test(font.importUrl)) {
+			// Reject CSS injection characters (semicolons allowed — used in Google Fonts weight lists)
+			if (/['")\\ ]/.test(font.importUrl)) {
 				console.warn(`Rejected font URL with unsafe characters for "${font.name}"`);
 				reject(new Error(`Invalid font URL: contains unsafe characters`));
 				return;

--- a/src/lib/customFonts.ts
+++ b/src/lib/customFonts.ts
@@ -75,19 +75,34 @@ export function loadFont(font: CustomFont): Promise<void> {
 		}
 
 		try {
+			// Validate URL at load time (not just at UI entry)
+			if (!isValidGoogleFontsUrl(font.importUrl)) {
+				console.warn(`Rejected invalid font URL for "${font.name}": not a valid Google Fonts URL`);
+				reject(new Error(`Invalid font URL: not a Google Fonts URL`));
+				return;
+			}
+
+			// Reject CSS injection characters
+			if (/['";)\\]/.test(font.importUrl)) {
+				console.warn(`Rejected font URL with unsafe characters for "${font.name}"`);
+				reject(new Error(`Invalid font URL: contains unsafe characters`));
+				return;
+			}
+
 			const styleId = `custom-font-${font.id}`;
 
-			// Remove existing style if present
+			// Remove existing element if present
 			const existing = document.getElementById(styleId);
 			if (existing) {
 				existing.remove();
 			}
 
-			// Create style element with @import
-			const style = document.createElement("style");
-			style.id = styleId;
-			style.textContent = `@import url('${font.importUrl}');`;
-			document.head.appendChild(style);
+			// Use <link> tag instead of @import template literal to prevent CSS injection
+			const link = document.createElement("link");
+			link.id = styleId;
+			link.rel = "stylesheet";
+			link.href = font.importUrl;
+			document.head.appendChild(link);
 
 			// Wait for font to load
 			waitForFont(font.fontFamily)

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -8,6 +8,7 @@ import {
 	type TextureSourceLike,
 } from "pixi.js";
 import { MotionBlurFilter } from "pixi-filters/motion-blur";
+import { isAllowedWallpaperValue } from "@/components/video-editor/projectPersistence";
 import type {
 	AnnotationRegion,
 	CropRegion,
@@ -219,6 +220,14 @@ export class FrameRenderer {
 		bgCanvas.width = this.config.width;
 		bgCanvas.height = this.config.height;
 		const bgCtx = bgCanvas.getContext("2d")!;
+
+		// Reject disallowed wallpaper values (e.g., external http URLs, file://, javascript:, blob:)
+		if (!isAllowedWallpaperValue(wallpaper)) {
+			bgCtx.fillStyle = "#000000";
+			bgCtx.fillRect(0, 0, this.config.width, this.config.height);
+			this.backgroundSprite = bgCanvas;
+			return;
+		}
 
 		try {
 			// Render background based on type

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -233,6 +233,7 @@ export class FrameRenderer {
 			// Render background based on type
 			if (
 				wallpaper.startsWith("file://") ||
+				wallpaper.startsWith("app-media://") ||
 				wallpaper.startsWith("data:") ||
 				wallpaper.startsWith("/") ||
 				wallpaper.startsWith("http")
@@ -247,7 +248,11 @@ export class FrameRenderer {
 					if (!imageUrl.startsWith(window.location.origin)) {
 						img.crossOrigin = "anonymous";
 					}
-				} else if (wallpaper.startsWith("file://") || wallpaper.startsWith("data:")) {
+				} else if (
+					wallpaper.startsWith("file://") ||
+					wallpaper.startsWith("app-media://") ||
+					wallpaper.startsWith("data:")
+				) {
 					imageUrl = wallpaper;
 				} else {
 					imageUrl = window.location.origin + wallpaper;

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -84,9 +84,15 @@ export class StreamingVideoDecoder {
 	private metadata: DecodedVideoInfo | null = null;
 
 	private async loadSourceFile(videoUrl: string): Promise<{ file: File; blob: Blob }> {
-		const isRemoteUrl = /^(https?:|blob:|data:)/i.test(videoUrl);
+		// Reject external HTTP(S) URLs — all video loading should go through IPC
+		if (/^https?:/i.test(videoUrl)) {
+			throw new Error("External HTTP URLs are not supported for video loading");
+		}
 
-		if (!isRemoteUrl && window.electronAPI?.readBinaryFile) {
+		// blob: and data: URLs are safe for in-memory video data — use fetch()
+		const isFetchableUrl = /^(blob:|data:)/i.test(videoUrl);
+
+		if (!isFetchableUrl && window.electronAPI?.readBinaryFile) {
 			const result = await this.withTimeout(
 				window.electronAPI.readBinaryFile(videoUrl),
 				SOURCE_LOAD_TIMEOUT_MS,

--- a/src/lib/securityValidation.test.ts
+++ b/src/lib/securityValidation.test.ts
@@ -47,3 +47,65 @@ describe("isAllowedExternalUrl", () => {
 		expect(isAllowedExternalUrl(undefined as unknown as string)).toBe(false);
 	});
 });
+
+describe("external URL domain allowlist", () => {
+	const ALLOWED_EXTERNAL_DOMAINS = ["github.com"];
+
+	function isAllowedDomain(url: string): boolean {
+		try {
+			const parsed = new URL(url);
+			return ALLOWED_EXTERNAL_DOMAINS.some(
+				(domain) => parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`),
+			);
+		} catch {
+			return false;
+		}
+	}
+
+	it("allows github.com", () => {
+		expect(isAllowedDomain("https://github.com/openscreen")).toBe(true);
+	});
+
+	it("allows subdomains of github.com", () => {
+		expect(isAllowedDomain("https://api.github.com/repos")).toBe(true);
+	});
+
+	it("rejects other domains", () => {
+		expect(isAllowedDomain("https://evil.com/steal")).toBe(false);
+		expect(isAllowedDomain("https://notgithub.com")).toBe(false);
+	});
+});
+
+describe("streamingDecoder URL classification", () => {
+	it("rejects http(s) URLs", () => {
+		expect(/^https?:/i.test("https://evil.com/video.webm")).toBe(true);
+		expect(/^https?:/i.test("http://evil.com/video.webm")).toBe(true);
+	});
+
+	it("allows blob: URLs via fetch path", () => {
+		expect(/^(blob:|data:)/i.test("blob:https://example.com/uuid")).toBe(true);
+	});
+
+	it("allows data: URLs via fetch path", () => {
+		expect(/^(blob:|data:)/i.test("data:video/webm;base64,abc")).toBe(true);
+	});
+
+	it("routes file paths to IPC", () => {
+		const url = "/path/to/video.webm";
+		expect(/^https?:/i.test(url)).toBe(false);
+		expect(/^(blob:|data:)/i.test(url)).toBe(false);
+		// Should go to IPC readBinaryFile path
+	});
+});
+
+describe("CSP meta tag", () => {
+	it("index.html contains a Content-Security-Policy meta tag", async () => {
+		const fs = await import("node:fs");
+		const html = fs.readFileSync("index.html", "utf-8");
+		expect(html).toContain('http-equiv="Content-Security-Policy"');
+		expect(html).toContain("default-src 'self' app-media:");
+		expect(html).toContain("script-src 'self'");
+		expect(html).toContain("frame-src 'none'");
+		expect(html).toContain("object-src 'none'");
+	});
+});

--- a/src/lib/securityValidation.test.ts
+++ b/src/lib/securityValidation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+// Replicate the isAllowedExternalUrl logic for testing
+function isAllowedExternalUrl(url: string): boolean {
+	if (!url || typeof url !== "string") return false;
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === "https:" || parsed.protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
+describe("isAllowedExternalUrl", () => {
+	it("allows https URLs", () => {
+		expect(isAllowedExternalUrl("https://example.com")).toBe(true);
+		expect(isAllowedExternalUrl("https://example.com/path?q=1")).toBe(true);
+	});
+
+	it("allows http URLs", () => {
+		expect(isAllowedExternalUrl("http://example.com")).toBe(true);
+	});
+
+	it("rejects file: URLs", () => {
+		expect(isAllowedExternalUrl("file:///etc/passwd")).toBe(false);
+	});
+
+	it("rejects javascript: URLs", () => {
+		expect(isAllowedExternalUrl("javascript:alert(1)")).toBe(false);
+	});
+
+	it("rejects data: URLs", () => {
+		expect(isAllowedExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+	});
+
+	it("rejects blob: URLs", () => {
+		expect(isAllowedExternalUrl("blob:https://example.com/uuid")).toBe(false);
+	});
+
+	it("rejects malformed URLs", () => {
+		expect(isAllowedExternalUrl("not-a-url")).toBe(false);
+		expect(isAllowedExternalUrl("")).toBe(false);
+	});
+
+	it("rejects null/undefined-like inputs", () => {
+		expect(isAllowedExternalUrl(null as unknown as string)).toBe(false);
+		expect(isAllowedExternalUrl(undefined as unknown as string)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Description
Add defense-in-depth layers against data exfiltration: navigation guards, external URL allowlisting, font/wallpaper source validation, Content Security Policy with dual enforcement, macOS hardened runtime with entitlements, and decoder path validation.

## Motivation
Even with IPC hardening (#359), a compromised renderer could still exfiltrate data through navigation redirects, font/image loading to attacker URLs, `shell.openExternal` abuse, or inline script injection. This PR closes those channels with multiple independent layers so no single bypass defeats all protections.

## Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Depends on #359. Extends the security hardening started in #352.

## Screenshots / Video
N/A — security hardening with no UI changes.

## Testing
1. `npm test` — all tests pass, including new regression tests
2. Manual: in DevTools Console, try `window.location = 'https://evil.com'` → should be blocked by navigation guard
3. Manual: inspect CSP header in DevTools Network tab → should show restrictive `default-src 'self'` policy
4. Manual: attempt to set a wallpaper to an `http://` URL → should be rejected by `isAllowedWallpaperValue`
5. Manual: verify macOS build signs with hardened runtime (`codesign -dv --verbose`)

### New test files:
- `src/lib/customFonts.test.ts` — font URL protocol validation (http/https blocked, local/app-media allowed)
- `src/lib/securityValidation.test.ts` — additional URL scheme validation tests
- `src/components/video-editor/projectPersistence.test.ts` — wallpaper value validation (asset paths, data URIs, colors, gradients; rejects http/traversal)

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Methodology

These changes were developed using a multi-LLM review workflow orchestrated through [llm-cli-gateway](https://github.com/verivus/llm-cli-gateway), an MCP-based tool for coordinating parallel code analysis across multiple AI models.

**Process:**
1. **Spec & planning** — exfiltration threat model and implementation plan developed collaboratively, building on the IPC hardening foundation from #359 ([spec](docs/planning/exfiltration-hardening/01_SPEC.md), [implementation plan](docs/planning/exfiltration-hardening/03_IMPLEMENTATION_PLAN.md))
2. **Implementation** — Claude Code (Opus) implemented the exfiltration prevention layers based on the plan
3. **Cross-model review** — OpenAI Codex reviewed the implementation, catching issues with parsed URL navigation handling, wallpaper path strictness, and realpath fallback behavior
4. **Fixes applied** — review findings were addressed in a dedicated fix commit (see `fix(security): address Codex review — parsed URL navigation, strict wallpaper paths, realpath fallback`)

This multi-LLM approach is particularly valuable for security work, where different models catch different classes of vulnerabilities and edge cases.

---
*Thank you for contributing!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Implemented Content Security Policy for enhanced renderer isolation.
  * Added filesystem path validation to restrict media access to trusted directories.
  * Restricted external URL handling; now only allows GitHub domains and blocks arbitrary HTTP(S) content.
  * Added validation for wallpaper sources; disallows external URLs.
  * Implemented media protocol handler for secure asset serving.
  * Enhanced macOS app signing and code hardening.

* **Bug Fixes**
  * Improved error recovery in screen recording when recorder encounters failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->