### PR TITLE
fix: validate project persistence state & restore vertical-stack layout bounds

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -819,26 +819,17 @@ export function registerIpcHandlers(
 			const filePath = result.filePaths[0];
 			const content = await fs.readFile(filePath, "utf-8");
 			const project = JSON.parse(content);
-			if (project && typeof project === "object") {
-				const rawProject = project as { media?: unknown; videoPath?: unknown };
-				const media =
-					normalizeProjectMedia(rawProject.media) ??
-					(typeof rawProject.videoPath === "string"
-						? {
-								screenVideoPath:
-									normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
-							}
-						: null);
-				currentProjectPath = filePath;
-				setCurrentRecordingSessionState(media ? { ...media, createdAt: Date.now() } : null);
-			} else {
-				// Invalid project structure — don't update currentProjectPath or session state
+			if (!project || typeof project !== "object") {
 				return {
 					success: false,
 					path: filePath,
 					message: "Invalid project structure: file does not contain a valid project object",
 				};
 			}
+
+			const session = await getApprovedProjectSession(project, filePath);
+			currentProjectPath = filePath;
+			setCurrentRecordingSessionState(session);
 
 			return {
 				success: true,
@@ -863,19 +854,7 @@ export function registerIpcHandlers(
 
 			const content = await fs.readFile(currentProjectPath, "utf-8");
 			const project = JSON.parse(content);
-			if (project && typeof project === "object") {
-				const rawProject = project as { media?: unknown; videoPath?: unknown };
-				const media =
-					normalizeProjectMedia(rawProject.media) ??
-					(typeof rawProject.videoPath === "string"
-						? {
-								screenVideoPath:
-									normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
-							}
-						: null);
-				setCurrentRecordingSessionState(media ? { ...media, createdAt: Date.now() } : null);
-			} else {
-				// Project file contains invalid structure — clear stale state
+			if (!project || typeof project !== "object") {
 				const stalePath = currentProjectPath;
 				currentProjectPath = null;
 				setCurrentRecordingSessionState(null);
@@ -885,6 +864,9 @@ export function registerIpcHandlers(
 					message: "Invalid project structure: file does not contain a valid project object",
 				};
 			}
+
+			const session = await getApprovedProjectSession(project, currentProjectPath);
+			setCurrentRecordingSessionState(session);
 			return {
 				success: true,
 				path: currentProjectPath,

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -819,9 +819,26 @@ export function registerIpcHandlers(
 			const filePath = result.filePaths[0];
 			const content = await fs.readFile(filePath, "utf-8");
 			const project = JSON.parse(content);
-			const session = await getApprovedProjectSession(project, filePath);
-			currentProjectPath = filePath;
-			setCurrentRecordingSessionState(session);
+			if (project && typeof project === "object") {
+				const rawProject = project as { media?: unknown; videoPath?: unknown };
+				const media =
+					normalizeProjectMedia(rawProject.media) ??
+					(typeof rawProject.videoPath === "string"
+						? {
+								screenVideoPath:
+									normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
+							}
+						: null);
+				currentProjectPath = filePath;
+				setCurrentRecordingSessionState(media ? { ...media, createdAt: Date.now() } : null);
+			} else {
+				// Invalid project structure — don't update currentProjectPath or session state
+				return {
+					success: false,
+					path: filePath,
+					message: "Invalid project structure: file does not contain a valid project object",
+				};
+			}
 
 			return {
 				success: true,
@@ -846,8 +863,28 @@ export function registerIpcHandlers(
 
 			const content = await fs.readFile(currentProjectPath, "utf-8");
 			const project = JSON.parse(content);
-			const session = await getApprovedProjectSession(project, currentProjectPath);
-			setCurrentRecordingSessionState(session);
+			if (project && typeof project === "object") {
+				const rawProject = project as { media?: unknown; videoPath?: unknown };
+				const media =
+					normalizeProjectMedia(rawProject.media) ??
+					(typeof rawProject.videoPath === "string"
+						? {
+								screenVideoPath:
+									normalizeVideoSourcePath(rawProject.videoPath) ?? rawProject.videoPath,
+							}
+						: null);
+				setCurrentRecordingSessionState(media ? { ...media, createdAt: Date.now() } : null);
+			} else {
+				// Project file contains invalid structure — clear stale state
+				const stalePath = currentProjectPath;
+				currentProjectPath = null;
+				setCurrentRecordingSessionState(null);
+				return {
+					success: false,
+					path: stalePath,
+					message: "Invalid project structure: file does not contain a valid project object",
+				};
+			}
 			return {
 				success: true,
 				path: currentProjectPath,
@@ -855,6 +892,9 @@ export function registerIpcHandlers(
 			};
 		} catch (error) {
 			console.error("Failed to load current project file:", error);
+			// File unreadable or unparseable — clear stale state to prevent retry loops
+			currentProjectPath = null;
+			setCurrentRecordingSessionState(null);
 			return {
 				success: false,
 				message: "Failed to load current project file",
@@ -907,6 +947,7 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("clear-current-video-path", () => {
 		setCurrentRecordingSessionState(null);
+		currentProjectPath = null;
 		return { success: true };
 	});
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -129,10 +129,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		return preferred.find((type) => MediaRecorder.isTypeSupported(type)) ?? "video/webm";
 	};
 
-	const computeBitrate = (width: number, height: number) => {
+	const computeBitrate = (width: number, height: number, frameRate: number) => {
 		const pixels = width * height;
-		const highFrameRateBoost =
-			TARGET_FRAME_RATE >= HIGH_FRAME_RATE_THRESHOLD ? HIGH_FRAME_RATE_BOOST : 1;
+		const highFrameRateBoost = frameRate >= HIGH_FRAME_RATE_THRESHOLD ? HIGH_FRAME_RATE_BOOST : 1;
 
 		if (pixels >= FOUR_K_PIXELS) {
 			return Math.round(BITRATE_4K * highFrameRateBoost);
@@ -514,7 +513,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			width = Math.floor(width / CODEC_ALIGNMENT) * CODEC_ALIGNMENT;
 			height = Math.floor(height / CODEC_ALIGNMENT) * CODEC_ALIGNMENT;
 
-			const videoBitsPerSecond = computeBitrate(width, height);
+			const videoBitsPerSecond = computeBitrate(width, height, frameRate ?? TARGET_FRAME_RATE);
 			const mimeType = selectMimeType();
 
 			console.log(

--- a/src/lib/compositeLayout.test.ts
+++ b/src/lib/compositeLayout.test.ts
@@ -33,7 +33,7 @@ describe("computeCompositeLayout", () => {
 		).toBeLessThanOrEqual(1920);
 	});
 
-	it("uses cover-style full-width stacking in vertical stack mode", () => {
+	it("bounds vertical-stack within maxContentSize when webcam is present", () => {
 		const layout = computeCompositeLayout({
 			canvasSize: { width: 1920, height: 1080 },
 			maxContentSize: { width: 1536, height: 864 },
@@ -43,23 +43,14 @@ describe("computeCompositeLayout", () => {
 		});
 
 		expect(layout).not.toBeNull();
-		expect(layout?.screenRect).toEqual({
-			x: 0,
-			y: 0,
-			width: 1920,
-			height: 0,
-		});
-		expect(layout?.webcamRect).toEqual({
-			x: 0,
-			y: 0,
-			width: 1920,
-			height: 1080,
-			borderRadius: 0,
-		});
-		expect(layout?.screenCover).toBe(true);
+		expect(layout!.screenRect.width).toBeLessThanOrEqual(1536);
+		expect(layout!.screenRect.height + (layout!.webcamRect?.height ?? 0)).toBeLessThanOrEqual(
+			864 + 1,
+		);
+		expect(layout!.screenRect.x).toBeGreaterThan(0);
 	});
 
-	it("fills the canvas with the screen when vertical stack has no webcam", () => {
+	it("bounds the screen within maxContentSize when vertical stack has no webcam", () => {
 		const layout = computeCompositeLayout({
 			canvasSize: { width: 1920, height: 1080 },
 			maxContentSize: { width: 1536, height: 864 },
@@ -69,13 +60,12 @@ describe("computeCompositeLayout", () => {
 
 		expect(layout).not.toBeNull();
 		expect(layout?.screenRect).toEqual({
-			x: 0,
-			y: 0,
-			width: 1920,
-			height: 1080,
+			x: 192,
+			y: 108,
+			width: 1536,
+			height: 864,
 		});
 		expect(layout?.webcamRect).toBeNull();
-		expect(layout?.screenCover).toBe(true);
 	});
 
 	it("forces circular and square masks to use square dimensions", () => {

--- a/src/lib/compositeLayout.ts
+++ b/src/lib/compositeLayout.ts
@@ -149,37 +149,77 @@ export function computeCompositeLayout(params: {
 
 	if (preset.transform.type === "stack") {
 		if (!webcamWidth || !webcamHeight || webcamWidth <= 0 || webcamHeight <= 0) {
-			// No webcam — screen fills the entire canvas (cover mode)
+			// No webcam — center the screen within the bounded content area
+			const screenRect = centerRect({
+				canvasSize,
+				size: screenSize,
+				maxSize: maxContentSize,
+			});
 			return {
-				screenRect: { x: 0, y: 0, width: canvasWidth, height: canvasHeight },
+				screenRect,
 				webcamRect: null,
-				screenCover: true,
 			};
 		}
 
-		// Webcam: full width at the bottom, maintaining its aspect ratio
+		// Both screen and webcam share a common width; compute heights at that width
+		const screenAspect = screenWidth / screenHeight;
 		const webcamAspect = webcamWidth / webcamHeight;
-		const resolvedWebcamWidth = canvasWidth;
-		const resolvedWebcamHeight = Math.round(canvasWidth / webcamAspect);
 
-		// Screen: fills remaining space at the top (cover mode — may crop sides)
-		const screenRectHeight = canvasHeight - resolvedWebcamHeight;
+		// Start with the max content width, then derive heights
+		const { width: maxW, height: maxH } = maxContentSize;
+		let commonWidth = Math.min(maxW, canvasWidth);
+		let sHeight = commonWidth / screenAspect;
+		let wHeight = commonWidth / webcamAspect;
+		let totalHeight = sHeight + wHeight;
+
+		// If combined height exceeds the max, scale everything down uniformly
+		if (totalHeight > maxH) {
+			const heightScale = maxH / totalHeight;
+			commonWidth = commonWidth * heightScale;
+			sHeight = sHeight * heightScale;
+			wHeight = wHeight * heightScale;
+			totalHeight = sHeight + wHeight;
+		}
+
+		// Also ensure we don't exceed canvas dimensions
+		if (commonWidth > canvasWidth) {
+			const scale = canvasWidth / commonWidth;
+			commonWidth *= scale;
+			sHeight *= scale;
+			wHeight *= scale;
+			totalHeight = sHeight + wHeight;
+		}
+		if (totalHeight > canvasHeight) {
+			const scale = canvasHeight / totalHeight;
+			commonWidth *= scale;
+			sHeight *= scale;
+			wHeight *= scale;
+			totalHeight = sHeight + wHeight;
+		}
+
+		const resolvedWidth = Math.round(commonWidth);
+		const resolvedScreenHeight = Math.round(sHeight);
+		const resolvedWebcamHeight = Math.round(wHeight);
+		const resolvedTotalHeight = resolvedScreenHeight + resolvedWebcamHeight;
+
+		// Center the stacked pair within the canvas
+		const offsetX = Math.max(0, Math.floor((canvasWidth - resolvedWidth) / 2));
+		const offsetY = Math.max(0, Math.floor((canvasHeight - resolvedTotalHeight) / 2));
 
 		return {
 			screenRect: {
-				x: 0,
-				y: 0,
-				width: canvasWidth,
-				height: Math.max(0, screenRectHeight),
+				x: offsetX,
+				y: offsetY,
+				width: resolvedWidth,
+				height: resolvedScreenHeight,
 			},
 			webcamRect: {
-				x: 0,
-				y: Math.max(0, screenRectHeight),
-				width: resolvedWebcamWidth,
+				x: offsetX,
+				y: offsetY + resolvedScreenHeight,
+				width: resolvedWidth,
 				height: resolvedWebcamHeight,
 				borderRadius: 0,
 			},
-			screenCover: true,
 		};
 	}
 


### PR DESCRIPTION
## Description
Two independent bug fixes: (1) validate parsed project structure before mutating `currentProjectPath` or recording session state, and (2) restore correct vertical-stack layout bounds within `maxContentSize` and use actual capture framerate for bitrate calculation.

## Motivation
**Persistence bug**: When loading a malformed or empty `.openscreen` project file, the IPC handlers would silently set `currentProjectPath` and corrupt `currentRecordingSession` with invalid data, leaving the editor in a broken state with no error feedback.

**Layout bug**: In vertical-stack mode with padding, the screen+webcam stack was not being constrained within `maxContentSize`, causing content to overflow the padded area. Additionally, the recorder used a hardcoded framerate for bitrate calculation instead of reading the actual framerate from the captured stream.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
None.

## Screenshots / Video
N/A — logic fixes with no visual changes to report.

## Testing
1. `npm test` — all tests pass
2. Manual (persistence): create a `.openscreen` file with invalid JSON content (e.g. `"not an object"`) and open it → should show error message, editor state should remain unchanged
3. Manual (layout): select vertical-stack layout with webcam and padding enabled → screen+webcam should be bounded and centered within the padded content area
4. Manual (bitrate): record a screen capture and check the exported file → bitrate should scale with actual capture framerate

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Methodology

These fixes were identified through a multi-LLM analysis workflow using [llm-cli-gateway](https://github.com/verivus/llm-cli-gateway), an MCP-based tool for orchestrating parallel code review across Claude, Codex, and Gemini. The persistence validation gap and layout regression were flagged during the initial security audit as non-security issues worth fixing alongside the hardening work.

---
*Thank you for contributing!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project file validation to detect and reject invalid file structures
  * Enhanced state cleanup when project loading encounters errors

* **Improvements**
  * Refined video bitrate calculation to account for variable frame rates
  * Enhanced positioning and scaling of screen and webcam elements in composite layouts

* **Tests**
  * Updated layout tests to reflect new composite positioning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->