### PR TITLE
fix: clamp trim handle end position to timeline boundary

### DIFF
--- a/src/components/video-editor/timeline/TimelineWrapper.tsx
+++ b/src/components/video-editor/timeline/TimelineWrapper.tsx
@@ -57,7 +57,7 @@ export default function TimelineWrapper({
 			const duration = Math.min(Math.max(rawDuration, minDuration), totalMs);
 
 			const start = Math.max(0, Math.min(normalizedStart, totalMs - duration));
-			const end = start + duration;
+			const end = Math.min(start + duration, totalMs);
 
 			return { start, end };
 		},


### PR DESCRIPTION
## Summary

Fixes #393 — the right-side trim handle could be dragged indefinitely past the end of the timeline.

**Root cause:** `clampSpanToBounds` in `TimelineWrapper.tsx` computed `end = start + duration` without capping it at `totalMs`. The sibling function `clampToNeighbours` does clamp `end` to `totalMs`, but it's only invoked when there's overlap with neighboring regions — so when no neighbor exists to the right, the handle was unconstrained.

**Fix:** Add `Math.min(start + duration, totalMs)` to ensure the end position never exceeds the video duration.

## Test plan

- [ ] Open the video editor/trimmer interface
- [ ] Select a clip on the timeline
- [ ] Drag the right trim handle past the end of the timeline
- [ ] Verify the handle stops/snaps at the timeline boundary
- [ ] Verify left trim handle still works correctly
- [ ] Verify dragging the entire clip still clamps correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video editor timeline behavior where selection spans could extend beyond the video's maximum duration. Selections are now clamped to the video's total time so range start/end values cannot exceed the video's end, preventing out-of-bounds ranges and improving timeline accuracy when trimming or selecting segments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/399)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->