### PR TITLE
fix(i18n): add missing zh-CN translation for newRecording dialog

### DIFF
--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -1,4 +1,10 @@
 {
+	"newRecording": {
+		"title": "返回录屏",
+		"description": "当前会话已保存。",
+		"cancel": "取消",
+		"confirm": "确认"
+	},
 	"errors": {
 		"noVideoLoaded": "未加载视频",
 		"videoNotReady": "视频未就绪",


### PR DESCRIPTION
## Summary
The zh-CN locale was missing the 'newRecording' section in `editor.json`, which exists in the en locale.

## Changes
Added the following translations to `src/i18n/locales/zh-CN/editor.json`:

| Key | English | Chinese |
|-----|---------|---------|
| newRecording.title | Return to Recorder | 返回录屏 |
| newRecording.description | Your current session has been saved. | 当前会话已保存。 |
| newRecording.cancel | Cancel | 取消 |
| newRecording.confirm | Confirm | 确认 |

## Checklist
- [x] Translation is accurate and consistent with existing zh-CN style
- [x] JSON is valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Chinese language support for the new recording feature, including translated strings for titles, descriptions, and action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->