### PR TITLE
fix(i18n): Update French translations for dialogs, editor, and settings

### DIFF
--- a/src/i18n/locales/fr/dialogs.json
+++ b/src/i18n/locales/fr/dialogs.json
@@ -29,7 +29,7 @@
 		"description": "Comprendre comment supprimer les parties indésirables de votre vidéo.",
 		"explanationBefore": "L'outil Coupe fonctionne en définissant les segments que vous souhaitez",
 		"remove": "supprimer",
-		"explanationMiddle": " — tout élément",
+		"explanationMiddle": " — tout ce qui est",
 		"covered": "couvert",
 		"explanationAfter": "par un segment de coupe rouge sera coupé lors de l'export.",
 		"visualExample": "Exemple visuel",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -1,4 +1,10 @@
 {
+	"newRecording": {
+		"title": "Retour à l'enregistreur",
+		"description": "Votre session actuelle a été enregistrée.",
+		"cancel": "Annuler",
+		"confirm": "Confirmer"
+	},
 	"errors": {
 		"noVideoLoaded": "Aucune vidéo chargée",
 		"videoNotReady": "Vidéo non prête",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -36,6 +36,8 @@
 		"systemAudioUnavailable": "Audio système non disponible. Enregistrement sans audio système.",
 		"microphoneDenied": "Accès au microphone refusé. L'enregistrement continuera sans audio.",
 		"cameraDenied": "Accès à la caméra refusé. L'enregistrement continuera sans webcam.",
+		"cameraDisconnected": "Webcam déconnectée.",
+		"cameraNotFound": "Caméra introuvable.",
 		"permissionDenied": "Permission d'enregistrement refusée. Veuillez autoriser l'enregistrement d'écran."
 	}
 }

--- a/src/i18n/locales/fr/launch.json
+++ b/src/i18n/locales/fr/launch.json
@@ -33,5 +33,11 @@
 	"recording": {
 		"selectSource": "Veuillez sélectionner une source à enregistrer"
 	},
-	"language": "Langue"
+	"language": "Langue",
+	"systemLanguagePrompt": {
+		"title": "Utiliser la langue de votre système ?",
+		"description": "Nous avons détecté {{language}} comme langue système. Voulez-vous passer OpenScreen en {{language}} ?",
+		"switch": "Passer en {{language}}",
+		"keepDefault": "Conserver la langue actuelle"
+	}
 }

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -13,7 +13,9 @@
 	"speed": {
 		"playbackSpeed": "Vitesse de lecture",
 		"selectRegion": "Sélectionnez une région de vitesse à ajuster",
-		"deleteRegion": "Supprimer la région de vitesse"
+		"deleteRegion": "Supprimer la région de vitesse",
+		"customPlaybackSpeed": "Vitesse de lecture personnalisée",
+		"maxSpeedError": "La vitesse ne peut pas dépasser 16×"
 	},
 	"trim": {
 		"deleteRegion": "Supprimer la région de coupe"
@@ -24,7 +26,8 @@
 		"selectPreset": "Choisir un préréglage",
 		"pictureInPicture": "Incrustation d'image",
 		"verticalStack": "Empilement vertical",
-		"webcamShape": "Forme de la caméra"
+		"webcamShape": "Forme de la caméra",
+		"webcamSize": "Taille de la caméra"
 	},
 	"effects": {
 		"title": "Effets vidéo",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -8,6 +8,13 @@
 			"manual": "Manuel",
 			"auto": "Auto",
 			"autoDescription": "La caméra suit la position du curseur enregistré"
+		},
+		"speed": {
+			"title": "Vitesse du zoom",
+			"instant": "Instantané",
+			"fast": "Rapide",
+			"smooth": "Fluide",
+			"lazy": "Lent"
 		}
 	},
 	"speed": {
@@ -26,6 +33,7 @@
 		"selectPreset": "Choisir un préréglage",
 		"pictureInPicture": "Incrustation d'image",
 		"verticalStack": "Empilement vertical",
+		"dualFrame": "Double cadre",
 		"webcamShape": "Forme de la caméra",
 		"webcamSize": "Taille de la caméra"
 	},


### PR DESCRIPTION
### Description
Update French (fr) translations to match the current English baseline across all namespaces.

### Motivation
Several translation keys were added or restructured in English but never reflected in the French locale, causing missing strings at runtime. This PR brings fr back in sync and adds it to the i18n validation script so it stays that way.

### Type of Change
 
 Other — i18n / Localization sync

### Related Issue(s)
None

### Screenshots / Video
N/A — text-only changes in JSON translation files.

### Testing
Run the i18n check script:
`node scripts/i18n-check.mjs`
Verify no MISSING or EXTRA keys are reported for fr.

### Checklist
[x] I have performed a self-review of my code.
[x] I have added any necessary screenshots or videos.
[x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated French translations: refined tutorial phrasing in the cut/removal dialog.
  * Added French copy for a new recording flow (titles, descriptions, confirm/cancel) and new recording error messages for camera issues.
  * Introduced a system-language prompt copy for launch.
  * Expanded settings translations: zoom speed modes, custom playback labels/errors, and new layout/webcam labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->