### PR TITLE
fix: HUD overlay and source selector follow across macOS Spaces

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -51,6 +51,12 @@ export function createHudOverlayWindow(): BrowserWindow {
 		},
 	});
 
+	// Follow the user across macOS Spaces (virtual desktops).
+	// Without this the HUD stays pinned to the Space it was first opened on.
+	if (process.platform === "darwin") {
+		win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+	}
+
 	win.webContents.on("did-finish-load", () => {
 		win?.webContents.send("main-process-message", new Date().toLocaleString());
 	});
@@ -141,6 +147,12 @@ export function createSourceSelectorWindow(): BrowserWindow {
 			contextIsolation: true,
 		},
 	});
+
+	// Follow the user across macOS Spaces so the selector appears on the
+	// active desktop regardless of where the HUD was originally opened.
+	if (process.platform === "darwin") {
+		win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+	}
 
 	if (VITE_DEV_SERVER_URL) {
 		win.loadURL(VITE_DEV_SERVER_URL + "?windowType=source-selector");

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -17,6 +17,11 @@ ipcMain.on("hud-overlay-hide", () => {
 	}
 });
 
+/**
+ * Creates the always-on-top HUD overlay window centred at the bottom of the
+ * primary display. The window is frameless, transparent, and follows the user
+ * across macOS Spaces so it is never lost when switching virtual desktops.
+ */
 export function createHudOverlayWindow(): BrowserWindow {
 	const primaryDisplay = screen.getPrimaryDisplay();
 	const { workArea } = primaryDisplay;
@@ -80,6 +85,10 @@ export function createHudOverlayWindow(): BrowserWindow {
 	return win;
 }
 
+/**
+ * Creates the main editor window. Starts maximised with a hidden title bar on
+ * macOS. This window is not always-on-top and appears in the taskbar/dock.
+ */
 export function createEditorWindow(): BrowserWindow {
 	const isMac = process.platform === "darwin";
 
@@ -126,6 +135,10 @@ export function createEditorWindow(): BrowserWindow {
 	return win;
 }
 
+/**
+ * Creates the floating source-selector window used to pick a screen or window
+ * to record. Frameless, transparent, and follows the user across macOS Spaces.
+ */
 export function createSourceSelectorWindow(): BrowserWindow {
 	const { width, height } = screen.getPrimaryDisplay().workAreaSize;
 


### PR DESCRIPTION
## Summary
  - Both windows had alwaysOnTop but lacked setVisibleOnAllWorkspaces, causing them to stay pinned to the Space they were opened on
  - Users switching to a different macOS virtual desktop would lose sight of the HUD overlay
  - Added win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true }) to both createHudOverlayWindow and createSourceSelectorWindow                                                                
  - macOS-only guard — no behaviour change on Windows/Linux                                                                                                                                               
                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
  - [ ] Open the app, switch to a different macOS Space — HUD should follow                                                                                                                               
  - [ ] Open source selector, switch Space — it should follow                                                                                                                                           
  - [ ] Enter a fullscreen app — HUD should remain visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HUD overlay and source selector windows on macOS now remain accessible across all virtual desktops (Spaces) and full-screen Spaces, preventing them from being pinned to a single workspace and ensuring consistent availability when switching desktops or using full-screen apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->