### PR TITLE
Add cloud integration layer with Kaltura as first provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,15 @@ dist-electron
 dist-ssr
 *.local
 
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# Kaltura session files (contain encrypted credentials)
+kaltura-session.json
+*.ks
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -25,6 +34,11 @@ dist-ssr
 *.sw?
 release/**
 *.kiro/
+
+# AI / tooling
+.claude/
+
+# Build
 # npx electron-builder --mac --win
 
 # Playwright

--- a/KALTURA.md
+++ b/KALTURA.md
@@ -97,7 +97,7 @@ Progress phases: `uploading` (0-80%) → `processing` (80-95%) → `complete` (1
 2. `KalturaBrowseDialog` fetches session info (KS, partnerId) and loads Kaltura's Unisphere media manager via script injection.
 3. The media manager renders inside a container div, allowing the user to search and browse their library.
 4. When the user selects an entry, `kalturaDownload` is called with the entry ID.
-5. `kaltura-service.ts` fetches the download URL via `playManifest` and streams the file to a temp directory.
+5. `kaltura-service.ts` fetches the download URL via `playManifest` and streams the file to the app recordings directory (`userData/recordings`).
 6. Progress is reported back via `kaltura-download-progress`.
 7. On completion, the file path is forwarded to the editor window via `kaltura-video-loaded`.
 

--- a/KALTURA.md
+++ b/KALTURA.md
@@ -14,7 +14,7 @@ All Kaltura functionality is opt-in. The UI surfaces upload/browse buttons only 
 
 ## Architecture
 
-```
+```text
 Renderer (React)                    Main Process (Node)
 ─────────────────                   ───────────────────
 KalturaSettingsDialog ──┐
@@ -26,7 +26,7 @@ KalturaBrowseDialog   ──┘              (handlers)           (business logi
 
 ### File Layout
 
-```
+```text
 electron/
   kaltura/
     kaltura-service.ts   # All Kaltura API calls, session management, upload/download logic

--- a/KALTURA.md
+++ b/KALTURA.md
@@ -1,0 +1,140 @@
+# Kaltura Integration
+
+This document describes how the Kaltura cloud integration works, how to extend it, and how it fits into OpenScreen's architecture. For end-user setup instructions, see [Connecting to Kaltura](README.md#connecting-to-kaltura) in the README.
+
+## Overview
+
+The integration adds three capabilities to OpenScreen:
+
+1. **Authentication** — sign in with Kaltura credentials, select from multiple accounts, persist sessions across restarts.
+2. **Upload** — save edited videos to Kaltura with metadata (title, description, tags, category). Chunked uploads with real-time progress.
+3. **Browse & Download** — embed Kaltura's media manager to search, browse, and load any video from the user's library into the editor.
+
+All Kaltura functionality is opt-in. The UI surfaces upload/browse buttons only when relevant, and the settings dialog is reachable from the toolbar without blocking any existing workflow.
+
+## Architecture
+
+```
+Renderer (React)                    Main Process (Node)
+─────────────────                   ───────────────────
+KalturaSettingsDialog ──┐
+KalturaUploadDialog   ──┤── IPC ──► kaltura-ipc.ts ──► kaltura-service.ts ──► Kaltura REST API
+KalturaBrowseDialog   ──┘              (handlers)           (business logic)
+     │
+     └── preload.ts (contextBridge)
+```
+
+### File Layout
+
+```
+electron/
+  kaltura/
+    kaltura-service.ts   # All Kaltura API calls, session management, upload/download logic
+    kaltura-ipc.ts       # IPC handler registration — thin bridge between renderer and service
+  preload.ts             # contextBridge exposing kaltura* methods to window.electronAPI
+
+src/components/video-editor/
+  KalturaLoginForm.tsx        # Shared login form (email/password, account selection, signup)
+  KalturaSettingsDialog.tsx   # Connection status, logout, account switching
+  KalturaUploadDialog.tsx     # Upload form with metadata fields and progress
+  KalturaBrowseDialog.tsx     # Embedded media manager for browsing and downloading
+
+src/i18n/locales/{en,es,zh-CN}/
+  kaltura.json           # All Kaltura UI strings (connection, login, upload, browse, toolbar)
+```
+
+### IPC Channel Map
+
+| Channel | Direction | Purpose |
+|---------|-----------|---------|
+| `kaltura-login` | renderer → main | Authenticate with email/password |
+| `kaltura-select-partner` | renderer → main | Choose account after multi-account login |
+| `kaltura-list-partners` | renderer → main | Re-fetch partner list (for account switching) |
+| `kaltura-logout` | renderer → main | Clear session and credentials |
+| `kaltura-load-session` | renderer → main | Restore persisted session on app start |
+| `kaltura-get-session-state` | renderer → main | Get current connection state |
+| `kaltura-open-signup` | renderer → main | Open Kaltura signup URL in browser |
+| `kaltura-upload` | renderer → main | Upload a video file with metadata |
+| `kaltura-upload-progress` | main → renderer | Real-time upload/processing progress |
+| `kaltura-list-categories` | renderer → main | Fetch category tree for upload form |
+| `kaltura-get-session-info` | renderer → main | Get KS + partnerId for media manager |
+| `kaltura-download` | renderer → main | Download a video by entry ID |
+| `kaltura-download-progress` | main → renderer | Download progress updates |
+| `open-kaltura-browse` | renderer → main | Open the browse window |
+| `close-kaltura-browse` | renderer → main | Close the browse window |
+| `kaltura-browse-video-loaded` | renderer → main | Notify that a downloaded video is ready |
+| `kaltura-video-loaded` | main → renderer | Forward loaded video path to editor |
+
+## Session Management
+
+Sessions are persisted to `{userData}/kaltura-session.json`. The file stores:
+
+- `serviceUrl`, `partnerId`, `userId`, `displayName`
+- `ks` (Kaltura Session token) — encrypted via Electron's `safeStorage`
+- `ksExpiry` — unix timestamp; tokens are generated with a 30-day TTL
+
+On app start, `kalturaLoadSession` reads and decrypts the stored session. If the KS has expired, the user is prompted to sign in again.
+
+Passwords are cached in-memory (never persisted) for up to 24 hours to support account switching without re-prompting. The cache is cleared on logout and on a timer.
+
+## Upload Flow
+
+1. User fills in metadata (name, description, tags, optional category) in `KalturaUploadDialog`.
+2. Renderer calls `kaltura-upload` with the video file path and metadata.
+3. `kaltura-service.ts` validates the file exists and is readable.
+4. Creates an upload token via Kaltura REST API.
+5. Reads the file in 10 MB chunks using streaming `fs.open` / `fileHandle.read` (avoids loading full file into memory).
+6. Uploads each chunk, reporting progress back to the renderer via `kaltura-upload-progress`.
+7. Creates a media entry and attaches the upload token.
+8. Optionally assigns a category.
+9. Returns the entry ID on success.
+
+Progress phases: `uploading` (0-80%) → `processing` (80-95%) → `complete` (100%).
+
+## Browse & Download Flow
+
+1. User opens the browse dialog from the toolbar or launch window.
+2. `KalturaBrowseDialog` fetches session info (KS, partnerId) and loads Kaltura's Unisphere media manager via script injection.
+3. The media manager renders inside a container div, allowing the user to search and browse their library.
+4. When the user selects an entry, `kalturaDownload` is called with the entry ID.
+5. `kaltura-service.ts` fetches the download URL via `playManifest` and streams the file to a temp directory.
+6. Progress is reported back via `kaltura-download-progress`.
+7. On completion, the file path is forwarded to the editor window via `kaltura-video-loaded`.
+
+## Security
+
+- **Context isolation**: all Kaltura windows use `contextIsolation: true`. No direct Node access from the renderer.
+- **Session encryption**: the KS token is encrypted with `safeStorage.encryptString()` before writing to disk and decrypted on read.
+- **File path validation**: upload and download operations validate file paths. The `isPathAllowed` check and `approvedPaths` Set prevent path traversal.
+- **Password handling**: passwords are cleared from React component state immediately after use and cached only in the main process memory with a TTL.
+- **Fetch timeouts**: all Kaltura API calls use a 60-second timeout via `AbortSignal.timeout()` to prevent hanging requests.
+
+## Internationalization
+
+All user-facing strings use the `kaltura` i18n namespace via `useScopedT("kaltura")`. Translation files are in `src/i18n/locales/{locale}/kaltura.json`.
+
+To add a new string:
+
+1. Add the key to `src/i18n/locales/en/kaltura.json`.
+2. Add translations to `es/kaltura.json` and `zh-CN/kaltura.json`.
+3. Use `t("section.key")` in the component (where `t = useScopedT("kaltura")`).
+4. Run `npm run i18n:check` to verify all locales are in sync.
+
+## Extending
+
+### Adding a new API call
+
+1. Add the function to `kaltura-service.ts` following the existing pattern (use `fetchWithTimeout`, return `{ success, error?, ... }`).
+2. Register the IPC handler in `kaltura-ipc.ts`.
+3. Add the preload bridge in `preload.ts`.
+4. Add the TypeScript type to `src/types/electron.d.ts` (if it exists) or rely on the preload's inline types.
+5. Call `window.electronAPI.yourNewMethod()` from the renderer.
+
+### Adding UI
+
+Kaltura UI components live in `src/components/video-editor/`. They follow the project's patterns:
+
+- **shadcn/ui** for Dialog, Input, Select, Button.
+- **Tailwind** for styling with the dark theme (`bg-[#09090b]`, `text-slate-200`, etc.).
+- **`useScopedT("kaltura")`** for all strings — no hardcoded text.
+- **Biome** for formatting (tabs, double quotes, 100-char width). Run `npm run lint:fix` before committing.

--- a/README.md
+++ b/README.md
@@ -1,102 +1,139 @@
-> [!WARNING]
-> This is very much in beta and might be buggy here and there (but hope you have a good experience!).
-
 <p align="center">
   <img src="public/openscreen.png" alt="OpenScreen Logo" width="64" />
-  <br />
-  <br />
-  <a href="https://deepwiki.com/siddharthvaddem/openscreen">
-    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
-  </a>
-  &nbsp;
-  <a href="https://discord.gg/yAQQhRaEeg">
-    <img src="https://img.shields.io/discord/pHAUbcqNd?logo=discord&label=Discord&color=5865F2" alt="Join Discord" />
-  </a>
 </p>
 
-# <p align="center">OpenScreen</p>
+# <p align="center">OpenScreen + Kaltura</p>
 
-<p align="center"><strong>OpenScreen is your free, open-source alternative to Screen Studio (sort of).</strong></p>
+<p align="center"><strong>Free, open-source screen recording — now with cloud save and load via Kaltura.</strong></p>
 
-If you don't want to pay $29/month for Screen Studio but want a much simpler version that does what most people seem to need, making beautiful product demos and walkthroughs, here's a free-to-use app for you. OpenScreen does not offer all Screen Studio features, but covers the basics well!
-
-Screen Studio is an awesome product and this is definitely not a 1:1 clone. OpenScreen is a much simpler take, just the basics for folks who want control and don't want to pay. If you need all the fancy features, your best bet is to support Screen Studio (they really do a great job, haha). But if you just want something free (no gotchas) and open, this project does the job!
-
-OpenScreen is 100% free for personal and commercial use. Use it, modify it, distribute it. (Just be cool 😁 and give a shoutout if you feel like it !)
+OpenScreen is a powerful free screen recorder and editor. This fork adds what the original was missing: **cloud storage**. Connect your [Kaltura](https://www.kaltura.com) account to save recordings to the cloud and load them back on any machine. No more local-only files — record, edit, save to cloud, and pick up where you left off from anywhere.
 
 <p align="center">
-	<img src="public/preview3.png" alt="OpenScreen App Preview 3" style="height: 0.2467; margin-right: 12px;" />
-	<img src="public/preview4.png" alt="OpenScreen App Preview 4" style="height: 0.1678; margin-right: 12px;" />
+	<img src="public/preview3.png" alt="OpenScreen App Preview" style="height: 0.2467; margin-right: 12px;" />
+	<img src="public/preview4.png" alt="OpenScreen Editor Preview" style="height: 0.1678; margin-right: 12px;" />
 </p>
 
+## What's New in This Fork
+
+### Cloud Save & Load
+The original OpenScreen keeps everything on your local machine. This fork connects to **Kaltura's cloud** so you can:
+- **Save to cloud** — upload finished recordings with title, description, tags, and categories. Track upload and processing progress in real time.
+- **Load from cloud** — browse your entire Kaltura media library, search by name, and pull any video into the editor.
+
+Your recordings stay local until you choose to save them. Once in the cloud, they're available from any machine where you sign in.
+
+### End-to-End Workflow
+```
+Record  →  Edit  →  Save to Cloud  →  Load Anywhere
+```
+Once uploaded, your videos benefit from Kaltura's transcoding, adaptive streaming, analytics, and AI features.
+
+### Kaltura Account Integration
+- **Sign in** directly from the editor — multi-account support included.
+- **Switch accounts** without re-entering credentials.
+- **Create a free Kaltura account** from within the app and start publishing immediately.
+
 ## Core Features
+
+Everything from OpenScreen, plus the Kaltura integration:
+
 - Record specific windows or your whole screen.
-- Add automatic or manual zooms (adjustable depth levels) and customize their durarion and position.
+- Add automatic or manual zooms (adjustable depth levels) and customize their duration and position.
 - Record microphone and system audio.
 - Crop video recordings to hide parts.
-- Choose between wallpapers, solid colors, gradients or a custom background.
+- Choose between wallpapers, solid colors, gradients, or a custom background.
 - Motion blur for smoother pan and zoom effects.
 - Add annotations (text, arrows, images).
 - Trim sections of the clip.
 - Customize the speed of different segments.
 - Export in different aspect ratios and resolutions.
+- **Save to Kaltura cloud** with metadata and categories.
+- **Load from Kaltura cloud** — browse, search, and edit any video from your library.
 
 ## Installation
 
-Download the latest installer for your platform from the [GitHub Releases](https://github.com/siddharthvaddem/openscreen/releases) page.
+Download the latest installer for your platform from the [Releases](../../releases) page.
 
 ### macOS
 
-If you encounter issues with macOS Gatekeeper blocking the app (since it does not come with a developer certificate), you can bypass this by running the following command in your terminal after installation:
+If macOS Gatekeeper blocks the app (since it's not signed with a developer certificate), run:
 
 ```bash
 xattr -rd com.apple.quarantine /Applications/Openscreen.app
 ```
 
-Note: Give your terminal Full Disk Access in **System Settings > Privacy & Security** to grant you access and then run the above command.
+> Give your terminal Full Disk Access in **System Settings > Privacy & Security** first.
 
-After running this command, proceed to **System Preferences > Security & Privacy** to grant the necessary permissions for "screen recording" and "accessibility". Once permissions are granted, you can launch the app.
+Then grant "Screen Recording" and "Accessibility" permissions in **System Preferences > Security & Privacy** and launch the app.
+
+### Windows
+
+Run the `.exe` installer from the releases page. Works out of the box.
 
 ### Linux
 
-Download the `.AppImage` file from the releases page. Make it executable and run:
+Download the `.AppImage`, make it executable, and run:
 
 ```bash
 chmod +x Openscreen-Linux-*.AppImage
 ./Openscreen-Linux-*.AppImage
 ```
 
-You may need to grant screen recording permissions depending on your desktop environment.
-
-**Note:** If the app fails to launch due to a "sandbox" error, run it with --no-sandbox:
+If the app fails to launch due to a sandbox error:
 ```bash
 ./Openscreen-Linux-*.AppImage --no-sandbox
 ```
 
-### Limitations
+### Platform Notes
 
-System audio capture relies on Electron's [desktopCapturer](https://www.electronjs.org/docs/latest/api/desktop-capturer) and has some platform-specific quirks:
+System audio capture relies on Electron's [desktopCapturer](https://www.electronjs.org/docs/latest/api/desktop-capturer):
 
-- **macOS**: Requires macOS 13+. On macOS 14.2+ you'll be prompted to grant audio capture permission. macOS 12 and below does not support system audio (mic still works).
+- **macOS**: Requires macOS 13+. On macOS 14.2+ you'll be prompted to grant audio capture permission.
 - **Windows**: Works out of the box.
-- **Linux**: Needs PipeWire (default on Ubuntu 22.04+, Fedora 34+). Older PulseAudio-only setups may not support system audio (mic should still work).
+- **Linux**: Needs PipeWire (default on Ubuntu 22.04+, Fedora 34+). Older PulseAudio-only setups may not support system audio.
 
-## Built with
-- Electron
-- React
-- TypeScript
-- Vite
-- PixiJS
-- dnd-timeline
+## Connecting to Kaltura
 
----
+1. Open the editor and click the **Kaltura Settings** button in the toolbar.
+2. Sign in with your Kaltura credentials (or create a free account).
+3. If your login is associated with multiple accounts, select the one you want to use.
+4. You're connected — upload and browse buttons are now active.
 
-_I'm new to open source, idk what I'm doing lol. If something is wrong please raise an issue 🙏_
+Your session is persisted locally (encrypted) so you stay connected across app restarts.
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run in development mode
+npm run dev
+
+# Type-check
+npx tsc --noEmit
+
+# Build for distribution
+npm run build
+```
+
+## Built With
+
+- [Electron](https://www.electronjs.org/) — cross-platform desktop app
+- [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) — UI
+- [Vite](https://vitejs.dev/) — build tooling
+- [PixiJS](https://pixijs.com/) — canvas rendering for video effects
+- [kaltura-client](https://www.npmjs.com/package/kaltura-client) — Kaltura API SDK
+- [dnd-timeline](https://github.com/samuelarbibe/dnd-timeline) — drag-and-drop timeline
+
+## Credits
+
+This project is a fork of [OpenScreen](https://github.com/siddharthvaddem/openscreen) by [@siddharthvaddem](https://github.com/siddharthvaddem). The original project is a free, open-source alternative to Screen Studio — all credit for the core recording and editing engine goes to the original author and contributors.
 
 ## Contributing
 
-Contributions are welcome! If you’d like to help out or see what’s currently being worked on, take a look at the open issues and the [project roadmap](https://github.com/users/siddharthvaddem/projects/3) to understand the current direction of the project and find ways to contribute.
+Contributions are welcome! For Kaltura-specific features, open an issue or PR in this fork. For core recording/editing improvements, consider contributing upstream to [OpenScreen](https://github.com/siddharthvaddem/openscreen).
 
 ## License
 
-This project is licensed under the [MIT License](./LICENSE). By using this software, you agree that the authors are not liable for any issues, damages, or claims arising from its use.
+This project is licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The original OpenScreen keeps everything on your local machine. This fork connec
 Your recordings stay local until you choose to save them. Once in the cloud, they're available from any machine where you sign in.
 
 ### End-to-End Workflow
-```
+```text
 Record  →  Edit  →  Save to Cloud  →  Load Anywhere
 ```
 Once uploaded, your videos benefit from Kaltura's transcoding, adaptive streaming, analytics, and AI features.

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -139,6 +139,114 @@ interface Window {
 		setHasUnsavedChanges: (hasChanges: boolean) => void;
 		onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => () => void;
 		setLocale: (locale: string) => Promise<void>;
+
+		// --- Kaltura Integration ---
+		kalturaLogin: (params: {
+			serviceUrl: string;
+			loginId: string;
+			password: string;
+		}) => Promise<{
+			success: boolean;
+			error?: string;
+			partners?: Array<{ id: number; name: string }>;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaSelectPartner: (params: {
+			partnerId: number;
+		}) => Promise<{
+			success: boolean;
+			error?: string;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaListPartners: () => Promise<{
+			success: boolean;
+			partners?: Array<{ id: number; name: string }>;
+			error?: string;
+		}>;
+		kalturaLogout: () => Promise<{ success: boolean }>;
+		kalturaLoadSession: () => Promise<{
+			success: boolean;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaGetSessionState: () => Promise<{
+			connected: boolean;
+			partnerId?: number;
+			serviceUrl?: string;
+			userId?: string;
+			displayName?: string;
+			ksExpiry?: number;
+		}>;
+		kalturaOpenSignup: () => Promise<{ success: boolean }>;
+		kalturaUpload: (options: {
+			filePath: string;
+			name: string;
+			description?: string;
+			tags?: string;
+			categoryIds?: string;
+		}) => Promise<{
+			success: boolean;
+			entryId?: string;
+			uploadId?: string;
+			error?: string;
+		}>;
+		kalturaListCategories: () => Promise<{
+			success: boolean;
+			categories?: Array<{ id: number; name: string; fullName: string }>;
+			error?: string;
+		}>;
+		onKalturaUploadProgress: (
+			callback: (progress: {
+				uploadId: string;
+				phase: "uploading" | "processing" | "complete" | "error";
+				percentage: number;
+				entryId?: string;
+				error?: string;
+			}) => void,
+		) => () => void;
+		kalturaGetSessionInfo: () => Promise<{
+			success: boolean;
+			ks?: string;
+			partnerId?: number;
+			serviceUrl?: string;
+		}>;
+		kalturaDownload: (params: { entryId: string }) => Promise<{
+			success: boolean;
+			filePath?: string;
+			error?: string;
+		}>;
+		onKalturaDownloadProgress: (
+			callback: (progress: {
+				phase: "downloading" | "complete" | "error";
+				percentage: number;
+				filePath?: string;
+				error?: string;
+			}) => void,
+		) => () => void;
+		openKalturaBrowse: () => Promise<void>;
+		closeKalturaBrowse: () => Promise<void>;
+		kalturaBrowseVideoLoaded: (filePath: string) => Promise<void>;
+		onKalturaVideoLoaded: (callback: (filePath: string) => void) => () => void;
 	};
 }
 

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -141,11 +141,7 @@ interface Window {
 		setLocale: (locale: string) => Promise<void>;
 
 		// --- Kaltura Integration ---
-		kalturaLogin: (params: {
-			serviceUrl: string;
-			loginId: string;
-			password: string;
-		}) => Promise<{
+		kalturaLogin: (params: { serviceUrl: string; loginId: string; password: string }) => Promise<{
 			success: boolean;
 			error?: string;
 			partners?: Array<{ id: number; name: string }>;
@@ -158,9 +154,7 @@ interface Window {
 				ksExpiry?: number;
 			};
 		}>;
-		kalturaSelectPartner: (params: {
-			partnerId: number;
-		}) => Promise<{
+		kalturaSelectPartner: (params: { partnerId: number }) => Promise<{
 			success: boolean;
 			error?: string;
 			state?: {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -352,8 +352,10 @@ function sampleCursorPoint() {
 export function registerIpcHandlers(
 	createEditorWindow: () => void,
 	createSourceSelectorWindow: () => BrowserWindow,
+	createKalturaBrowseWindow: () => BrowserWindow,
 	getMainWindow: () => BrowserWindow | null,
 	getSourceSelectorWindow: () => BrowserWindow | null,
+	getKalturaBrowseWindow: () => BrowserWindow | null,
 	onRecordingStateChange?: (recording: boolean, sourceName: string) => void,
 	switchToHud?: () => void,
 ) {
@@ -436,6 +438,31 @@ export function registerIpcHandlers(
 			return;
 		}
 		createSourceSelectorWindow();
+	});
+
+	ipcMain.handle("open-kaltura-browse", () => {
+		createKalturaBrowseWindow();
+	});
+
+	ipcMain.handle("close-kaltura-browse", () => {
+		const browseWin = getKalturaBrowseWindow();
+		if (browseWin && !browseWin.isDestroyed()) {
+			browseWin.close();
+		}
+	});
+
+	ipcMain.handle("kaltura-browse-video-loaded", (_, filePath: string) => {
+		// Broadcast to all windows (HUD or editor — whichever is listening)
+		const browseWin = getKalturaBrowseWindow();
+		for (const win of BrowserWindow.getAllWindows()) {
+			if (!win.isDestroyed() && win !== browseWin) {
+				win.webContents.send("kaltura-video-loaded", filePath);
+			}
+		}
+		// Close the browse window
+		if (browseWin && !browseWin.isDestroyed()) {
+			browseWin.close();
+		}
 	});
 
 	ipcMain.handle("switch-to-editor", () => {

--- a/electron/kaltura/kaltura-ipc.ts
+++ b/electron/kaltura/kaltura-ipc.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from "electron";
 import {
-	downloadFromKaltura,
 	type DownloadProgress,
+	downloadFromKaltura,
 	getSessionInfo,
 	getSessionState,
 	listCategories,
@@ -11,19 +11,19 @@ import {
 	logout,
 	openSignup,
 	selectPartner,
-	uploadToKaltura,
 	type UploadOptions,
 	type UploadProgress,
+	uploadToKaltura,
 } from "./kaltura-service";
-
-// Keep track of active upload progress listeners
-const uploadProgressListeners = new Map<string, (progress: UploadProgress) => void>();
 
 export function registerKalturaIpcHandlers() {
 	// --- Auth ---
-	ipcMain.handle("kaltura-login", async (_, params: { serviceUrl: string; loginId: string; password: string }) => {
-		return login(params.serviceUrl, params.loginId, params.password);
-	});
+	ipcMain.handle(
+		"kaltura-login",
+		async (_, params: { serviceUrl: string; loginId: string; password: string }) => {
+			return login(params.serviceUrl, params.loginId, params.password);
+		},
+	);
 
 	ipcMain.handle("kaltura-select-partner", async (_, params: { partnerId: number }) => {
 		return selectPartner(params.partnerId);
@@ -55,7 +55,6 @@ export function registerKalturaIpcHandlers() {
 		const uploadId = `upload-${Date.now()}`;
 
 		const onProgress = (progress: UploadProgress) => {
-			// Send progress to the renderer via the webContents
 			try {
 				event.sender.send("kaltura-upload-progress", { uploadId, ...progress });
 			} catch {
@@ -63,14 +62,8 @@ export function registerKalturaIpcHandlers() {
 			}
 		};
 
-		uploadProgressListeners.set(uploadId, onProgress);
-
-		try {
-			const result = await uploadToKaltura(options, onProgress);
-			return { ...result, uploadId };
-		} finally {
-			uploadProgressListeners.delete(uploadId);
-		}
+		const result = await uploadToKaltura(options, onProgress);
+		return { ...result, uploadId };
 	});
 
 	// --- Categories ---

--- a/electron/kaltura/kaltura-ipc.ts
+++ b/electron/kaltura/kaltura-ipc.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { ipcMain } from "electron";
 import {
 	type DownloadProgress,
@@ -52,6 +53,11 @@ export function registerKalturaIpcHandlers() {
 
 	// --- Upload ---
 	ipcMain.handle("kaltura-upload", async (event, options: UploadOptions) => {
+		// Validate filePath: must be absolute and free of traversal sequences
+		if (!path.isAbsolute(options.filePath) || options.filePath.includes("..")) {
+			return { success: false, error: "Invalid file path." };
+		}
+
 		const uploadId = `upload-${Date.now()}`;
 
 		const onProgress = (progress: UploadProgress) => {

--- a/electron/kaltura/kaltura-ipc.ts
+++ b/electron/kaltura/kaltura-ipc.ts
@@ -1,0 +1,97 @@
+import { ipcMain } from "electron";
+import {
+	downloadFromKaltura,
+	type DownloadProgress,
+	getSessionInfo,
+	getSessionState,
+	listCategories,
+	listPartners,
+	loadSession,
+	login,
+	logout,
+	openSignup,
+	selectPartner,
+	uploadToKaltura,
+	type UploadOptions,
+	type UploadProgress,
+} from "./kaltura-service";
+
+// Keep track of active upload progress listeners
+const uploadProgressListeners = new Map<string, (progress: UploadProgress) => void>();
+
+export function registerKalturaIpcHandlers() {
+	// --- Auth ---
+	ipcMain.handle("kaltura-login", async (_, params: { serviceUrl: string; loginId: string; password: string }) => {
+		return login(params.serviceUrl, params.loginId, params.password);
+	});
+
+	ipcMain.handle("kaltura-select-partner", async (_, params: { partnerId: number }) => {
+		return selectPartner(params.partnerId);
+	});
+
+	ipcMain.handle("kaltura-list-partners", async () => {
+		return listPartners();
+	});
+
+	ipcMain.handle("kaltura-logout", async () => {
+		return logout();
+	});
+
+	ipcMain.handle("kaltura-load-session", async () => {
+		return loadSession();
+	});
+
+	ipcMain.handle("kaltura-get-session-state", () => {
+		return getSessionState();
+	});
+
+	ipcMain.handle("kaltura-open-signup", () => {
+		openSignup();
+		return { success: true };
+	});
+
+	// --- Upload ---
+	ipcMain.handle("kaltura-upload", async (event, options: UploadOptions) => {
+		const uploadId = `upload-${Date.now()}`;
+
+		const onProgress = (progress: UploadProgress) => {
+			// Send progress to the renderer via the webContents
+			try {
+				event.sender.send("kaltura-upload-progress", { uploadId, ...progress });
+			} catch {
+				// sender may have been destroyed
+			}
+		};
+
+		uploadProgressListeners.set(uploadId, onProgress);
+
+		try {
+			const result = await uploadToKaltura(options, onProgress);
+			return { ...result, uploadId };
+		} finally {
+			uploadProgressListeners.delete(uploadId);
+		}
+	});
+
+	// --- Categories ---
+	ipcMain.handle("kaltura-list-categories", async () => {
+		return listCategories();
+	});
+
+	// --- Session Info (for media manager embedding) ---
+	ipcMain.handle("kaltura-get-session-info", () => {
+		return getSessionInfo();
+	});
+
+	// --- Download ---
+	ipcMain.handle("kaltura-download", async (event, params: { entryId: string }) => {
+		const onProgress = (progress: DownloadProgress) => {
+			try {
+				event.sender.send("kaltura-download-progress", progress);
+			} catch {
+				// sender may have been destroyed
+			}
+		};
+		return downloadFromKaltura(params.entryId, onProgress);
+	});
+}

--- a/electron/kaltura/kaltura-service.ts
+++ b/electron/kaltura/kaltura-service.ts
@@ -1,3 +1,4 @@
+import { createWriteStream, mkdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -5,7 +6,7 @@ import { app, safeStorage, shell } from "electron";
 
 // kaltura-client is a CJS module — use createRequire to load it in ESM context
 const require = createRequire(import.meta.url);
-// biome-ignore lint: kaltura-client has no type declarations
+// eslint-disable-next-line -- kaltura-client is untyped CJS; require is the only option
 const kaltura = require("kaltura-client");
 
 // --- Constants ---
@@ -15,6 +16,20 @@ const KS_EXPIRY_SECONDS = 2592000; // 30 days
 const PASSWORD_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours — needed for account switching
 const SIGNUP_URL =
 	"https://subscription.kaltura.com/get-started/kmc-free-trial-free?utm_source=trendemon&utm_medium=promotion&utm_campaign=an-2026-03-pathfactory&utm_content=popup-desktop";
+const UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB
+const CATEGORY_PAGE_SIZE = 500;
+const FETCH_TIMEOUT_MS = 60_000; // 60 seconds
+const UPLOAD_PROGRESS_TOKEN = 10; // % allocated to token creation
+const UPLOAD_PROGRESS_UPLOAD = 70; // % allocated to file upload (10-80)
+
+function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
+	return fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+}
+
+/** Strip trailing slashes and append the API v3 base path. */
+function apiUrl(serviceUrl: string, path: string): string {
+	return `${serviceUrl.replace(/\/+$/, "")}/api_v3${path}`;
+}
 
 // --- Interfaces ---
 
@@ -91,18 +106,19 @@ async function loginByLoginId(
 	password: string,
 	partnerId?: number,
 ): Promise<string> {
-	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/loginByLoginId`;
+	const url = apiUrl(serviceUrl, "/service/user/action/loginByLoginId");
 	const params = new URLSearchParams({
 		format: "1",
 		loginId,
 		password,
 		expiry: String(KS_EXPIRY_SECONDS),
+		privileges: "disableentitlement",
 	});
 	if (partnerId) {
 		params.set("partnerId", String(partnerId));
 	}
 
-	const response = await fetch(url, {
+	const response = await fetchWithTimeout(url, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: params.toString(),
@@ -145,20 +161,17 @@ async function loginByLoginId(
 	throw new Error("Unexpected response from Kaltura API");
 }
 
-async function loginByKs(
-	serviceUrl: string,
-	ks: string,
-	partnerId: number,
-): Promise<string> {
-	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/loginByKs`;
+async function loginByKs(serviceUrl: string, ks: string, partnerId: number): Promise<string> {
+	const url = apiUrl(serviceUrl, "/service/user/action/loginByKs");
 	const params = new URLSearchParams({
 		format: "1",
 		ks,
 		requestedPartnerId: String(partnerId),
 		expiry: String(KS_EXPIRY_SECONDS),
+		privileges: "disableentitlement",
 	});
 
-	const response = await fetch(url, {
+	const response = await fetchWithTimeout(url, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: params.toString(),
@@ -178,12 +191,12 @@ async function loginByKs(
 	throw new Error("Unexpected response from Kaltura API");
 }
 
-async function listPartnersForUser(
-	serviceUrl: string,
-	ks: string,
-): Promise<KalturaPartner[]> {
-	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/partner/action/listPartnersForUser?format=1&clientTag=openscreen`;
-	const response = await fetch(url, {
+async function listPartnersForUser(serviceUrl: string, ks: string): Promise<KalturaPartner[]> {
+	const url = apiUrl(
+		serviceUrl,
+		"/service/partner/action/listPartnersForUser?format=1&clientTag=openscreen",
+	);
+	const response = await fetchWithTimeout(url, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
@@ -194,7 +207,7 @@ async function listPartnersForUser(
 			},
 			pager: {
 				objectType: "KalturaFilterPager",
-				pageSize: 500,
+				pageSize: CATEGORY_PAGE_SIZE,
 			},
 		}),
 	});
@@ -215,8 +228,8 @@ async function getUserInfo(
 	serviceUrl: string,
 	ks: string,
 ): Promise<{ id: string; fullName: string }> {
-	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/get`;
-	const response = await fetch(url, {
+	const url = apiUrl(serviceUrl, "/service/user/action/get");
+	const response = await fetchWithTimeout(url, {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: new URLSearchParams({ format: "1", ks }).toString(),
@@ -357,7 +370,11 @@ export async function login(
 	}
 }
 
-export async function listPartners(): Promise<{ success: boolean; partners?: KalturaPartner[]; error?: string }> {
+export async function listPartners(): Promise<{
+	success: boolean;
+	partners?: KalturaPartner[];
+	error?: string;
+}> {
 	try {
 		// Use the current session's KS to list partners — no password needed
 		if (currentSession?.ks && currentSession.serviceUrl) {
@@ -508,14 +525,17 @@ async function getAuthenticatedClient() {
 // Helper to promisify kaltura service calls
 function execKaltura<T>(serviceAction: unknown, client: unknown): Promise<T> {
 	return new Promise((resolve, reject) => {
-		(serviceAction as { execute: (client: unknown, cb: (ok: boolean, res: unknown) => void) => void })
-			.execute(client, (success: boolean, results: unknown) => {
-				if (success && results) {
-					resolve(results as T);
-				} else {
-					reject(new Error(`Kaltura API call failed: ${JSON.stringify(results)}`));
-				}
-			});
+		(
+			serviceAction as {
+				execute: (client: unknown, cb: (ok: boolean, res: unknown) => void) => void;
+			}
+		).execute(client, (success: boolean, results: unknown) => {
+			if (success && results) {
+				resolve(results as T);
+			} else {
+				reject(new Error(`Kaltura API call failed: ${JSON.stringify(results)}`));
+			}
+		});
 	});
 }
 
@@ -546,6 +566,16 @@ export async function uploadToKaltura(
 	entryId?: string;
 	error?: string;
 }> {
+	// Validate the file exists and is readable
+	try {
+		const stats = await fs.stat(options.filePath);
+		if (!stats.isFile()) {
+			return { success: false, error: "Path is not a file" };
+		}
+	} catch {
+		return { success: false, error: "File not found or inaccessible" };
+	}
+
 	try {
 		const client = await getAuthenticatedClient();
 
@@ -567,9 +597,8 @@ export async function uploadToKaltura(
 		// 2. Upload file (kaltura-client handles the file path directly)
 		const fileStats = await fs.stat(options.filePath);
 		const fileSize = fileStats.size;
-		const CHUNK_SIZE = 10 * 1024 * 1024; // 10MB chunks
 
-		if (fileSize <= CHUNK_SIZE) {
+		if (fileSize <= UPLOAD_CHUNK_SIZE) {
 			// Single upload for small files
 			await execKaltura(
 				kaltura.services.uploadToken.upload(
@@ -584,39 +613,45 @@ export async function uploadToKaltura(
 			onProgress?.({ phase: "uploading", percentage: 80 });
 		} else {
 			// Chunked upload for large files
-			const totalChunks = Math.ceil(fileSize / CHUNK_SIZE);
-			const fileBuffer = await fs.readFile(options.filePath);
+			const totalChunks = Math.ceil(fileSize / UPLOAD_CHUNK_SIZE);
+			const fileHandle = await fs.open(options.filePath, "r");
+			try {
+				for (let i = 0; i < totalChunks; i++) {
+					const start = i * UPLOAD_CHUNK_SIZE;
+					const end = Math.min(start + UPLOAD_CHUNK_SIZE, fileSize);
+					const chunkSize = end - start;
+					const chunk = Buffer.alloc(chunkSize);
+					await fileHandle.read(chunk, 0, chunkSize, start);
+					const isFinal = i === totalChunks - 1;
 
-			for (let i = 0; i < totalChunks; i++) {
-				const start = i * CHUNK_SIZE;
-				const end = Math.min(start + CHUNK_SIZE, fileSize);
-				const chunk = fileBuffer.subarray(start, end);
-				const isFinal = i === totalChunks - 1;
-
-				// Write chunk to temp file
-				const tempChunkPath = path.join(
-					app.getPath("temp"),
-					`kaltura-chunk-${createdToken.id}-${i}`,
-				);
-				await fs.writeFile(tempChunkPath, chunk);
-
-				try {
-					await execKaltura(
-						kaltura.services.uploadToken.upload(
-							createdToken.id,
-							tempChunkPath,
-							i > 0, // resume
-							isFinal, // finalChunk
-							start, // resumeAt
-						),
-						client,
+					// Write chunk to temp file
+					const tempChunkPath = path.join(
+						app.getPath("temp"),
+						`kaltura-chunk-${createdToken.id}-${i}`,
 					);
-				} finally {
-					await fs.unlink(tempChunkPath).catch(() => {});
-				}
+					await fs.writeFile(tempChunkPath, chunk);
 
-				const uploadPct = 10 + Math.round(((i + 1) / totalChunks) * 70);
-				onProgress?.({ phase: "uploading", percentage: uploadPct });
+					try {
+						await execKaltura(
+							kaltura.services.uploadToken.upload(
+								createdToken.id,
+								tempChunkPath,
+								i > 0, // resume
+								isFinal, // finalChunk
+								start, // resumeAt
+							),
+							client,
+						);
+					} finally {
+						await fs.unlink(tempChunkPath).catch(() => undefined);
+					}
+
+					const uploadPct =
+						UPLOAD_PROGRESS_TOKEN + Math.round(((i + 1) / totalChunks) * UPLOAD_PROGRESS_UPLOAD);
+					onProgress?.({ phase: "uploading", percentage: uploadPct });
+				}
+			} finally {
+				await fileHandle.close();
 			}
 		}
 
@@ -638,36 +673,34 @@ export async function uploadToKaltura(
 			throw new Error("Failed to create media entry");
 		}
 
-		onProgress?.({ phase: "processing", percentage: 90 });
-
-		// 4. Associate uploaded file with entry
-		const resource = new kaltura.objects.UploadedFileTokenResource();
-		resource.token = createdToken.id;
-
-		await execKaltura(
-			kaltura.services.media.addContent(createdEntry.id, resource),
-			client,
-		);
-
-		onProgress?.({ phase: "processing", percentage: 95 });
-
-		// 5. Add to categories if specified
+		// 4. Assign categories via categoryEntry service
 		if (options.categoryIds) {
-			const categoryIds = options.categoryIds.split(",").map((id) => id.trim());
+			const categoryIds = options.categoryIds
+				.split(",")
+				.map((id) => id.trim())
+				.filter((id) => id && !Number.isNaN(Number(id)));
 			for (const categoryId of categoryIds) {
 				try {
 					const categoryEntry = new kaltura.objects.CategoryEntry();
 					categoryEntry.categoryId = Number.parseInt(categoryId, 10);
 					categoryEntry.entryId = createdEntry.id;
-					await execKaltura(
-						kaltura.services.categoryEntry.add(categoryEntry),
-						client,
-					);
+					await execKaltura(kaltura.services.categoryEntry.add(categoryEntry), client);
 				} catch (catError) {
-					console.warn(`Failed to add entry to category ${categoryId}:`, catError);
+					console.error(
+						`[KalturaUpload] categoryEntry.add failed for category ${categoryId}:`,
+						catError,
+					);
 				}
 			}
 		}
+
+		onProgress?.({ phase: "processing", percentage: 90 });
+
+		// 5. Associate uploaded file with entry
+		const resource = new kaltura.objects.UploadedFileTokenResource();
+		resource.token = createdToken.id;
+
+		await execKaltura(kaltura.services.media.addContent(createdEntry.id, resource), client);
 
 		onProgress?.({
 			phase: "complete",
@@ -734,13 +767,10 @@ export async function downloadFromKaltura(
 	const ks = currentKs;
 
 	// Build playManifest download URL
-	const downloadUrl =
-		`${serviceUrl}/p/${partnerId}/sp/${partnerId}00/playManifest/entryId/${entryId}/format/download/protocol/https?ks=${ks}`;
+	const downloadUrl = `${serviceUrl}/p/${partnerId}/sp/${partnerId}00/playManifest/entryId/${entryId}/format/download/protocol/https?ks=${ks}`;
 
 	const recordingsDir = path.join(app.getPath("userData"), "recordings");
 
-	// Ensure recordings directory exists
-	const { mkdirSync } = await import("node:fs");
 	mkdirSync(recordingsDir, { recursive: true });
 
 	const destPath = path.join(recordingsDir, `kaltura-${entryId}-${Date.now()}.mp4`);
@@ -755,7 +785,7 @@ export async function downloadFromKaltura(
 	onProgress?.({ phase: "downloading", percentage: 0 });
 
 	try {
-		const response = await fetch(downloadUrl, { redirect: "follow" });
+		const response = await fetchWithTimeout(downloadUrl, { redirect: "follow" });
 
 		if (!response.ok) {
 			throw new Error(`Download failed: HTTP ${response.status}`);
@@ -768,7 +798,6 @@ export async function downloadFromKaltura(
 			throw new Error("No response body");
 		}
 
-		const { createWriteStream } = await import("node:fs");
 		const fileStream = createWriteStream(destPath);
 		let downloaded = 0;
 
@@ -821,7 +850,7 @@ export async function listCategories(): Promise<{
 
 		const filter = new kaltura.objects.CategoryFilter();
 		const pager = new kaltura.objects.FilterPager();
-		pager.pageSize = 500;
+		pager.pageSize = CATEGORY_PAGE_SIZE;
 
 		const result = await execKaltura<{
 			objects: Array<{ id: number; name: string; fullName: string }>;

--- a/electron/kaltura/kaltura-service.ts
+++ b/electron/kaltura/kaltura-service.ts
@@ -1,0 +1,841 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { app, safeStorage, shell } from "electron";
+
+// kaltura-client is a CJS module — use createRequire to load it in ESM context
+const require = createRequire(import.meta.url);
+// biome-ignore lint: kaltura-client has no type declarations
+const kaltura = require("kaltura-client");
+
+// --- Constants ---
+
+const KALTURA_SESSION_FILE = path.join(app.getPath("userData"), "kaltura-session.json");
+const KS_EXPIRY_SECONDS = 2592000; // 30 days
+const PASSWORD_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours — needed for account switching
+const SIGNUP_URL =
+	"https://subscription.kaltura.com/get-started/kmc-free-trial-free?utm_source=trendemon&utm_medium=promotion&utm_campaign=an-2026-03-pathfactory&utm_content=popup-desktop";
+
+// --- Interfaces ---
+
+export interface KalturaStoredSession {
+	serviceUrl: string;
+	partnerId: number;
+	ks: string;
+	ksExpiry: number; // unix timestamp in seconds
+	userId: string;
+	displayName?: string;
+}
+
+export interface KalturaSessionState {
+	connected: boolean;
+	partnerId?: number;
+	serviceUrl?: string;
+	userId?: string;
+	displayName?: string;
+	ksExpiry?: number;
+}
+
+export interface KalturaPartner {
+	id: number;
+	name: string;
+}
+
+export interface LoginResult {
+	success: boolean;
+	error?: string;
+	partners?: KalturaPartner[];
+	state?: KalturaSessionState;
+}
+
+export interface SelectPartnerResult {
+	success: boolean;
+	error?: string;
+	state?: KalturaSessionState;
+}
+
+// --- Module State ---
+
+let currentKs: string | null = null;
+let currentSession: KalturaStoredSession | null = null;
+
+// Password cache (in-memory only, never persisted)
+let cachedPassword: string | null = null;
+let cachedLoginId: string | null = null;
+let cachedServiceUrl: string | null = null;
+let passwordCacheTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cachePassword(serviceUrl: string, loginId: string, password: string) {
+	cachedServiceUrl = serviceUrl;
+	cachedLoginId = loginId;
+	cachedPassword = password;
+	if (passwordCacheTimer) clearTimeout(passwordCacheTimer);
+	passwordCacheTimer = setTimeout(clearPasswordCache, PASSWORD_CACHE_TTL_MS);
+}
+
+function clearPasswordCache() {
+	cachedPassword = null;
+	cachedLoginId = null;
+	cachedServiceUrl = null;
+	if (passwordCacheTimer) {
+		clearTimeout(passwordCacheTimer);
+		passwordCacheTimer = null;
+	}
+}
+
+// --- Kaltura REST API (direct fetch, not kaltura-client) ---
+
+async function loginByLoginId(
+	serviceUrl: string,
+	loginId: string,
+	password: string,
+	partnerId?: number,
+): Promise<string> {
+	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/loginByLoginId`;
+	const params = new URLSearchParams({
+		format: "1",
+		loginId,
+		password,
+		expiry: String(KS_EXPIRY_SECONDS),
+	});
+	if (partnerId) {
+		params.set("partnerId", String(partnerId));
+	}
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: params.toString(),
+	});
+
+	const text = await response.text();
+
+	// The API returns a plain string KS on success, or JSON error
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		// Plain string KS (success)
+		if (text && !text.includes("KalturaAPIException")) {
+			return text.replace(/^"|"$/g, "");
+		}
+		throw new Error("Unexpected response from Kaltura API");
+	}
+
+	if (parsed && typeof parsed === "object" && "objectType" in (parsed as Record<string, unknown>)) {
+		const err = parsed as { objectType: string; message: string; code: string };
+		if (err.objectType === "KalturaAPIException") {
+			const friendlyMessages: Record<string, string> = {
+				USER_NOT_FOUND: "User not found. Check your email address.",
+				LOGIN_DATA_NOT_FOUND: "Invalid email or password.",
+				USER_WRONG_PASSWORD: "Invalid email or password.",
+				INVALID_PARTNER_ID: "Invalid account. Please try again.",
+				LOGIN_BLOCKED: "Too many failed attempts. Please try again later.",
+				PASSWORD_STRUCTURE_INVALID: "Invalid password format.",
+			};
+			throw new Error(friendlyMessages[err.code] || err.message || "Login failed");
+		}
+	}
+
+	// If parsed is a string (JSON-encoded KS)
+	if (typeof parsed === "string") {
+		return parsed;
+	}
+
+	throw new Error("Unexpected response from Kaltura API");
+}
+
+async function loginByKs(
+	serviceUrl: string,
+	ks: string,
+	partnerId: number,
+): Promise<string> {
+	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/loginByKs`;
+	const params = new URLSearchParams({
+		format: "1",
+		ks,
+		requestedPartnerId: String(partnerId),
+		expiry: String(KS_EXPIRY_SECONDS),
+	});
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: params.toString(),
+	});
+
+	const data = await response.json();
+
+	if (data?.objectType === "KalturaAPIException") {
+		throw new Error(data.message || "Failed to switch account");
+	}
+
+	// loginByKs returns { partnerId, ks } — extract the KS
+	if (data?.ks && typeof data.ks === "string") {
+		return data.ks;
+	}
+
+	throw new Error("Unexpected response from Kaltura API");
+}
+
+async function listPartnersForUser(
+	serviceUrl: string,
+	ks: string,
+): Promise<KalturaPartner[]> {
+	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/partner/action/listPartnersForUser?format=1&clientTag=openscreen`;
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			ks,
+			partnerFilter: {
+				objectType: "KalturaPartnerFilter",
+				statusEqual: 1,
+			},
+			pager: {
+				objectType: "KalturaFilterPager",
+				pageSize: 500,
+			},
+		}),
+	});
+
+	const data = await response.json();
+
+	if (data?.objectType === "KalturaAPIException") {
+		throw new Error(data.message || "Failed to list accounts");
+	}
+
+	return (data.objects || []).map((p: { id: number; name: string }) => ({
+		id: p.id,
+		name: p.name,
+	}));
+}
+
+async function getUserInfo(
+	serviceUrl: string,
+	ks: string,
+): Promise<{ id: string; fullName: string }> {
+	const url = `${serviceUrl.replace(/\/+$/, "")}/api_v3/service/user/action/get`;
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({ format: "1", ks }).toString(),
+	});
+
+	const data = await response.json();
+
+	if (data?.objectType === "KalturaAPIException") {
+		throw new Error(data.message || "Failed to get user info");
+	}
+
+	return {
+		id: data.id || data.email || "",
+		fullName: data.fullName || data.firstName || "",
+	};
+}
+
+// --- Session Persistence ---
+
+async function saveSession(session: KalturaStoredSession): Promise<void> {
+	const encrypted = safeStorage.isEncryptionAvailable()
+		? safeStorage.encryptString(session.ks).toString("base64")
+		: session.ks;
+
+	const stored = {
+		serviceUrl: session.serviceUrl,
+		partnerId: session.partnerId,
+		ks: encrypted,
+		ksExpiry: session.ksExpiry,
+		userId: session.userId,
+		displayName: session.displayName,
+		encrypted: safeStorage.isEncryptionAvailable(),
+	};
+
+	await fs.writeFile(KALTURA_SESSION_FILE, JSON.stringify(stored, null, 2), "utf-8");
+}
+
+export async function loadSession(): Promise<{ success: boolean; state?: KalturaSessionState }> {
+	try {
+		// Clean up old config file from app-token auth
+		const oldConfigFile = path.join(app.getPath("userData"), "kaltura-config.json");
+		try {
+			await fs.unlink(oldConfigFile);
+		} catch {
+			// doesn't exist, fine
+		}
+
+		const content = await fs.readFile(KALTURA_SESSION_FILE, "utf-8");
+		const stored = JSON.parse(content);
+
+		const ks = stored.encrypted
+			? safeStorage.decryptString(Buffer.from(stored.ks, "base64"))
+			: stored.ks;
+
+		const session: KalturaStoredSession = {
+			serviceUrl: stored.serviceUrl,
+			partnerId: stored.partnerId,
+			ks,
+			ksExpiry: stored.ksExpiry,
+			userId: stored.userId,
+			displayName: stored.displayName,
+		};
+
+		// Check if session is still valid
+		if (Date.now() / 1000 >= session.ksExpiry) {
+			// Expired, clear it
+			await clearSession();
+			return { success: false };
+		}
+
+		currentSession = session;
+		currentKs = session.ks;
+
+		return { success: true, state: getSessionState() };
+	} catch {
+		return { success: false };
+	}
+}
+
+async function clearSession(): Promise<void> {
+	try {
+		await fs.unlink(KALTURA_SESSION_FILE);
+	} catch {
+		// file may not exist
+	}
+	currentSession = null;
+	currentKs = null;
+}
+
+// --- Public API ---
+
+export function getSessionState(): KalturaSessionState {
+	if (!currentSession || !currentKs) {
+		return { connected: false };
+	}
+	return {
+		connected: Date.now() / 1000 < currentSession.ksExpiry,
+		partnerId: currentSession.partnerId,
+		serviceUrl: currentSession.serviceUrl,
+		userId: currentSession.userId,
+		displayName: currentSession.displayName,
+		ksExpiry: currentSession.ksExpiry,
+	};
+}
+
+export async function login(
+	serviceUrl: string,
+	loginId: string,
+	password: string,
+): Promise<LoginResult> {
+	try {
+		// Step 1: Login without partnerId to get a multi-partner KS
+		const ks = await loginByLoginId(serviceUrl, loginId, password);
+
+		// Cache password for partner switching
+		cachePassword(serviceUrl, loginId, password);
+
+		// Step 2: List available partners
+		const partners = await listPartnersForUser(serviceUrl, ks);
+
+		if (partners.length === 0) {
+			clearPasswordCache();
+			return { success: false, error: "No accounts found for this user." };
+		}
+
+		if (partners.length === 1) {
+			// Single partner: auto-select and complete login
+			const result = await completeLogin(serviceUrl, loginId, password, partners[0].id);
+			return result;
+		}
+
+		// Multiple partners: return list for user to choose
+		return { success: true, partners };
+	} catch (error) {
+		clearPasswordCache();
+		console.error("Kaltura login failed:", error);
+		return { success: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export async function listPartners(): Promise<{ success: boolean; partners?: KalturaPartner[]; error?: string }> {
+	try {
+		// Use the current session's KS to list partners — no password needed
+		if (currentSession?.ks && currentSession.serviceUrl) {
+			const partners = await listPartnersForUser(currentSession.serviceUrl, currentSession.ks);
+			return { success: true, partners };
+		}
+		// Fallback: try cached credentials
+		if (cachedPassword && cachedLoginId && cachedServiceUrl) {
+			const ks = await loginByLoginId(cachedServiceUrl, cachedLoginId, cachedPassword);
+			const partners = await listPartnersForUser(cachedServiceUrl, ks);
+			return { success: true, partners };
+		}
+		return { success: false, error: "No active session. Please sign in again." };
+	} catch (error) {
+		console.error("Kaltura list partners failed:", error);
+		return { success: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export async function selectPartner(partnerId: number): Promise<SelectPartnerResult> {
+	try {
+		const svcUrl = cachedServiceUrl || currentSession?.serviceUrl;
+		const loginId = cachedLoginId || currentSession?.userId;
+
+		// Prefer password-based login if available
+		if (cachedPassword && loginId && svcUrl) {
+			return await completeLogin(svcUrl, loginId, cachedPassword, partnerId);
+		}
+
+		// Fall back to KS-based partner switch (no password needed)
+		if (currentSession?.ks && currentSession.serviceUrl) {
+			const newKs = await loginByKs(currentSession.serviceUrl, currentSession.ks, partnerId);
+			const userId = loginId || currentSession.userId;
+
+			let displayName: string | undefined;
+			try {
+				const userInfo = await getUserInfo(currentSession.serviceUrl, newKs);
+				displayName = userInfo.fullName || undefined;
+			} catch {
+				// Non-critical
+			}
+
+			const session: KalturaStoredSession = {
+				serviceUrl: currentSession.serviceUrl,
+				partnerId,
+				ks: newKs,
+				ksExpiry: Math.floor(Date.now() / 1000) + KS_EXPIRY_SECONDS,
+				userId: userId,
+				displayName,
+			};
+
+			currentSession = session;
+			currentKs = newKs;
+			await saveSession(session);
+
+			return { success: true, state: getSessionState() };
+		}
+
+		return { success: false, error: "Session expired. Please sign in again." };
+	} catch (error) {
+		console.error("Kaltura partner selection failed:", error);
+		return { success: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+async function completeLogin(
+	serviceUrl: string,
+	loginId: string,
+	password: string,
+	partnerId: number,
+): Promise<LoginResult> {
+	// Login with specific partner
+	const ks = await loginByLoginId(serviceUrl, loginId, password, partnerId);
+
+	// Get user display name
+	let displayName: string | undefined;
+	try {
+		const userInfo = await getUserInfo(serviceUrl, ks);
+		displayName = userInfo.fullName || undefined;
+	} catch {
+		// Non-critical, continue without display name
+	}
+
+	// Build and save session
+	const session: KalturaStoredSession = {
+		serviceUrl,
+		partnerId,
+		ks,
+		ksExpiry: Math.floor(Date.now() / 1000) + KS_EXPIRY_SECONDS,
+		userId: loginId,
+		displayName,
+	};
+
+	currentSession = session;
+	currentKs = ks;
+	await saveSession(session);
+
+	return { success: true, state: getSessionState() };
+}
+
+export async function logout(): Promise<{ success: boolean }> {
+	await clearSession();
+	clearPasswordCache();
+	return { success: true };
+}
+
+export function openSignup(): void {
+	shell.openExternal(SIGNUP_URL);
+}
+
+// --- Kaltura Client for Upload/Categories ---
+
+function createKalturaClientInstance(serviceUrl: string) {
+	const clientConfig = new kaltura.Configuration();
+	clientConfig.serviceUrl = serviceUrl;
+	return new kaltura.Client(clientConfig);
+}
+
+async function getAuthenticatedClient() {
+	if (!currentSession || !currentKs) {
+		throw new Error("Not signed in. Please sign in to your Kaltura account.");
+	}
+
+	// Check if KS is expired
+	if (Date.now() / 1000 >= currentSession.ksExpiry) {
+		// Try silent re-login if password is cached
+		if (cachedPassword && cachedLoginId && cachedServiceUrl) {
+			const result = await completeLogin(
+				cachedServiceUrl,
+				cachedLoginId,
+				cachedPassword,
+				currentSession.partnerId,
+			);
+			if (!result.success) {
+				throw new Error("Session expired. Please sign in again.");
+			}
+		} else {
+			await clearSession();
+			throw new Error("Session expired. Please sign in again.");
+		}
+	}
+
+	const client = createKalturaClientInstance(currentSession.serviceUrl);
+	client.setKs(currentKs!);
+	return client;
+}
+
+// Helper to promisify kaltura service calls
+function execKaltura<T>(serviceAction: unknown, client: unknown): Promise<T> {
+	return new Promise((resolve, reject) => {
+		(serviceAction as { execute: (client: unknown, cb: (ok: boolean, res: unknown) => void) => void })
+			.execute(client, (success: boolean, results: unknown) => {
+				if (success && results) {
+					resolve(results as T);
+				} else {
+					reject(new Error(`Kaltura API call failed: ${JSON.stringify(results)}`));
+				}
+			});
+	});
+}
+
+// --- Upload ---
+
+export interface UploadOptions {
+	filePath: string;
+	name: string;
+	description?: string;
+	tags?: string;
+	categoryIds?: string;
+}
+
+export interface UploadProgress {
+	phase: "uploading" | "processing" | "complete" | "error";
+	percentage: number;
+	entryId?: string;
+	error?: string;
+}
+
+type ProgressCallback = (progress: UploadProgress) => void;
+
+export async function uploadToKaltura(
+	options: UploadOptions,
+	onProgress?: ProgressCallback,
+): Promise<{
+	success: boolean;
+	entryId?: string;
+	error?: string;
+}> {
+	try {
+		const client = await getAuthenticatedClient();
+
+		onProgress?.({ phase: "uploading", percentage: 0 });
+
+		// 1. Create upload token
+		const uploadToken = new kaltura.objects.UploadToken();
+		const createdToken = await execKaltura<{ id: string }>(
+			kaltura.services.uploadToken.add(uploadToken),
+			client,
+		);
+
+		if (!createdToken?.id) {
+			throw new Error("Failed to create upload token");
+		}
+
+		onProgress?.({ phase: "uploading", percentage: 10 });
+
+		// 2. Upload file (kaltura-client handles the file path directly)
+		const fileStats = await fs.stat(options.filePath);
+		const fileSize = fileStats.size;
+		const CHUNK_SIZE = 10 * 1024 * 1024; // 10MB chunks
+
+		if (fileSize <= CHUNK_SIZE) {
+			// Single upload for small files
+			await execKaltura(
+				kaltura.services.uploadToken.upload(
+					createdToken.id,
+					options.filePath,
+					false, // resume
+					true, // finalChunk
+					-1, // resumeAt
+				),
+				client,
+			);
+			onProgress?.({ phase: "uploading", percentage: 80 });
+		} else {
+			// Chunked upload for large files
+			const totalChunks = Math.ceil(fileSize / CHUNK_SIZE);
+			const fileBuffer = await fs.readFile(options.filePath);
+
+			for (let i = 0; i < totalChunks; i++) {
+				const start = i * CHUNK_SIZE;
+				const end = Math.min(start + CHUNK_SIZE, fileSize);
+				const chunk = fileBuffer.subarray(start, end);
+				const isFinal = i === totalChunks - 1;
+
+				// Write chunk to temp file
+				const tempChunkPath = path.join(
+					app.getPath("temp"),
+					`kaltura-chunk-${createdToken.id}-${i}`,
+				);
+				await fs.writeFile(tempChunkPath, chunk);
+
+				try {
+					await execKaltura(
+						kaltura.services.uploadToken.upload(
+							createdToken.id,
+							tempChunkPath,
+							i > 0, // resume
+							isFinal, // finalChunk
+							start, // resumeAt
+						),
+						client,
+					);
+				} finally {
+					await fs.unlink(tempChunkPath).catch(() => {});
+				}
+
+				const uploadPct = 10 + Math.round(((i + 1) / totalChunks) * 70);
+				onProgress?.({ phase: "uploading", percentage: uploadPct });
+			}
+		}
+
+		onProgress?.({ phase: "processing", percentage: 85 });
+
+		// 3. Create media entry
+		const mediaEntry = new kaltura.objects.MediaEntry();
+		mediaEntry.name = options.name;
+		mediaEntry.mediaType = kaltura.enums.MediaType.VIDEO;
+		if (options.description) mediaEntry.description = options.description;
+		if (options.tags) mediaEntry.tags = options.tags;
+
+		const createdEntry = await execKaltura<{ id: string }>(
+			kaltura.services.media.add(mediaEntry),
+			client,
+		);
+
+		if (!createdEntry?.id) {
+			throw new Error("Failed to create media entry");
+		}
+
+		onProgress?.({ phase: "processing", percentage: 90 });
+
+		// 4. Associate uploaded file with entry
+		const resource = new kaltura.objects.UploadedFileTokenResource();
+		resource.token = createdToken.id;
+
+		await execKaltura(
+			kaltura.services.media.addContent(createdEntry.id, resource),
+			client,
+		);
+
+		onProgress?.({ phase: "processing", percentage: 95 });
+
+		// 5. Add to categories if specified
+		if (options.categoryIds) {
+			const categoryIds = options.categoryIds.split(",").map((id) => id.trim());
+			for (const categoryId of categoryIds) {
+				try {
+					const categoryEntry = new kaltura.objects.CategoryEntry();
+					categoryEntry.categoryId = Number.parseInt(categoryId, 10);
+					categoryEntry.entryId = createdEntry.id;
+					await execKaltura(
+						kaltura.services.categoryEntry.add(categoryEntry),
+						client,
+					);
+				} catch (catError) {
+					console.warn(`Failed to add entry to category ${categoryId}:`, catError);
+				}
+			}
+		}
+
+		onProgress?.({
+			phase: "complete",
+			percentage: 100,
+			entryId: createdEntry.id,
+		});
+
+		return { success: true, entryId: createdEntry.id };
+	} catch (error) {
+		console.error("Kaltura upload failed:", error);
+		const errorMsg = String(error);
+		onProgress?.({ phase: "error", percentage: 0, error: errorMsg });
+		return { success: false, error: errorMsg };
+	}
+}
+
+// --- Session Info (for renderer to embed media manager) ---
+
+export function getSessionInfo(): {
+	success: boolean;
+	ks?: string;
+	partnerId?: number;
+	serviceUrl?: string;
+} {
+	if (!currentSession || !currentKs) {
+		return { success: false };
+	}
+	if (Date.now() / 1000 >= currentSession.ksExpiry) {
+		return { success: false };
+	}
+	return {
+		success: true,
+		ks: currentKs,
+		partnerId: currentSession.partnerId,
+		serviceUrl: currentSession.serviceUrl,
+	};
+}
+
+// --- Download from Kaltura ---
+
+export interface DownloadProgress {
+	phase: "downloading" | "complete" | "error";
+	percentage: number;
+	filePath?: string;
+	error?: string;
+}
+
+type DownloadProgressCallback = (progress: DownloadProgress) => void;
+
+export async function downloadFromKaltura(
+	entryId: string,
+	onProgress?: DownloadProgressCallback,
+): Promise<{ success: boolean; filePath?: string; error?: string }> {
+	if (!currentSession || !currentKs) {
+		return { success: false, error: "Not signed in." };
+	}
+
+	// Validate entryId format to prevent path traversal
+	if (!/^[0-9]_[a-zA-Z0-9]+$/.test(entryId)) {
+		return { success: false, error: "Invalid entry ID format." };
+	}
+
+	const { serviceUrl, partnerId } = currentSession;
+	const ks = currentKs;
+
+	// Build playManifest download URL
+	const downloadUrl =
+		`${serviceUrl}/p/${partnerId}/sp/${partnerId}00/playManifest/entryId/${entryId}/format/download/protocol/https?ks=${ks}`;
+
+	const recordingsDir = path.join(app.getPath("userData"), "recordings");
+
+	// Ensure recordings directory exists
+	const { mkdirSync } = await import("node:fs");
+	mkdirSync(recordingsDir, { recursive: true });
+
+	const destPath = path.join(recordingsDir, `kaltura-${entryId}-${Date.now()}.mp4`);
+
+	// Validate resolved path stays within recordings dir
+	const resolvedDest = path.resolve(destPath);
+	const resolvedDir = path.resolve(recordingsDir);
+	if (!resolvedDest.startsWith(resolvedDir + path.sep)) {
+		return { success: false, error: "Invalid download path." };
+	}
+
+	onProgress?.({ phase: "downloading", percentage: 0 });
+
+	try {
+		const response = await fetch(downloadUrl, { redirect: "follow" });
+
+		if (!response.ok) {
+			throw new Error(`Download failed: HTTP ${response.status}`);
+		}
+
+		const contentLength = Number(response.headers.get("content-length") || 0);
+		const body = response.body;
+
+		if (!body) {
+			throw new Error("No response body");
+		}
+
+		const { createWriteStream } = await import("node:fs");
+		const fileStream = createWriteStream(destPath);
+		let downloaded = 0;
+
+		const reader = body.getReader();
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				fileStream.write(Buffer.from(value));
+				downloaded += value.byteLength;
+
+				if (contentLength > 0) {
+					const pct = Math.round((downloaded / contentLength) * 100);
+					onProgress?.({ phase: "downloading", percentage: pct });
+				}
+			}
+		} finally {
+			fileStream.end();
+			await new Promise<void>((resolve, reject) => {
+				fileStream.on("finish", resolve);
+				fileStream.on("error", reject);
+			});
+		}
+
+		onProgress?.({ phase: "complete", percentage: 100, filePath: destPath });
+		return { success: true, filePath: destPath };
+	} catch (error) {
+		// Clean up partial file
+		try {
+			await fs.unlink(destPath);
+		} catch {
+			// may not exist
+		}
+		const errorMsg = error instanceof Error ? error.message : String(error);
+		onProgress?.({ phase: "error", percentage: 0, error: errorMsg });
+		return { success: false, error: errorMsg };
+	}
+}
+
+// --- Categories ---
+
+export async function listCategories(): Promise<{
+	success: boolean;
+	categories?: Array<{ id: number; name: string; fullName: string }>;
+	error?: string;
+}> {
+	try {
+		const client = await getAuthenticatedClient();
+
+		const filter = new kaltura.objects.CategoryFilter();
+		const pager = new kaltura.objects.FilterPager();
+		pager.pageSize = 500;
+
+		const result = await execKaltura<{
+			objects: Array<{ id: number; name: string; fullName: string }>;
+		}>(kaltura.services.category.listAction(filter, pager), client);
+
+		const categories = (result.objects || []).map((cat) => ({
+			id: cat.id,
+			name: cat.name,
+			fullName: cat.fullName,
+		}));
+
+		return { success: true, categories };
+	} catch (error) {
+		console.error("Failed to list categories:", error);
+		return { success: false, error: String(error) };
+	}
+}

--- a/electron/kaltura/kaltura-service.ts
+++ b/electron/kaltura/kaltura-service.ts
@@ -341,14 +341,26 @@ export async function login(
 	password: string,
 ): Promise<LoginResult> {
 	try {
+		// Validate serviceUrl: must be HTTPS
+		let normalizedUrl: string;
+		try {
+			const parsed = new URL(serviceUrl);
+			if (parsed.protocol !== "https:") {
+				return { success: false, error: "Service URL must use HTTPS." };
+			}
+			normalizedUrl = parsed.origin;
+		} catch {
+			return { success: false, error: "Invalid service URL." };
+		}
+
 		// Step 1: Login without partnerId to get a multi-partner KS
-		const ks = await loginByLoginId(serviceUrl, loginId, password);
+		const ks = await loginByLoginId(normalizedUrl, loginId, password);
 
 		// Cache password for partner switching
-		cachePassword(serviceUrl, loginId, password);
+		cachePassword(normalizedUrl, loginId, password);
 
 		// Step 2: List available partners
-		const partners = await listPartnersForUser(serviceUrl, ks);
+		const partners = await listPartnersForUser(normalizedUrl, ks);
 
 		if (partners.length === 0) {
 			clearPasswordCache();
@@ -357,7 +369,7 @@ export async function login(
 
 		if (partners.length === 1) {
 			// Single partner: auto-select and complete login
-			const result = await completeLogin(serviceUrl, loginId, password, partners[0].id);
+			const result = await completeLogin(normalizedUrl, loginId, password, partners[0].id);
 			return result;
 		}
 
@@ -754,20 +766,23 @@ export async function downloadFromKaltura(
 	entryId: string,
 	onProgress?: DownloadProgressCallback,
 ): Promise<{ success: boolean; filePath?: string; error?: string }> {
-	if (!currentSession || !currentKs) {
-		return { success: false, error: "Not signed in." };
-	}
-
 	// Validate entryId format to prevent path traversal
 	if (!/^[0-9]_[a-zA-Z0-9]+$/.test(entryId)) {
 		return { success: false, error: "Invalid entry ID format." };
 	}
 
-	const { serviceUrl, partnerId } = currentSession;
-	const ks = currentKs;
+	// Validate session (handles KS expiry and silent re-auth)
+	try {
+		await getAuthenticatedClient();
+	} catch (error) {
+		return { success: false, error: error instanceof Error ? error.message : "Not signed in." };
+	}
+
+	const { serviceUrl, partnerId } = currentSession!;
+	const ks = currentKs!;
 
 	// Build playManifest download URL
-	const downloadUrl = `${serviceUrl}/p/${partnerId}/sp/${partnerId}00/playManifest/entryId/${entryId}/format/download/protocol/https?ks=${ks}`;
+	const downloadUrl = `${serviceUrl}/p/${partnerId}/sp/${partnerId}00/playManifest/entryId/${entryId}/format/download/protocol/https?ks=${encodeURIComponent(ks)}`;
 
 	const recordingsDir = path.join(app.getPath("userData"), "recordings");
 
@@ -847,22 +862,32 @@ export async function listCategories(): Promise<{
 }> {
 	try {
 		const client = await getAuthenticatedClient();
-
 		const filter = new kaltura.objects.CategoryFilter();
-		const pager = new kaltura.objects.FilterPager();
-		pager.pageSize = CATEGORY_PAGE_SIZE;
+		const allCategories: Array<{ id: number; name: string; fullName: string }> = [];
+		let pageIndex = 1;
 
-		const result = await execKaltura<{
-			objects: Array<{ id: number; name: string; fullName: string }>;
-		}>(kaltura.services.category.listAction(filter, pager), client);
+		while (true) {
+			const pager = new kaltura.objects.FilterPager();
+			pager.pageSize = CATEGORY_PAGE_SIZE;
+			pager.pageIndex = pageIndex;
 
-		const categories = (result.objects || []).map((cat) => ({
-			id: cat.id,
-			name: cat.name,
-			fullName: cat.fullName,
-		}));
+			const result = await execKaltura<{
+				objects: Array<{ id: number; name: string; fullName: string }>;
+				totalCount: number;
+			}>(kaltura.services.category.listAction(filter, pager), client);
 
-		return { success: true, categories };
+			const objects = result.objects || [];
+			for (const cat of objects) {
+				allCategories.push({ id: cat.id, name: cat.name, fullName: cat.fullName });
+			}
+
+			if (allCategories.length >= result.totalCount || objects.length < CATEGORY_PAGE_SIZE) {
+				break;
+			}
+			pageIndex++;
+		}
+
+		return { success: true, categories: allCategories };
 	} catch (error) {
 		console.error("Failed to list categories:", error);
 		return { success: false, error: String(error) };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,8 @@ import {
 } from "electron";
 import { mainT, setMainLocale } from "./i18n";
 import { registerIpcHandlers } from "./ipc/handlers";
-import { createEditorWindow, createHudOverlayWindow, createSourceSelectorWindow } from "./windows";
+import { registerKalturaIpcHandlers } from "./kaltura/kaltura-ipc";
+import { createEditorWindow, createHudOverlayWindow, createKalturaBrowseWindow, createSourceSelectorWindow } from "./windows";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -60,6 +61,7 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
 // Window references
 let mainWindow: BrowserWindow | null = null;
 let sourceSelectorWindow: BrowserWindow | null = null;
+let kalturaBrowseWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let selectedSourceName = "";
 
@@ -320,6 +322,18 @@ function createSourceSelectorWindowWrapper() {
 	return sourceSelectorWindow;
 }
 
+function createKalturaBrowseWindowWrapper() {
+	if (kalturaBrowseWindow && !kalturaBrowseWindow.isDestroyed()) {
+		kalturaBrowseWindow.focus();
+		return kalturaBrowseWindow;
+	}
+	kalturaBrowseWindow = createKalturaBrowseWindow();
+	kalturaBrowseWindow.on("closed", () => {
+		kalturaBrowseWindow = null;
+	});
+	return kalturaBrowseWindow;
+}
+
 // On macOS, applications and their menu bar stay active until the user quits
 // explicitly with Cmd + Q.
 app.on("window-all-closed", () => {
@@ -381,11 +395,14 @@ app.whenReady().then(async () => {
 		showMainWindow();
 	}
 
+	registerKalturaIpcHandlers();
 	registerIpcHandlers(
 		createEditorWindowWrapper,
 		createSourceSelectorWindowWrapper,
+		createKalturaBrowseWindowWrapper,
 		() => mainWindow,
 		() => sourceSelectorWindow,
+		() => kalturaBrowseWindow,
 		(recording: boolean, sourceName: string) => {
 			selectedSourceName = sourceName;
 			if (!tray) createTray();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,7 +15,12 @@ import {
 import { mainT, setMainLocale } from "./i18n";
 import { registerIpcHandlers } from "./ipc/handlers";
 import { registerKalturaIpcHandlers } from "./kaltura/kaltura-ipc";
-import { createEditorWindow, createHudOverlayWindow, createKalturaBrowseWindow, createSourceSelectorWindow } from "./windows";
+import {
+	createEditorWindow,
+	createHudOverlayWindow,
+	createKalturaBrowseWindow,
+	createSourceSelectorWindow,
+} from "./windows";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -165,8 +165,25 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	kalturaListCategories: () => {
 		return ipcRenderer.invoke("kaltura-list-categories");
 	},
-	onKalturaUploadProgress: (callback: (progress: unknown) => void) => {
-		const listener = (_: unknown, progress: unknown) => callback(progress);
+	onKalturaUploadProgress: (
+		callback: (progress: {
+			uploadId: string;
+			phase: "uploading" | "processing" | "complete" | "error";
+			percentage: number;
+			entryId?: string;
+			error?: string;
+		}) => void,
+	) => {
+		const listener = (
+			_: unknown,
+			progress: {
+				uploadId: string;
+				phase: "uploading" | "processing" | "complete" | "error";
+				percentage: number;
+				entryId?: string;
+				error?: string;
+			},
+		) => callback(progress);
 		ipcRenderer.on("kaltura-upload-progress", listener);
 		return () => ipcRenderer.removeListener("kaltura-upload-progress", listener);
 	},
@@ -176,8 +193,23 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	kalturaDownload: (params: { entryId: string }) => {
 		return ipcRenderer.invoke("kaltura-download", params);
 	},
-	onKalturaDownloadProgress: (callback: (progress: unknown) => void) => {
-		const listener = (_: unknown, progress: unknown) => callback(progress);
+	onKalturaDownloadProgress: (
+		callback: (progress: {
+			phase: "downloading" | "complete" | "error";
+			percentage: number;
+			filePath?: string;
+			error?: string;
+		}) => void,
+	) => {
+		const listener = (
+			_: unknown,
+			progress: {
+				phase: "downloading" | "complete" | "error";
+				percentage: number;
+				filePath?: string;
+				error?: string;
+			},
+		) => callback(progress);
 		ipcRenderer.on("kaltura-download-progress", listener);
 		return () => ipcRenderer.removeListener("kaltura-download-progress", listener);
 	},

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -130,6 +130,72 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	setHasUnsavedChanges: (hasChanges: boolean) => {
 		ipcRenderer.send("set-has-unsaved-changes", hasChanges);
 	},
+
+	// --- Kaltura Integration ---
+	kalturaLogin: (params: { serviceUrl: string; loginId: string; password: string }) => {
+		return ipcRenderer.invoke("kaltura-login", params);
+	},
+	kalturaSelectPartner: (params: { partnerId: number }) => {
+		return ipcRenderer.invoke("kaltura-select-partner", params);
+	},
+	kalturaListPartners: () => {
+		return ipcRenderer.invoke("kaltura-list-partners");
+	},
+	kalturaLogout: () => {
+		return ipcRenderer.invoke("kaltura-logout");
+	},
+	kalturaLoadSession: () => {
+		return ipcRenderer.invoke("kaltura-load-session");
+	},
+	kalturaGetSessionState: () => {
+		return ipcRenderer.invoke("kaltura-get-session-state");
+	},
+	kalturaOpenSignup: () => {
+		return ipcRenderer.invoke("kaltura-open-signup");
+	},
+	kalturaUpload: (options: {
+		filePath: string;
+		name: string;
+		description?: string;
+		tags?: string;
+		categoryIds?: string;
+	}) => {
+		return ipcRenderer.invoke("kaltura-upload", options);
+	},
+	kalturaListCategories: () => {
+		return ipcRenderer.invoke("kaltura-list-categories");
+	},
+	onKalturaUploadProgress: (callback: (progress: unknown) => void) => {
+		const listener = (_: unknown, progress: unknown) => callback(progress);
+		ipcRenderer.on("kaltura-upload-progress", listener);
+		return () => ipcRenderer.removeListener("kaltura-upload-progress", listener);
+	},
+	kalturaGetSessionInfo: () => {
+		return ipcRenderer.invoke("kaltura-get-session-info");
+	},
+	kalturaDownload: (params: { entryId: string }) => {
+		return ipcRenderer.invoke("kaltura-download", params);
+	},
+	onKalturaDownloadProgress: (callback: (progress: unknown) => void) => {
+		const listener = (_: unknown, progress: unknown) => callback(progress);
+		ipcRenderer.on("kaltura-download-progress", listener);
+		return () => ipcRenderer.removeListener("kaltura-download-progress", listener);
+	},
+	openKalturaBrowse: () => {
+		return ipcRenderer.invoke("open-kaltura-browse");
+	},
+	closeKalturaBrowse: () => {
+		return ipcRenderer.invoke("close-kaltura-browse");
+	},
+	kalturaBrowseVideoLoaded: (filePath: string) => {
+		return ipcRenderer.invoke("kaltura-browse-video-loaded", filePath);
+	},
+	onKalturaVideoLoaded: (callback: (filePath: string) => void) => {
+		const listener = (_: unknown, filePath: string) => callback(filePath);
+		ipcRenderer.on("kaltura-video-loaded", listener);
+		return () => ipcRenderer.removeListener("kaltura-video-loaded", listener);
+	},
+
 	onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => {
 		const listener = async () => {
 			try {

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -37,6 +37,7 @@ export function createKalturaBrowseWindow(): BrowserWindow {
 			preload: path.join(__dirname, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
+			// Needed to load the Kaltura Unisphere media manager widget from CDN
 			webSecurity: false,
 		},
 	});

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -17,6 +17,41 @@ ipcMain.on("hud-overlay-hide", () => {
 	}
 });
 
+export function createKalturaBrowseWindow(): BrowserWindow {
+	const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+
+	const winWidth = 1100;
+	const winHeight = 750;
+
+	const win = new BrowserWindow({
+		width: winWidth,
+		height: winHeight,
+		x: Math.round((width - winWidth) / 2),
+		y: Math.round((height - winHeight) / 2),
+		frame: false,
+		resizable: false,
+		alwaysOnTop: true,
+		transparent: false,
+		backgroundColor: "#09090b",
+		webPreferences: {
+			preload: path.join(__dirname, "preload.mjs"),
+			nodeIntegration: false,
+			contextIsolation: true,
+			webSecurity: false,
+		},
+	});
+
+	if (VITE_DEV_SERVER_URL) {
+		win.loadURL(VITE_DEV_SERVER_URL + "?windowType=kaltura-browse");
+	} else {
+		win.loadFile(path.join(RENDERER_DIST, "index.html"), {
+			query: { windowType: "kaltura-browse" },
+		});
+	}
+
+	return win;
+}
+
 export function createHudOverlayWindow(): BrowserWindow {
 	const primaryDisplay = screen.getPrimaryDisplay();
 	const { workArea } = primaryDisplay;

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -37,7 +37,8 @@ export function createKalturaBrowseWindow(): BrowserWindow {
 			preload: path.join(__dirname, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
-			// Needed to load the Kaltura Unisphere media manager widget from CDN
+			// Required: the Kaltura Unisphere media manager widget loads ES modules from
+			// its CDN (cross-origin). Context isolation is still enforced — no Node access.
 			webSecurity: false,
 		},
 	});
@@ -133,6 +134,7 @@ export function createEditorWindow(): BrowserWindow {
 			preload: path.join(__dirname, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
+			// Pre-existing upstream setting; needed for loading local video files via file:// URLs
 			webSecurity: false,
 			backgroundThrottling: false,
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"fix-webm-duration": "^1.0.6",
 				"gif.js": "^0.2.0",
 				"gsap": "^3.13.0",
+				"kaltura-client": "^22.13.1",
 				"lucide-react": "^0.545.0",
 				"mediabunny": "^1.25.1",
 				"motion": "^12.23.24",
@@ -7126,7 +7127,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/at-least-node": {
@@ -7193,6 +7193,17 @@
 			"integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
+			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -7739,6 +7750,15 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -7970,7 +7990,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -8108,6 +8127,15 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/css-tree": {
@@ -8329,7 +8357,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -9059,7 +9086,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -9409,7 +9435,6 @@
 			"version": "1.15.11",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
 			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -9456,7 +9481,6 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
 			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -9990,7 +10014,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -10377,6 +10400,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"license": "MIT"
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
@@ -10821,6 +10850,20 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"node_modules/kaltura-client": {
+			"version": "22.13.1",
+			"resolved": "https://registry.npmjs.org/kaltura-client/-/kaltura-client-22.13.1.tgz",
+			"integrity": "sha512-MjWYzjTEM70HKE/glRRA6NssJL26fJymlDVLKlVVdU6ap3HX8Fv2RrtyAG+JqOJFjxF6NnRx6AdK2n527YwszQ==",
+			"license": "AGPLv3",
+			"dependencies": {
+				"axios": "^1.1.3",
+				"md5": "^2.3.0",
+				"path": "^0.12.7"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/kew": {
@@ -11553,6 +11596,17 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -11622,7 +11676,6 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -11632,7 +11685,6 @@
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "1.52.0"
@@ -12493,6 +12545,16 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
+		"node_modules/path": {
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+			"integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"process": "^0.11.1",
+				"util": "^0.10.3"
+			}
+		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -13150,7 +13212,6 @@
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
@@ -13223,6 +13284,15 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/psl": {
 			"version": "1.15.0",
@@ -15592,11 +15662,26 @@
 				"pako": "^1.0.5"
 			}
 		},
+		"node_modules/util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "2.0.3"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
+		},
+		"node_modules/util/node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+			"license": "ISC"
 		},
 		"node_modules/uuid": {
 			"version": "13.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.13",
-				"@playwright/test": "^1.59.1",
+				"@playwright/test": "^1.58.2",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -61,8 +61,6 @@
 				"@types/react-dom": "^18.2.21",
 				"@types/uuid": "^10.0.0",
 				"@vitejs/plugin-react": "^4.2.1",
-				"@vitest/browser": "^4.0.16",
-				"@vitest/browser-playwright": "^4.0.16",
 				"autoprefixer": "^10.4.21",
 				"electron": "^39.2.7",
 				"electron-builder": "^26.7.0",
@@ -197,6 +195,7 @@
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -425,6 +424,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
 			"integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -741,6 +741,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -789,6 +790,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1552,7 +1554,6 @@
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"cross-dirname": "^0.1.0",
 				"debug": "^4.3.4",
@@ -1574,7 +1575,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -1591,7 +1591,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -1606,7 +1605,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -1901,13 +1899,14 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -1934,13 +1933,14 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -1967,13 +1967,14 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openharmony"
@@ -2305,6 +2306,7 @@
 			"integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/core": "^0.16.13"
@@ -2347,6 +2349,7 @@
 			"integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -2361,6 +2364,7 @@
 			"integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -2389,6 +2393,7 @@
 			"integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13",
@@ -2438,6 +2443,7 @@
 			"integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -2581,6 +2587,7 @@
 			"integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -2595,6 +2602,7 @@
 			"integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -2612,6 +2620,7 @@
 			"integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.7.2",
 				"@jimp/utils": "^0.16.13"
@@ -3038,7 +3047,6 @@
 			"resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
 			"integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@pixi/colord": "^2.9.6"
 			}
@@ -3053,8 +3061,7 @@
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
 			"integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pixi/core": {
 			"version": "7.4.3",
@@ -3081,8 +3088,7 @@
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
 			"integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pixi/filter-drop-shadow": {
 			"version": "5.2.0",
@@ -3109,22 +3115,19 @@
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
 			"integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pixi/runner": {
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
 			"integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pixi/settings": {
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
 			"integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@pixi/constants": "7.4.3",
 				"@types/css-font-loading-module": "^0.0.12",
@@ -3136,7 +3139,6 @@
 			"resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
 			"integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@pixi/extensions": "7.4.3",
 				"@pixi/settings": "7.4.3",
@@ -3148,7 +3150,6 @@
 			"resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
 			"integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@pixi/color": "7.4.3",
 				"@pixi/constants": "7.4.3",
@@ -3163,22 +3164,19 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
 			"integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pixi/utils/node_modules/earcut": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
 			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/@pixi/utils/node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
@@ -3191,12 +3189,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3204,12 +3202,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@polka/url": {
-			"version": "1.0.0-next.29",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-			"dev": true
 		},
 		"node_modules/@radix-ui/number": {
 			"version": "1.1.1",
@@ -4477,7 +4469,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
@@ -4604,8 +4597,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4670,6 +4662,7 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
 			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/deep-eql": "*",
 				"assertion-error": "^2.0.1"
@@ -4695,7 +4688,8 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/dom-mediacapture-transform": {
 			"version": "0.1.11",
@@ -4815,6 +4809,7 @@
 			"integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -4826,6 +4821,7 @@
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -4949,1377 +4945,12 @@
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
-		"node_modules/@vitest/browser": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.0.16.tgz",
-			"integrity": "sha512-t4toy8X/YTnjYEPoY0pbDBg3EvDPg1elCDrfc+VupPHwoN/5/FNQ8Z+xBYIaEnOE2vVEyKwqYBzZ9h9rJtZVcg==",
-			"dev": true,
-			"dependencies": {
-				"@vitest/mocker": "4.0.16",
-				"@vitest/utils": "4.0.16",
-				"magic-string": "^0.30.21",
-				"pixelmatch": "7.1.0",
-				"pngjs": "^7.0.0",
-				"sirv": "^3.0.2",
-				"tinyrainbow": "^3.0.3",
-				"ws": "^8.18.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"vitest": "4.0.16"
-			}
-		},
-		"node_modules/@vitest/browser-playwright": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.16.tgz",
-			"integrity": "sha512-I2Fy/ANdphi1yI46d15o0M1M4M0UJrUiVKkH5oKeRZZCdPg0fw/cfTKZzv9Ge9eobtJYp4BGblMzXdXH0vcl5g==",
-			"dev": true,
-			"dependencies": {
-				"@vitest/browser": "4.0.16",
-				"@vitest/mocker": "4.0.16",
-				"tinyrainbow": "^3.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"playwright": "*",
-				"vitest": "4.0.16"
-			},
-			"peerDependenciesMeta": {
-				"playwright": {
-					"optional": false
-				}
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/android-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/android-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/@vitest/mocker": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-			"integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
-			"dev": true,
-			"dependencies": {
-				"@vitest/spy": "4.0.16",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/esbuild": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.7",
-				"@esbuild/android-arm": "0.27.7",
-				"@esbuild/android-arm64": "0.27.7",
-				"@esbuild/android-x64": "0.27.7",
-				"@esbuild/darwin-arm64": "0.27.7",
-				"@esbuild/darwin-x64": "0.27.7",
-				"@esbuild/freebsd-arm64": "0.27.7",
-				"@esbuild/freebsd-x64": "0.27.7",
-				"@esbuild/linux-arm": "0.27.7",
-				"@esbuild/linux-arm64": "0.27.7",
-				"@esbuild/linux-ia32": "0.27.7",
-				"@esbuild/linux-loong64": "0.27.7",
-				"@esbuild/linux-mips64el": "0.27.7",
-				"@esbuild/linux-ppc64": "0.27.7",
-				"@esbuild/linux-riscv64": "0.27.7",
-				"@esbuild/linux-s390x": "0.27.7",
-				"@esbuild/linux-x64": "0.27.7",
-				"@esbuild/netbsd-arm64": "0.27.7",
-				"@esbuild/netbsd-x64": "0.27.7",
-				"@esbuild/openbsd-arm64": "0.27.7",
-				"@esbuild/openbsd-x64": "0.27.7",
-				"@esbuild/openharmony-arm64": "0.27.7",
-				"@esbuild/sunos-x64": "0.27.7",
-				"@esbuild/win32-arm64": "0.27.7",
-				"@esbuild/win32-ia32": "0.27.7",
-				"@esbuild/win32-x64": "0.27.7"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@vitest/browser-playwright/node_modules/vite": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/android-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/android-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@vitest/mocker": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-			"integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
-			"dev": true,
-			"dependencies": {
-				"@vitest/spy": "4.0.16",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/esbuild": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.7",
-				"@esbuild/android-arm": "0.27.7",
-				"@esbuild/android-arm64": "0.27.7",
-				"@esbuild/android-x64": "0.27.7",
-				"@esbuild/darwin-arm64": "0.27.7",
-				"@esbuild/darwin-x64": "0.27.7",
-				"@esbuild/freebsd-arm64": "0.27.7",
-				"@esbuild/freebsd-x64": "0.27.7",
-				"@esbuild/linux-arm": "0.27.7",
-				"@esbuild/linux-arm64": "0.27.7",
-				"@esbuild/linux-ia32": "0.27.7",
-				"@esbuild/linux-loong64": "0.27.7",
-				"@esbuild/linux-mips64el": "0.27.7",
-				"@esbuild/linux-ppc64": "0.27.7",
-				"@esbuild/linux-riscv64": "0.27.7",
-				"@esbuild/linux-s390x": "0.27.7",
-				"@esbuild/linux-x64": "0.27.7",
-				"@esbuild/netbsd-arm64": "0.27.7",
-				"@esbuild/netbsd-x64": "0.27.7",
-				"@esbuild/openbsd-arm64": "0.27.7",
-				"@esbuild/openbsd-x64": "0.27.7",
-				"@esbuild/openharmony-arm64": "0.27.7",
-				"@esbuild/sunos-x64": "0.27.7",
-				"@esbuild/win32-arm64": "0.27.7",
-				"@esbuild/win32-ia32": "0.27.7",
-				"@esbuild/win32-x64": "0.27.7"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/pixelmatch": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
-			"integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
-			"dev": true,
-			"dependencies": {
-				"pngjs": "^7.0.0"
-			},
-			"bin": {
-				"pixelmatch": "bin/pixelmatch"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/pngjs": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.19.0"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/vite": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.16",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
 			"integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@types/chai": "^5.2.2",
@@ -6337,6 +4968,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
 			"integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^3.0.3"
 			},
@@ -6349,6 +4981,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
 			"integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/utils": "4.0.16",
 				"pathe": "^2.0.3"
@@ -6362,6 +4995,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
 			"integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "4.0.16",
 				"magic-string": "^0.30.21",
@@ -6376,6 +5010,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
 			"integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
@@ -6385,6 +5020,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
 			"integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "4.0.16",
 				"tinyrainbow": "^3.0.3"
@@ -6494,6 +5130,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -7091,6 +5728,7 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
 			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			}
@@ -7343,6 +5981,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -7655,7 +6294,6 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -7725,10 +6363,11 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+			"integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -8112,8 +6751,7 @@
 			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -8469,6 +7107,7 @@
 			"integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "26.7.0",
 				"builder-util": "26.4.1",
@@ -8561,8 +7200,7 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dom-walk": {
 			"version": "0.1.2",
@@ -8903,7 +7541,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@electron/asar": "^3.2.1",
 				"debug": "^4.1.1",
@@ -8924,7 +7561,6 @@
 			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -9068,7 +7704,8 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
 			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -9180,6 +7817,7 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -10640,6 +9278,7 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -11474,7 +10113,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -12057,15 +10695,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/mrmime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12326,7 +10955,6 @@
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -12616,7 +11244,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pe-library": {
 			"version": "0.4.1",
@@ -12881,6 +11510,7 @@
 			"resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.14.0.tgz",
 			"integrity": "sha512-ituDiEBb1Oqx56RYwTtC6MjPUhPfF/i15fpUv5oEqmzC/ce3SaSumulJcOjKG7+y0J0Ekl9Rl4XTxaUw+MVFZw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@pixi/colord": "^2.9.6",
 				"@types/css-font-loading-module": "^0.0.12",
@@ -12900,12 +11530,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -12918,9 +11548,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -12976,9 +11606,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -12993,6 +11623,8 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -13137,7 +11769,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"commander": "^9.4.0"
 			},
@@ -13155,7 +11786,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
@@ -13166,7 +11796,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -13182,7 +11811,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -13195,8 +11823,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/proc-log": {
 			"version": "5.0.0",
@@ -13350,7 +11977,6 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
 			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"side-channel": "^1.1.0"
 			},
@@ -13409,6 +12035,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -13421,6 +12048,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -14248,7 +12876,6 @@
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"object-inspect": "^1.13.3",
@@ -14268,7 +12895,6 @@
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
 			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"object-inspect": "^1.13.3"
@@ -14285,7 +12911,6 @@
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -14304,7 +12929,6 @@
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -14349,20 +12973,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/sirv": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-			"dev": true,
-			"dependencies": {
-				"@polka/url": "^1.0.0-next.24",
-				"mrmime": "^2.0.0",
-				"totalist": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/slash": {
@@ -14596,7 +13206,8 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
@@ -14985,6 +13596,7 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
 			"integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -15057,7 +13669,6 @@
 			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
@@ -15121,7 +13732,6 @@
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.6"
 			},
@@ -15136,7 +13746,6 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -15150,6 +13759,7 @@
 			"integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -15302,6 +13912,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -15310,10 +13921,11 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -15386,15 +13998,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/totalist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/tough-cookie": {
@@ -15586,7 +14189,6 @@
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
 			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"punycode": "^1.4.1",
 				"qs": "^6.12.3"
@@ -15599,8 +14201,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/use-callback-ref": {
 			"version": "1.3.3",
@@ -15729,6 +14330,7 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -15803,13 +14405,15 @@
 			"resolved": "https://registry.npmjs.org/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.6.tgz",
 			"integrity": "sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/vitest": {
 			"version": "4.0.16",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
 			"integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/expect": "4.0.16",
 				"@vitest/mocker": "4.0.16",
@@ -15883,13 +14487,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"aix"
@@ -15899,13 +14504,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -15915,13 +14521,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -15931,13 +14538,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -15947,13 +14555,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -15963,13 +14572,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -15979,13 +14589,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -15995,13 +14606,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -16011,13 +14623,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16027,13 +14640,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16043,13 +14657,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16059,13 +14674,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16075,13 +14691,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
 			"cpu": [
 				"mips64el"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16091,13 +14708,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16107,13 +14725,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16123,13 +14742,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16139,13 +14759,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -16155,13 +14776,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -16171,13 +14793,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -16187,13 +14810,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
@@ -16203,13 +14827,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -16219,13 +14844,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -16235,13 +14861,14 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -16255,6 +14882,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
 			"integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/spy": "4.0.16",
 				"estree-walker": "^3.0.3",
@@ -16277,11 +14905,12 @@
 			}
 		},
 		"node_modules/vitest/node_modules/esbuild": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -16289,32 +14918,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.12",
-				"@esbuild/android-arm": "0.25.12",
-				"@esbuild/android-arm64": "0.25.12",
-				"@esbuild/android-x64": "0.25.12",
-				"@esbuild/darwin-arm64": "0.25.12",
-				"@esbuild/darwin-x64": "0.25.12",
-				"@esbuild/freebsd-arm64": "0.25.12",
-				"@esbuild/freebsd-x64": "0.25.12",
-				"@esbuild/linux-arm": "0.25.12",
-				"@esbuild/linux-arm64": "0.25.12",
-				"@esbuild/linux-ia32": "0.25.12",
-				"@esbuild/linux-loong64": "0.25.12",
-				"@esbuild/linux-mips64el": "0.25.12",
-				"@esbuild/linux-ppc64": "0.25.12",
-				"@esbuild/linux-riscv64": "0.25.12",
-				"@esbuild/linux-s390x": "0.25.12",
-				"@esbuild/linux-x64": "0.25.12",
-				"@esbuild/netbsd-arm64": "0.25.12",
-				"@esbuild/netbsd-x64": "0.25.12",
-				"@esbuild/openbsd-arm64": "0.25.12",
-				"@esbuild/openbsd-x64": "0.25.12",
-				"@esbuild/openharmony-arm64": "0.25.12",
-				"@esbuild/sunos-x64": "0.25.12",
-				"@esbuild/win32-arm64": "0.25.12",
-				"@esbuild/win32-ia32": "0.25.12",
-				"@esbuild/win32-x64": "0.25.12"
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
 			}
 		},
 		"node_modules/vitest/node_modules/fdir": {
@@ -16322,6 +14951,7 @@
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
 			},
@@ -16335,10 +14965,12 @@
 			}
 		},
 		"node_modules/vitest/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
+			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -16347,23 +14979,25 @@
 			}
 		},
 		"node_modules/vitest/node_modules/vite": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"dev": true,
+			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"esbuild": "^0.25.0",
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2",
-				"postcss": "^8.5.3",
-				"rollup": "^4.34.9",
-				"tinyglobby": "^0.2.13"
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -16372,14 +15006,14 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@types/node": "^20.19.0 || >=22.12.0",
 				"jiti": ">=1.21.0",
-				"less": "*",
+				"less": "^4.0.0",
 				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
 				"terser": "^5.16.0",
 				"tsx": "^4.8.1",
 				"yaml": "^2.4.2"
@@ -16578,27 +15212,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/xhr": {
 			"version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"fix-webm-duration": "^1.0.6",
 		"gif.js": "^0.2.0",
 		"gsap": "^3.13.0",
+		"kaltura-client": "^22.13.1",
 		"lucide-react": "^0.545.0",
 		"mediabunny": "^1.25.1",
 		"motion": "^12.23.24",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { LaunchWindow } from "./components/launch/LaunchWindow";
 import { SourceSelector } from "./components/launch/SourceSelector";
 import { Toaster } from "./components/ui/sonner";
 import { TooltipProvider } from "./components/ui/tooltip";
+import { KalturaBrowsePage } from "./components/video-editor/KalturaBrowseDialog";
 import { ShortcutsConfigDialog } from "./components/video-editor/ShortcutsConfigDialog";
 import VideoEditor from "./components/video-editor/VideoEditor";
 import { ShortcutsProvider } from "./contexts/ShortcutsContext";
@@ -33,6 +34,8 @@ export default function App() {
 				return <LaunchWindow />;
 			case "source-selector":
 				return <SourceSelector />;
+			case "kaltura-browse":
+				return <KalturaBrowsePage />;
 			case "editor":
 				return (
 					<ShortcutsProvider>

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -202,11 +202,19 @@ export function LaunchWindow() {
 	// Listen for video loaded from the Kaltura browse window
 	useEffect(() => {
 		const unsub = window.electronAPI.onKalturaVideoLoaded(async (filePath: string) => {
-			await window.electronAPI.setCurrentVideoPath(filePath);
-			// Note: don't call setCurrentRecordingSession(null) — setCurrentVideoPath already
-			// creates a recording session with the video path. Wiping it would cause
-			// "No video to load" in the editor.
-			await window.electronAPI.switchToEditor();
+			try {
+				const result = await window.electronAPI.setCurrentVideoPath(filePath);
+				if (!result.success) {
+					console.error("Failed to set video path");
+					return;
+				}
+				// Note: don't call setCurrentRecordingSession(null) — setCurrentVideoPath already
+				// creates a recording session with the video path. Wiping it would cause
+				// "No video to load" in the editor.
+				await window.electronAPI.switchToEditor();
+			} catch (err) {
+				console.error("Failed to load Kaltura video:", err);
+			}
 		});
 		return unsub;
 	}, []);

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Languages } from "lucide-react";
+import { ChevronDown, Cloud, Languages } from "lucide-react";
 import { useEffect, useState } from "react";
 import { BsPauseCircle, BsPlayCircle, BsRecordCircle } from "react-icons/bs";
 import { FaRegStopCircle } from "react-icons/fa";
@@ -189,6 +189,23 @@ export function LaunchWindow() {
 		if (window.electronAPI) {
 			window.electronAPI.openSourceSelector();
 		}
+	};
+
+	// --- Kaltura Load ---
+	// Listen for video loaded from the Kaltura browse window
+	useEffect(() => {
+		const unsub = window.electronAPI.onKalturaVideoLoaded(async (filePath: string) => {
+			await window.electronAPI.setCurrentVideoPath(filePath);
+			// Note: don't call setCurrentRecordingSession(null) — setCurrentVideoPath already
+			// creates a recording session with the video path. Wiping it would cause
+			// "No video to load" in the editor.
+			await window.electronAPI.switchToEditor();
+		});
+		return unsub;
+	}, []);
+
+	const handleLoadFromKaltura = () => {
+		window.electronAPI.openKalturaBrowse();
 	};
 
 	const openVideoFile = async () => {
@@ -515,6 +532,17 @@ export function LaunchWindow() {
 					</button>
 				</Tooltip>
 
+				{/* Load from Kaltura */}
+				<Tooltip content="Load from Kaltura">
+					<button
+						className={`${hudIconBtnClasses} ${styles.electronNoDrag}`}
+						onClick={handleLoadFromKaltura}
+						disabled={recording}
+					>
+						<Cloud size={ICON_SIZE} className="text-orange-400/70" />
+					</button>
+				</Tooltip>
+
 				{/* Window controls */}
 				<div className={`flex items-center gap-0.5 ${styles.electronNoDrag}`}>
 					<button
@@ -533,6 +561,7 @@ export function LaunchWindow() {
 					</button>
 				</div>
 			</div>
+
 		</div>
 	);
 }

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -17,6 +17,12 @@ import {
 	MdVolumeUp,
 } from "react-icons/md";
 import { RxDragHandleDots2 } from "react-icons/rx";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useI18n, useScopedT } from "@/contexts/I18nContext";
 import { type Locale, SUPPORTED_LOCALES } from "@/i18n/config";
 import { getLocaleName } from "@/i18n/loader";
@@ -72,6 +78,7 @@ const windowBtnClasses =
 
 export function LaunchWindow() {
 	const t = useScopedT("launch");
+	const tK = useScopedT("kaltura");
 	const { locale, setLocale } = useI18n();
 	const [isMac, setIsMac] = useState(false);
 
@@ -191,7 +198,7 @@ export function LaunchWindow() {
 		}
 	};
 
-	// --- Kaltura Load ---
+	// --- Kaltura ---
 	// Listen for video loaded from the Kaltura browse window
 	useEffect(() => {
 		const unsub = window.electronAPI.onKalturaVideoLoaded(async (filePath: string) => {
@@ -532,16 +539,25 @@ export function LaunchWindow() {
 					</button>
 				</Tooltip>
 
-				{/* Load from Kaltura */}
-				<Tooltip content="Load from Kaltura">
-					<button
-						className={`${hudIconBtnClasses} ${styles.electronNoDrag}`}
-						onClick={handleLoadFromKaltura}
-						disabled={recording}
+				{/* Cloud sources dropdown — generic menu, providers are items */}
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild disabled={recording}>
+						<button className={`${hudIconBtnClasses} ${styles.electronNoDrag}`} type="button">
+							<Cloud size={ICON_SIZE} className="text-white/60" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						className={`bg-[#1a1a1f] border-white/10 min-w-[160px] ${styles.electronNoDrag}`}
+						sideOffset={8}
 					>
-						<Cloud size={ICON_SIZE} className="text-orange-400/70" />
-					</button>
-				</Tooltip>
+						<DropdownMenuItem
+							className="text-slate-200 focus:bg-white/10 focus:text-white cursor-pointer"
+							onSelect={handleLoadFromKaltura}
+						>
+							{tK("toolbar.loadFromKaltura")}
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
 
 				{/* Window controls */}
 				<div className={`flex items-center gap-0.5 ${styles.electronNoDrag}`}>
@@ -561,7 +577,6 @@ export function LaunchWindow() {
 					</button>
 				</div>
 			</div>
-
 		</div>
 	);
 }

--- a/src/components/video-editor/ExportDialog.tsx
+++ b/src/components/video-editor/ExportDialog.tsx
@@ -50,13 +50,16 @@ export function ExportDialog({
 	useEffect(() => {
 		if (!isExporting && progress && progress.percentage >= 100 && !error) {
 			setShowSuccess(true);
-			const timer = setTimeout(() => {
-				setShowSuccess(false);
-				onClose();
-			}, 2000);
-			return () => clearTimeout(timer);
+			// Keep the dialog open when there's a follow-up action (e.g. Upload to Kaltura)
+			if (!onUploadToKaltura || exportFormat !== "mp4") {
+				const timer = setTimeout(() => {
+					setShowSuccess(false);
+					onClose();
+				}, 2000);
+				return () => clearTimeout(timer);
+			}
 		}
-	}, [isExporting, progress, error, onClose]);
+	}, [isExporting, progress, error, onClose, onUploadToKaltura, exportFormat]);
 
 	if (!isOpen) return null;
 

--- a/src/components/video-editor/ExportDialog.tsx
+++ b/src/components/video-editor/ExportDialog.tsx
@@ -1,4 +1,4 @@
-import { Download, Loader2, X } from "lucide-react";
+import { Cloud, Download, Loader2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useScopedT } from "@/contexts/I18nContext";
@@ -14,6 +14,7 @@ interface ExportDialogProps {
 	exportFormat?: "mp4" | "gif";
 	exportedFilePath?: string;
 	onShowInFolder?: () => void;
+	onUploadToKaltura?: () => void;
 }
 
 export function ExportDialog({
@@ -26,6 +27,7 @@ export function ExportDialog({
 	exportFormat = "mp4",
 	exportedFilePath,
 	onShowInFolder,
+	onUploadToKaltura,
 }: ExportDialogProps) {
 	const t = useScopedT("dialogs");
 	const [showSuccess, setShowSuccess] = useState(false);
@@ -110,13 +112,25 @@ export function ExportDialog({
 										{t("export.yourFormatReady", { format: formatLabel.toLowerCase() })}
 									</span>
 									{exportedFilePath && (
-										<Button
-											variant="secondary"
-											onClick={onShowInFolder}
-											className="mt-2 w-fit px-3 py-1 text-sm rounded-md bg-white/10 hover:bg-white/20 text-slate-200"
-										>
-											{t("export.showInFolder")}
-										</Button>
+										<div className="flex gap-2 mt-2">
+											<Button
+												variant="secondary"
+												onClick={onShowInFolder}
+												className="w-fit px-3 py-1 text-sm rounded-md bg-white/10 hover:bg-white/20 text-slate-200"
+											>
+												{t("export.showInFolder")}
+											</Button>
+											{onUploadToKaltura && exportFormat === "mp4" && (
+												<Button
+													variant="secondary"
+													onClick={onUploadToKaltura}
+													className="w-fit px-3 py-1 text-sm rounded-md bg-orange-500/20 hover:bg-orange-500/30 text-orange-300 border border-orange-500/30"
+												>
+													<Cloud className="w-3.5 h-3.5 mr-1.5" />
+													Upload to Kaltura
+												</Button>
+											)}
+										</div>
 									)}
 									{exportedFilePath && (
 										<span className="text-xs text-slate-500 break-all max-w-xs mt-1">

--- a/src/components/video-editor/ExportDialog.tsx
+++ b/src/components/video-editor/ExportDialog.tsx
@@ -30,6 +30,7 @@ export function ExportDialog({
 	onUploadToKaltura,
 }: ExportDialogProps) {
 	const t = useScopedT("dialogs");
+	const ts = useScopedT("settings");
 	const [showSuccess, setShowSuccess] = useState(false);
 
 	// Reset showSuccess when a new export starts or dialog reopens
@@ -124,10 +125,10 @@ export function ExportDialog({
 												<Button
 													variant="secondary"
 													onClick={onUploadToKaltura}
-													className="w-fit px-3 py-1 text-sm rounded-md bg-orange-500/20 hover:bg-orange-500/30 text-orange-300 border border-orange-500/30"
+													className="w-fit px-3 py-1 text-sm rounded-md bg-white/10 hover:bg-white/20 text-slate-200"
 												>
 													<Cloud className="w-3.5 h-3.5 mr-1.5" />
-													Upload to Kaltura
+													{ts("cloud.uploadTo", { provider: "Kaltura" })}
 												</Button>
 											)}
 										</div>

--- a/src/components/video-editor/KalturaBrowseDialog.tsx
+++ b/src/components/video-editor/KalturaBrowseDialog.tsx
@@ -34,13 +34,18 @@ export function KalturaBrowsePage() {
 
 	// Check session on mount
 	useEffect(() => {
-		window.electronAPI.kalturaLoadSession().then((result) => {
-			if (result.success && result.state?.connected) {
-				setState({ phase: "loading_manager" });
-			} else {
+		window.electronAPI
+			.kalturaLoadSession()
+			.then((result) => {
+				if (result.success && result.state?.connected) {
+					setState({ phase: "loading_manager" });
+				} else {
+					setState({ phase: "login" });
+				}
+			})
+			.catch(() => {
 				setState({ phase: "login" });
-			}
-		});
+			});
 		return () => {
 			cleanupRef.current?.();
 			cleanupRef.current = null;
@@ -90,6 +95,10 @@ export function KalturaBrowsePage() {
 
 				if (cancelled || !containerRef.current) return;
 
+				// The Kaltura Unisphere media manager is loaded from CDN as an ESM module.
+				// This is the official integration pattern — the widget renders inside our
+				// container div with context isolation still active (no Node access).
+				// webSecurity: false on this window's BrowserPreferences allows the cross-origin load.
 				const serverUrl = "https://unisphere.nvq2.ovp.kaltura.com/v1";
 				const loaderUrl = `${serverUrl}/loader/index.esm.js`;
 
@@ -173,7 +182,8 @@ export function KalturaBrowsePage() {
 									| Array<{ id: string; name: string; mediaType?: number }>
 									| undefined;
 								if (!objects?.length) throw new Error(t("browse.entryNotFound"));
-								const entry = objects.find((e) => e.name === entryName) || objects[0];
+								const entry = objects.find((e) => e.name === entryName);
+								if (!entry) throw new Error(t("browse.entryNotFound"));
 								handleEntrySelected(entry.id, entry.name);
 							})
 							.catch((err) => {

--- a/src/components/video-editor/KalturaBrowseDialog.tsx
+++ b/src/components/video-editor/KalturaBrowseDialog.tsx
@@ -1,0 +1,583 @@
+import { AlertCircle, ArrowLeft, Check, Download, ExternalLink, Loader2, MousePointerClick, RefreshCw, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+type PageState =
+	| { phase: "checking_session" }
+	| { phase: "login"; error?: string }
+	| { phase: "logging_in" }
+	| { phase: "account_selection"; partners: Array<{ id: number; name: string }> }
+	| { phase: "connecting_partner" }
+	| { phase: "loading_manager" }
+	| { phase: "browsing" }
+	| { phase: "downloading"; entryName: string; percentage: number }
+	| { phase: "error"; message: string };
+
+/**
+ * Full-page Kaltura browse component rendered in its own BrowserWindow.
+ * Handles login if needed, then shows the media manager.
+ */
+export function KalturaBrowsePage() {
+	const [state, setState] = useState<PageState>({ phase: "checking_session" });
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [clickedSignup, setClickedSignup] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const cleanupRef = useRef<(() => void) | null>(null);
+	const emailInputRef = useRef<HTMLInputElement>(null);
+
+	// Check session on mount
+	useEffect(() => {
+		window.electronAPI.kalturaLoadSession().then((result) => {
+			if (result.success && result.state?.connected) {
+				setState({ phase: "loading_manager" });
+			} else {
+				setState({ phase: "login" });
+			}
+		});
+		return () => {
+			cleanupRef.current?.();
+			cleanupRef.current = null;
+		};
+	}, []);
+
+	// Initialize media manager when we reach the loading_manager phase
+	useEffect(() => {
+		if (state.phase !== "loading_manager") return;
+
+		let cancelled = false;
+
+		async function init() {
+			try {
+				const sessionInfo = await window.electronAPI.kalturaGetSessionInfo();
+				if (!sessionInfo.success || !sessionInfo.ks || !sessionInfo.partnerId) {
+					setState({ phase: "login", error: "Session expired. Please sign in again." });
+					return;
+				}
+
+				if (cancelled || !containerRef.current) return;
+
+				const serverUrl = "https://unisphere.nvq2.ovp.kaltura.com/v1";
+				const loaderUrl = `${serverUrl}/loader/index.esm.js`;
+
+				const { loader } = await import(/* @vite-ignore */ loaderUrl);
+
+				if (cancelled || !containerRef.current) return;
+
+				const options = {
+					appId: "openscreen",
+					appVersion: "1.0.0",
+					workspaceName: `openscreen-browse-${Date.now()}`,
+					serverUrl,
+					runtimes: [
+						{
+							widgetName: "unisphere.widget.media-manager",
+							runtimeName: "kaltura-items-media-manager",
+							settings: {
+								contextType: "category",
+								contextId: "",
+								ks: sessionInfo.ks,
+								partnerId: sessionInfo.partnerId,
+								endpointUrl: `${sessionInfo.serviceUrl || "https://www.kaltura.com"}/api_v3`,
+							},
+							visuals: [
+								{
+									type: "table",
+									target: { target: "element", elementId: "kaltura-media-manager-container" },
+									settings: {},
+								},
+							],
+						},
+					],
+					ui: {
+						theme: "dark",
+						language: "en",
+					},
+				};
+
+				await loader(options);
+				if (cancelled) return;
+
+				if (cancelled) return;
+
+				setState({ phase: "browsing" });
+
+				// The media manager widget's internal event system is broken (emit loses `this`).
+				// Intercept Select button clicks at the DOM level via a capturing listener
+				// (fires before the widget's broken handler), then resolve entry via API.
+				const root = containerRef.current;
+				if (root) {
+					let selecting = false;
+
+					function resolveAndSelect(row: HTMLTableRowElement) {
+						if (selecting) return;
+						const cells = row.querySelectorAll("td");
+						if (cells.length < 2) return;
+
+						// Skip category rows (Drupal pattern: check type column)
+						if (cells.length >= 4) {
+							const typeTxt = (cells[3]?.textContent || "").trim().toLowerCase();
+							if (typeTxt === "category") return;
+						}
+
+						const entryName = (cells[1]?.textContent || "").trim();
+						if (!entryName) return;
+
+						selecting = true;
+						row.style.opacity = "0.6";
+
+						const endpoint = `${sessionInfo.serviceUrl || "https://www.kaltura.com"}/api_v3`;
+						const params = new URLSearchParams({
+							ks: sessionInfo.ks!,
+							"filter[searchTextMatchOr]": entryName,
+							"filter[objectType]": "KalturaMediaEntryFilter",
+							"pager[pageSize]": "5",
+							format: "1",
+						});
+
+						fetch(`${endpoint}/service/media/action/list?${params}`)
+							.then((r) => r.json())
+							.then((data) => {
+								const objects = data?.objects as Array<{ id: string; name: string; mediaType?: number }> | undefined;
+								if (!objects?.length) throw new Error("Entry not found");
+								const entry = objects.find((e) => e.name === entryName) || objects[0];
+								handleEntrySelected(entry.id, entry.name);
+							})
+							.catch((err) => {
+								console.error("[KalturaBrowse] Failed to resolve entry:", err);
+								selecting = false;
+								row.style.opacity = "";
+							});
+					}
+
+					// Double-click and keyboard selection on rows (same as WP plugin)
+					function bindRow(row: HTMLTableRowElement) {
+						if (row.dataset.selectBound) return;
+						row.dataset.selectBound = "1";
+						row.style.cursor = "pointer";
+						// Use capture phase to fire before React's synthetic event system
+						row.addEventListener("dblclick", (e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							resolveAndSelect(row);
+						}, true);
+						row.addEventListener("keydown", (e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								e.stopPropagation();
+								resolveAndSelect(row);
+							}
+						}, true);
+						row.setAttribute("tabindex", "0");
+					}
+
+					// Also add a capturing dblclick on the root container as a fallback
+					const rootDblClickHandler = (e: Event) => {
+						const row = (e.target as HTMLElement).closest("tr") as HTMLTableRowElement | null;
+						if (row && row.closest("tbody")) {
+							resolveAndSelect(row);
+						}
+					};
+					root.addEventListener("dblclick", rootDblClickHandler, true);
+
+					const observer = new MutationObserver(() => {
+						const rows = root.querySelectorAll<HTMLTableRowElement>("tbody tr");
+						rows.forEach(bindRow);
+
+						// Also try broader selectors in case the widget uses a different structure
+						const altRows = root.querySelectorAll<HTMLTableRowElement>("tr[data-row-id], tr[role='row'], [class*='row']");
+						if (altRows.length > 0 && rows.length === 0) {
+							altRows.forEach(bindRow);
+						}
+					});
+					observer.observe(root, { childList: true, subtree: true });
+
+					// Bind any rows already in the DOM after widget loads
+					setTimeout(() => {
+						root.querySelectorAll<HTMLTableRowElement>("tbody tr").forEach(bindRow);
+					}, 3000);
+
+					cleanupRef.current = () => {
+						observer.disconnect();
+						root.removeEventListener("dblclick", rootDblClickHandler, true);
+					};
+				}
+			} catch (error) {
+				if (!cancelled) {
+					console.error("Failed to initialize media manager:", error);
+					setState({ phase: "error", message: `Failed to load media browser: ${String(error)}` });
+				}
+			}
+		}
+
+		init();
+
+		return () => {
+			cancelled = true;
+			// Don't clean up observer/listeners here — this runs on every
+			// state.phase change (including the "loading_manager" → "browsing"
+			// transition that happens inside init). Cleanup happens via
+			// cleanupRef when the component unmounts or account is switched.
+		};
+	}, [state.phase]);
+
+	const handleLogin = useCallback(async () => {
+		if (!email.trim() || !password.trim()) return;
+
+		setState({ phase: "logging_in" });
+
+		try {
+			const result = await window.electronAPI.kalturaLogin({
+				serviceUrl: "https://www.kaltura.com",
+				loginId: email.trim(),
+				password: password.trim(),
+			});
+
+			if (!result.success) {
+				setState({ phase: "login", error: result.error || "Login failed" });
+				return;
+			}
+
+			if (result.partners && result.partners.length > 1) {
+				setState({ phase: "account_selection", partners: result.partners });
+				return;
+			}
+
+			if (result.state?.connected) {
+				setPassword("");
+				setState({ phase: "loading_manager" });
+			}
+		} catch (error) {
+			setState({ phase: "login", error: String(error) });
+		}
+	}, [email, password]);
+
+	const handleSelectPartner = useCallback(async (partnerId: number) => {
+		setState({ phase: "connecting_partner" });
+
+		try {
+			const result = await window.electronAPI.kalturaSelectPartner({ partnerId });
+
+			if (!result.success) {
+				setState({ phase: "login", error: result.error || "Failed to select account" });
+				return;
+			}
+
+			if (result.state?.connected) {
+				setPassword("");
+				setState({ phase: "loading_manager" });
+			}
+		} catch (error) {
+			setState({ phase: "login", error: String(error) });
+		}
+	}, []);
+
+	const handleEntrySelected = useCallback(async (entryId: string, entryName: string) => {
+		setState({ phase: "downloading", entryName, percentage: 0 });
+
+		const unsubProgress = window.electronAPI.onKalturaDownloadProgress((progress) => {
+			const p = progress as { phase: string; percentage: number; filePath?: string; error?: string };
+			if (p.phase === "downloading") {
+				setState({ phase: "downloading", entryName, percentage: p.percentage });
+			}
+		});
+
+		try {
+			const result = await window.electronAPI.kalturaDownload({ entryId });
+			unsubProgress();
+
+			if (result.success && result.filePath) {
+				await window.electronAPI.kalturaBrowseVideoLoaded(result.filePath);
+			} else {
+				setState({ phase: "error", message: result.error || "Download failed" });
+			}
+		} catch (error) {
+			unsubProgress();
+			setState({ phase: "error", message: String(error) });
+		}
+	}, []);
+
+	const handleClose = useCallback(() => {
+		window.electronAPI.closeKalturaBrowse();
+	}, []);
+
+	const handleSwitchAccount = useCallback(async () => {
+		cleanupRef.current?.();
+		cleanupRef.current = null;
+		const result = await window.electronAPI.kalturaListPartners();
+		if (result.success && result.partners && result.partners.length > 1) {
+			setState({ phase: "account_selection", partners: result.partners });
+		} else if (result.success && result.partners?.length === 1) {
+			// Only one account — nothing to switch to
+		} else {
+			// Credentials expired — fall back to login
+			await window.electronAPI.kalturaLogout();
+			setEmail("");
+			setPassword("");
+			setState({ phase: "login", error: result.error || "Please sign in again to switch accounts." });
+		}
+	}, []);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" && state.phase === "login") {
+				handleLogin();
+			}
+		},
+		[state.phase, handleLogin],
+	);
+
+	const handleSignup = useCallback(() => {
+		setClickedSignup(true);
+		window.electronAPI.kalturaOpenSignup();
+	}, []);
+
+	// When user returns to the app after signup, auto-focus the email input
+	useEffect(() => {
+		if (!clickedSignup) return;
+		const onFocus = () => {
+			// Small delay to let the window fully activate
+			setTimeout(() => emailInputRef.current?.focus(), 100);
+		};
+		window.addEventListener("focus", onFocus);
+		return () => window.removeEventListener("focus", onFocus);
+	}, [clickedSignup]);
+
+	// --- Login form ---
+	const renderLogin = () => (
+		<div className="flex-1 flex items-center justify-center">
+			<div className="w-full max-w-sm" onKeyDown={handleKeyDown}>
+				{state.phase === "login" && state.error && (
+					<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-3 flex items-start gap-2 mb-4">
+						<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+						<p className="text-sm text-red-400">{state.error}</p>
+					</div>
+				)}
+				{clickedSignup && (
+					<div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-3 flex items-start gap-2 mb-4 animate-in fade-in slide-in-from-top-2 duration-300">
+						<Check className="w-4 h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
+						<p className="text-sm text-emerald-300">Account created? Sign in with your new credentials below.</p>
+					</div>
+				)}
+				<div className="space-y-4">
+					<div>
+						<label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Email</label>
+						<input
+							ref={emailInputRef}
+							type="email"
+							value={email}
+							onChange={(e) => setEmail(e.target.value)}
+							placeholder="you@example.com"
+							className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
+							autoFocus
+						/>
+					</div>
+					<div>
+						<label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Password</label>
+						<input
+							type="password"
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							placeholder="Enter your password"
+							className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
+						/>
+					</div>
+					<Button
+						onClick={handleLogin}
+						disabled={!email.trim() || !password.trim()}
+						className="w-full bg-orange-500 hover:bg-orange-600 text-white py-3 rounded-lg font-medium transition-colors disabled:opacity-50"
+					>
+						Sign In
+					</Button>
+					{clickedSignup ? (
+						<p className="w-full text-center text-xs text-slate-500">
+							After creating your account and verifying your email, come back here to sign in.
+						</p>
+					) : (
+						<button
+							type="button"
+							onClick={handleSignup}
+							className="w-full text-center text-sm text-slate-500 hover:text-orange-400 transition-colors flex items-center justify-center gap-1"
+						>
+							Don't have an account? Sign up <ExternalLink className="w-3 h-3" />
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+
+	// --- Account selection ---
+	const renderAccountSelection = () => {
+		if (state.phase !== "account_selection") return null;
+		return (
+			<div className="flex-1 flex items-center justify-center">
+				<div className="w-full max-w-sm">
+					<p className="text-sm text-slate-400 mb-4">Select an account to continue:</p>
+					<div className="space-y-2 max-h-[400px] overflow-y-auto">
+						{state.partners.map((partner) => (
+							<button
+								key={partner.id}
+								type="button"
+								onClick={() => handleSelectPartner(partner.id)}
+								className="w-full text-left bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg px-4 py-3 text-white transition-colors"
+							>
+								<span className="font-medium">{partner.name}</span>
+								<span className="text-xs text-slate-500 ml-2">#{partner.id}</span>
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="w-full h-full bg-[#09090b] flex flex-col p-5">
+			{/* Header */}
+			<div className="flex items-center justify-between mb-4 flex-shrink-0">
+				<div className="flex items-center gap-3">
+					{state.phase === "account_selection" && (
+						<button
+							type="button"
+							onClick={() => setState({ phase: "login" })}
+							className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center ring-1 ring-white/10 hover:bg-white/10 transition-colors"
+						>
+							<ArrowLeft className="w-5 h-5 text-slate-300" />
+						</button>
+					)}
+					{state.phase !== "account_selection" && (
+						<div className="w-10 h-10 rounded-full bg-orange-500/20 ring-1 ring-orange-500/50 flex items-center justify-center">
+							<Download className="w-5 h-5 text-orange-400" />
+						</div>
+					)}
+					<div>
+						<span className="text-lg font-bold text-slate-200 block">
+							{state.phase === "login" || state.phase === "logging_in"
+								? "Sign in to Kaltura"
+								: state.phase === "account_selection" || state.phase === "connecting_partner"
+									? "Select Account"
+									: "Load from Kaltura"}
+						</span>
+						<span className="text-xs text-slate-500">
+							{state.phase === "login" || state.phase === "logging_in"
+								? (clickedSignup ? "Welcome back \u2014 sign in with your new account" : "Connect to browse your video library")
+								: state.phase === "account_selection"
+									? "Choose which account to use"
+									: "Select a video from your library"}
+						</span>
+					</div>
+				</div>
+				{state.phase !== "downloading" && state.phase !== "logging_in" && state.phase !== "connecting_partner" && (
+					<div className="flex items-center gap-2">
+						{(state.phase === "browsing" || state.phase === "loading_manager") && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={handleSwitchAccount}
+								className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full gap-1.5 text-xs"
+							>
+								<RefreshCw className="w-3.5 h-3.5" />
+								Switch Account
+							</Button>
+						)}
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={handleClose}
+							className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full"
+						>
+							<X className="w-5 h-5" />
+						</Button>
+					</div>
+				)}
+			</div>
+
+			{/* Content */}
+			{(state.phase === "login" || state.phase === "logging_in") && (
+				state.phase === "logging_in" ? (
+					<div className="flex-1 flex items-center justify-center">
+						<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
+						<span className="ml-3 text-sm text-slate-400">Signing in...</span>
+					</div>
+				) : renderLogin()
+			)}
+
+			{(state.phase === "account_selection" || state.phase === "connecting_partner") && (
+				state.phase === "connecting_partner" ? (
+					<div className="flex-1 flex items-center justify-center">
+						<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
+						<span className="ml-3 text-sm text-slate-400">Connecting...</span>
+					</div>
+				) : renderAccountSelection()
+			)}
+
+			{(state.phase === "checking_session" || state.phase === "loading_manager" || state.phase === "browsing" || state.phase === "downloading") && (
+				<div className="flex-1 min-h-0 flex flex-col">
+					{/* Selection hint banner */}
+					{state.phase === "browsing" && (
+						<div className="flex items-center gap-2 px-3 py-2 bg-orange-500/10 border border-orange-500/20 rounded-lg mb-2 flex-shrink-0">
+							<MousePointerClick className="w-4 h-4 text-orange-400 flex-shrink-0" />
+							<span className="text-xs text-orange-300">Double-click a video to select and load it into the editor</span>
+						</div>
+					)}
+					<div className="flex-1 min-h-0 relative rounded-xl overflow-auto border border-white/5">
+					{/* Unisphere media manager container */}
+					<div
+						id="kaltura-media-manager-container"
+						ref={containerRef}
+						className="w-full h-full"
+					/>
+
+					{/* Loading states */}
+					{(state.phase === "checking_session" || state.phase === "loading_manager") && (
+						<div className="absolute inset-0 flex items-center justify-center bg-[#09090b]">
+							<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
+							<span className="ml-3 text-sm text-slate-400">
+								{state.phase === "checking_session" ? "Checking session..." : "Loading media browser..."}
+							</span>
+						</div>
+					)}
+
+					{/* Downloading state */}
+					{state.phase === "downloading" && (
+						<div className="absolute inset-0 flex flex-col items-center justify-center bg-[#09090b]/90 backdrop-blur-sm">
+							<Loader2 className="w-8 h-8 text-orange-400 animate-spin mb-4" />
+							<span className="text-sm font-medium text-slate-200 mb-1">
+								Downloading: {state.entryName}
+							</span>
+							<div className="w-64 h-2 bg-white/10 rounded-full overflow-hidden mt-2">
+								<div
+									className="h-full bg-orange-500 rounded-full transition-all duration-300"
+									style={{ width: `${state.percentage}%` }}
+								/>
+							</div>
+							<span className="text-xs text-slate-500 mt-2">{state.percentage}%</span>
+						</div>
+					)}
+					</div>
+				</div>
+			)}
+
+			{/* Error state */}
+			{state.phase === "error" && (
+				<div className="flex-1 flex items-center justify-center">
+					<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3 max-w-md">
+						<AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+						<div>
+							<p className="text-sm text-red-400 leading-relaxed">{state.message}</p>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={handleClose}
+								className="mt-3 text-slate-400 hover:text-white"
+							>
+								Close
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/video-editor/KalturaBrowseDialog.tsx
+++ b/src/components/video-editor/KalturaBrowseDialog.tsx
@@ -1,13 +1,21 @@
-import { AlertCircle, ArrowLeft, Check, Download, ExternalLink, Loader2, MousePointerClick, RefreshCw, X } from "lucide-react";
+import {
+	AlertCircle,
+	Download,
+	Loader2,
+	LogOut,
+	MousePointerClick,
+	RefreshCw,
+	X,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { useI18n, useScopedT } from "@/contexts/I18nContext";
+import { KalturaLoginForm } from "./KalturaLoginForm";
 
 type PageState =
 	| { phase: "checking_session" }
 	| { phase: "login"; error?: string }
-	| { phase: "logging_in" }
 	| { phase: "account_selection"; partners: Array<{ id: number; name: string }> }
-	| { phase: "connecting_partner" }
 	| { phase: "loading_manager" }
 	| { phase: "browsing" }
 	| { phase: "downloading"; entryName: string; percentage: number }
@@ -15,16 +23,14 @@ type PageState =
 
 /**
  * Full-page Kaltura browse component rendered in its own BrowserWindow.
- * Handles login if needed, then shows the media manager.
+ * Handles login if needed, then shows the embedded media manager.
  */
 export function KalturaBrowsePage() {
 	const [state, setState] = useState<PageState>({ phase: "checking_session" });
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
-	const [clickedSignup, setClickedSignup] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const cleanupRef = useRef<(() => void) | null>(null);
-	const emailInputRef = useRef<HTMLInputElement>(null);
+	const { locale } = useI18n();
+	const t = useScopedT("kaltura");
 
 	// Check session on mount
 	useEffect(() => {
@@ -41,6 +47,33 @@ export function KalturaBrowsePage() {
 		};
 	}, []);
 
+	const handleEntrySelected = useCallback(
+		async (entryId: string, entryName: string) => {
+			setState({ phase: "downloading", entryName, percentage: 0 });
+
+			const unsubProgress = window.electronAPI.onKalturaDownloadProgress((progress) => {
+				if (progress.phase === "downloading") {
+					setState({ phase: "downloading", entryName, percentage: progress.percentage });
+				}
+			});
+
+			try {
+				const result = await window.electronAPI.kalturaDownload({ entryId });
+				unsubProgress();
+
+				if (result.success && result.filePath) {
+					await window.electronAPI.kalturaBrowseVideoLoaded(result.filePath);
+				} else {
+					setState({ phase: "error", message: result.error || t("browse.downloadFailed") });
+				}
+			} catch (error) {
+				unsubProgress();
+				setState({ phase: "error", message: String(error) });
+			}
+		},
+		[t],
+	);
+
 	// Initialize media manager when we reach the loading_manager phase
 	useEffect(() => {
 		if (state.phase !== "loading_manager") return;
@@ -51,7 +84,7 @@ export function KalturaBrowsePage() {
 			try {
 				const sessionInfo = await window.electronAPI.kalturaGetSessionInfo();
 				if (!sessionInfo.success || !sessionInfo.ks || !sessionInfo.partnerId) {
-					setState({ phase: "login", error: "Session expired. Please sign in again." });
+					setState({ phase: "login", error: t("connection.sessionExpired") });
 					return;
 				}
 
@@ -91,13 +124,11 @@ export function KalturaBrowsePage() {
 					],
 					ui: {
 						theme: "dark",
-						language: "en",
+						language: locale,
 					},
 				};
 
 				await loader(options);
-				if (cancelled) return;
-
 				if (cancelled) return;
 
 				setState({ phase: "browsing" });
@@ -114,7 +145,7 @@ export function KalturaBrowsePage() {
 						const cells = row.querySelectorAll("td");
 						if (cells.length < 2) return;
 
-						// Skip category rows (Drupal pattern: check type column)
+						// Skip category rows
 						if (cells.length >= 4) {
 							const typeTxt = (cells[3]?.textContent || "").trim().toLowerCase();
 							if (typeTxt === "category") return;
@@ -138,8 +169,10 @@ export function KalturaBrowsePage() {
 						fetch(`${endpoint}/service/media/action/list?${params}`)
 							.then((r) => r.json())
 							.then((data) => {
-								const objects = data?.objects as Array<{ id: string; name: string; mediaType?: number }> | undefined;
-								if (!objects?.length) throw new Error("Entry not found");
+								const objects = data?.objects as
+									| Array<{ id: string; name: string; mediaType?: number }>
+									| undefined;
+								if (!objects?.length) throw new Error(t("browse.entryNotFound"));
 								const entry = objects.find((e) => e.name === entryName) || objects[0];
 								handleEntrySelected(entry.id, entry.name);
 							})
@@ -150,28 +183,33 @@ export function KalturaBrowsePage() {
 							});
 					}
 
-					// Double-click and keyboard selection on rows (same as WP plugin)
 					function bindRow(row: HTMLTableRowElement) {
 						if (row.dataset.selectBound) return;
 						row.dataset.selectBound = "1";
 						row.style.cursor = "pointer";
-						// Use capture phase to fire before React's synthetic event system
-						row.addEventListener("dblclick", (e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							resolveAndSelect(row);
-						}, true);
-						row.addEventListener("keydown", (e) => {
-							if (e.key === "Enter" || e.key === " ") {
+						row.addEventListener(
+							"dblclick",
+							(e) => {
 								e.preventDefault();
 								e.stopPropagation();
 								resolveAndSelect(row);
-							}
-						}, true);
+							},
+							true,
+						);
+						row.addEventListener(
+							"keydown",
+							(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									e.preventDefault();
+									e.stopPropagation();
+									resolveAndSelect(row);
+								}
+							},
+							true,
+						);
 						row.setAttribute("tabindex", "0");
 					}
 
-					// Also add a capturing dblclick on the root container as a fallback
 					const rootDblClickHandler = (e: Event) => {
 						const row = (e.target as HTMLElement).closest("tr") as HTMLTableRowElement | null;
 						if (row && row.closest("tbody")) {
@@ -184,15 +222,16 @@ export function KalturaBrowsePage() {
 						const rows = root.querySelectorAll<HTMLTableRowElement>("tbody tr");
 						rows.forEach(bindRow);
 
-						// Also try broader selectors in case the widget uses a different structure
-						const altRows = root.querySelectorAll<HTMLTableRowElement>("tr[data-row-id], tr[role='row'], [class*='row']");
+						const altRows = root.querySelectorAll<HTMLTableRowElement>(
+							"tr[data-row-id], tr[role='row'], [class*='row']",
+						);
 						if (altRows.length > 0 && rows.length === 0) {
 							altRows.forEach(bindRow);
 						}
 					});
 					observer.observe(root, { childList: true, subtree: true });
 
-					// Bind any rows already in the DOM after widget loads
+					// Bind rows already in the DOM after initial widget render
 					setTimeout(() => {
 						root.querySelectorAll<HTMLTableRowElement>("tbody tr").forEach(bindRow);
 					}, 3000);
@@ -205,7 +244,7 @@ export function KalturaBrowsePage() {
 			} catch (error) {
 				if (!cancelled) {
 					console.error("Failed to initialize media manager:", error);
-					setState({ phase: "error", message: `Failed to load media browser: ${String(error)}` });
+					setState({ phase: "error", message: t("browse.loadFailed", { error: String(error) }) });
 				}
 			}
 		}
@@ -214,88 +253,8 @@ export function KalturaBrowsePage() {
 
 		return () => {
 			cancelled = true;
-			// Don't clean up observer/listeners here — this runs on every
-			// state.phase change (including the "loading_manager" → "browsing"
-			// transition that happens inside init). Cleanup happens via
-			// cleanupRef when the component unmounts or account is switched.
 		};
-	}, [state.phase]);
-
-	const handleLogin = useCallback(async () => {
-		if (!email.trim() || !password.trim()) return;
-
-		setState({ phase: "logging_in" });
-
-		try {
-			const result = await window.electronAPI.kalturaLogin({
-				serviceUrl: "https://www.kaltura.com",
-				loginId: email.trim(),
-				password: password.trim(),
-			});
-
-			if (!result.success) {
-				setState({ phase: "login", error: result.error || "Login failed" });
-				return;
-			}
-
-			if (result.partners && result.partners.length > 1) {
-				setState({ phase: "account_selection", partners: result.partners });
-				return;
-			}
-
-			if (result.state?.connected) {
-				setPassword("");
-				setState({ phase: "loading_manager" });
-			}
-		} catch (error) {
-			setState({ phase: "login", error: String(error) });
-		}
-	}, [email, password]);
-
-	const handleSelectPartner = useCallback(async (partnerId: number) => {
-		setState({ phase: "connecting_partner" });
-
-		try {
-			const result = await window.electronAPI.kalturaSelectPartner({ partnerId });
-
-			if (!result.success) {
-				setState({ phase: "login", error: result.error || "Failed to select account" });
-				return;
-			}
-
-			if (result.state?.connected) {
-				setPassword("");
-				setState({ phase: "loading_manager" });
-			}
-		} catch (error) {
-			setState({ phase: "login", error: String(error) });
-		}
-	}, []);
-
-	const handleEntrySelected = useCallback(async (entryId: string, entryName: string) => {
-		setState({ phase: "downloading", entryName, percentage: 0 });
-
-		const unsubProgress = window.electronAPI.onKalturaDownloadProgress((progress) => {
-			const p = progress as { phase: string; percentage: number; filePath?: string; error?: string };
-			if (p.phase === "downloading") {
-				setState({ phase: "downloading", entryName, percentage: p.percentage });
-			}
-		});
-
-		try {
-			const result = await window.electronAPI.kalturaDownload({ entryId });
-			unsubProgress();
-
-			if (result.success && result.filePath) {
-				await window.electronAPI.kalturaBrowseVideoLoaded(result.filePath);
-			} else {
-				setState({ phase: "error", message: result.error || "Download failed" });
-			}
-		} catch (error) {
-			unsubProgress();
-			setState({ phase: "error", message: String(error) });
-		}
-	}, []);
+	}, [state.phase, handleEntrySelected, t, locale]);
 
 	const handleClose = useCallback(() => {
 		window.electronAPI.closeKalturaBrowse();
@@ -310,176 +269,61 @@ export function KalturaBrowsePage() {
 		} else if (result.success && result.partners?.length === 1) {
 			// Only one account — nothing to switch to
 		} else {
-			// Credentials expired — fall back to login
 			await window.electronAPI.kalturaLogout();
-			setEmail("");
-			setPassword("");
-			setState({ phase: "login", error: result.error || "Please sign in again to switch accounts." });
+			setState({
+				phase: "login",
+				error: result.error || t("connection.switchError"),
+			});
 		}
-	}, []);
+	}, [t]);
 
-	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent) => {
-			if (e.key === "Enter" && state.phase === "login") {
-				handleLogin();
-			}
-		},
-		[state.phase, handleLogin],
-	);
-
-	const handleSignup = useCallback(() => {
-		setClickedSignup(true);
-		window.electronAPI.kalturaOpenSignup();
-	}, []);
-
-	// When user returns to the app after signup, auto-focus the email input
-	useEffect(() => {
-		if (!clickedSignup) return;
-		const onFocus = () => {
-			// Small delay to let the window fully activate
-			setTimeout(() => emailInputRef.current?.focus(), 100);
-		};
-		window.addEventListener("focus", onFocus);
-		return () => window.removeEventListener("focus", onFocus);
-	}, [clickedSignup]);
-
-	// --- Login form ---
-	const renderLogin = () => (
-		<div className="flex-1 flex items-center justify-center">
-			<div className="w-full max-w-sm" onKeyDown={handleKeyDown}>
-				{state.phase === "login" && state.error && (
-					<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-3 flex items-start gap-2 mb-4">
-						<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-						<p className="text-sm text-red-400">{state.error}</p>
-					</div>
-				)}
-				{clickedSignup && (
-					<div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-3 flex items-start gap-2 mb-4 animate-in fade-in slide-in-from-top-2 duration-300">
-						<Check className="w-4 h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
-						<p className="text-sm text-emerald-300">Account created? Sign in with your new credentials below.</p>
-					</div>
-				)}
-				<div className="space-y-4">
-					<div>
-						<label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Email</label>
-						<input
-							ref={emailInputRef}
-							type="email"
-							value={email}
-							onChange={(e) => setEmail(e.target.value)}
-							placeholder="you@example.com"
-							className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
-							autoFocus
-						/>
-					</div>
-					<div>
-						<label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Password</label>
-						<input
-							type="password"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							placeholder="Enter your password"
-							className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
-						/>
-					</div>
-					<Button
-						onClick={handleLogin}
-						disabled={!email.trim() || !password.trim()}
-						className="w-full bg-orange-500 hover:bg-orange-600 text-white py-3 rounded-lg font-medium transition-colors disabled:opacity-50"
-					>
-						Sign In
-					</Button>
-					{clickedSignup ? (
-						<p className="w-full text-center text-xs text-slate-500">
-							After creating your account and verifying your email, come back here to sign in.
-						</p>
-					) : (
-						<button
-							type="button"
-							onClick={handleSignup}
-							className="w-full text-center text-sm text-slate-500 hover:text-orange-400 transition-colors flex items-center justify-center gap-1"
-						>
-							Don't have an account? Sign up <ExternalLink className="w-3 h-3" />
-						</button>
-					)}
-				</div>
-			</div>
-		</div>
-	);
-
-	// --- Account selection ---
-	const renderAccountSelection = () => {
-		if (state.phase !== "account_selection") return null;
-		return (
-			<div className="flex-1 flex items-center justify-center">
-				<div className="w-full max-w-sm">
-					<p className="text-sm text-slate-400 mb-4">Select an account to continue:</p>
-					<div className="space-y-2 max-h-[400px] overflow-y-auto">
-						{state.partners.map((partner) => (
-							<button
-								key={partner.id}
-								type="button"
-								onClick={() => handleSelectPartner(partner.id)}
-								className="w-full text-left bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg px-4 py-3 text-white transition-colors"
-							>
-								<span className="font-medium">{partner.name}</span>
-								<span className="text-xs text-slate-500 ml-2">#{partner.id}</span>
-							</button>
-						))}
-					</div>
-				</div>
-			</div>
-		);
-	};
+	const isLoginPhase = state.phase === "login" || state.phase === "account_selection";
 
 	return (
 		<div className="w-full h-full bg-[#09090b] flex flex-col p-5">
 			{/* Header */}
 			<div className="flex items-center justify-between mb-4 flex-shrink-0">
 				<div className="flex items-center gap-3">
-					{state.phase === "account_selection" && (
-						<button
-							type="button"
-							onClick={() => setState({ phase: "login" })}
-							className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center ring-1 ring-white/10 hover:bg-white/10 transition-colors"
-						>
-							<ArrowLeft className="w-5 h-5 text-slate-300" />
-						</button>
-					)}
-					{state.phase !== "account_selection" && (
-						<div className="w-10 h-10 rounded-full bg-orange-500/20 ring-1 ring-orange-500/50 flex items-center justify-center">
-							<Download className="w-5 h-5 text-orange-400" />
-						</div>
-					)}
+					<div className="w-10 h-10 rounded-full bg-orange-500/20 ring-1 ring-orange-500/50 flex items-center justify-center">
+						<Download className="w-5 h-5 text-orange-400" />
+					</div>
 					<div>
 						<span className="text-lg font-bold text-slate-200 block">
-							{state.phase === "login" || state.phase === "logging_in"
-								? "Sign in to Kaltura"
-								: state.phase === "account_selection" || state.phase === "connecting_partner"
-									? "Select Account"
-									: "Load from Kaltura"}
+							{isLoginPhase ? t("browse.signInTitle") : t("browse.title")}
 						</span>
 						<span className="text-xs text-slate-500">
-							{state.phase === "login" || state.phase === "logging_in"
-								? (clickedSignup ? "Welcome back \u2014 sign in with your new account" : "Connect to browse your video library")
-								: state.phase === "account_selection"
-									? "Choose which account to use"
-									: "Select a video from your library"}
+							{isLoginPhase ? t("browse.connectPrompt") : t("browse.selectPrompt")}
 						</span>
 					</div>
 				</div>
-				{state.phase !== "downloading" && state.phase !== "logging_in" && state.phase !== "connecting_partner" && (
+				{state.phase !== "downloading" && (
 					<div className="flex items-center gap-2">
 						{(state.phase === "browsing" || state.phase === "loading_manager") && (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={handleSwitchAccount}
-								className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full gap-1.5 text-xs"
-							>
-								<RefreshCw className="w-3.5 h-3.5" />
-								Switch Account
-							</Button>
+							<>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={async () => {
+										cleanupRef.current?.();
+										cleanupRef.current = null;
+										await window.electronAPI.kalturaLogout();
+										setState({ phase: "login" });
+									}}
+									className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full gap-1.5 text-xs"
+								>
+									<LogOut className="w-3.5 h-3.5" />
+									{t("connection.signOut")}
+								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={handleSwitchAccount}
+									className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full gap-1.5 text-xs"
+								>
+									<RefreshCw className="w-3.5 h-3.5" />
+									{t("connection.switchAccount")}
+								</Button>
+							</>
 						)}
 						<Button
 							variant="ghost"
@@ -493,68 +337,77 @@ export function KalturaBrowsePage() {
 				)}
 			</div>
 
-			{/* Content */}
-			{(state.phase === "login" || state.phase === "logging_in") && (
-				state.phase === "logging_in" ? (
-					<div className="flex-1 flex items-center justify-center">
-						<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
-						<span className="ml-3 text-sm text-slate-400">Signing in...</span>
+			{/* Login / Account Selection */}
+			{isLoginPhase && (
+				<div className="flex-1 flex items-center justify-center">
+					<div className="w-full max-w-sm">
+						<KalturaLoginForm
+							error={state.phase === "login" ? state.error : undefined}
+							partners={state.phase === "account_selection" ? state.partners : undefined}
+							onLoginSuccess={(result) => {
+								if (result.partners && result.partners.length > 1) {
+									setState({ phase: "account_selection", partners: result.partners });
+								} else if (result.state?.connected) {
+									setState({ phase: "loading_manager" });
+								}
+							}}
+							onPartnerSelected={(result) => {
+								if (result.state?.connected) {
+									setState({ phase: "loading_manager" });
+								}
+							}}
+							onError={(msg) => setState({ phase: "login", error: msg })}
+							onBack={() => setState({ phase: "login" })}
+						/>
 					</div>
-				) : renderLogin()
+				</div>
 			)}
 
-			{(state.phase === "account_selection" || state.phase === "connecting_partner") && (
-				state.phase === "connecting_partner" ? (
-					<div className="flex-1 flex items-center justify-center">
-						<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
-						<span className="ml-3 text-sm text-slate-400">Connecting...</span>
-					</div>
-				) : renderAccountSelection()
-			)}
-
-			{(state.phase === "checking_session" || state.phase === "loading_manager" || state.phase === "browsing" || state.phase === "downloading") && (
+			{/* Media Manager / Download */}
+			{(state.phase === "checking_session" ||
+				state.phase === "loading_manager" ||
+				state.phase === "browsing" ||
+				state.phase === "downloading") && (
 				<div className="flex-1 min-h-0 flex flex-col">
-					{/* Selection hint banner */}
 					{state.phase === "browsing" && (
 						<div className="flex items-center gap-2 px-3 py-2 bg-orange-500/10 border border-orange-500/20 rounded-lg mb-2 flex-shrink-0">
 							<MousePointerClick className="w-4 h-4 text-orange-400 flex-shrink-0" />
-							<span className="text-xs text-orange-300">Double-click a video to select and load it into the editor</span>
+							<span className="text-xs text-orange-300">{t("browse.selectionHint")}</span>
 						</div>
 					)}
 					<div className="flex-1 min-h-0 relative rounded-xl overflow-auto border border-white/5">
-					{/* Unisphere media manager container */}
-					<div
-						id="kaltura-media-manager-container"
-						ref={containerRef}
-						className="w-full h-full"
-					/>
+						<div
+							id="kaltura-media-manager-container"
+							ref={containerRef}
+							className="w-full h-full"
+						/>
 
-					{/* Loading states */}
-					{(state.phase === "checking_session" || state.phase === "loading_manager") && (
-						<div className="absolute inset-0 flex items-center justify-center bg-[#09090b]">
-							<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
-							<span className="ml-3 text-sm text-slate-400">
-								{state.phase === "checking_session" ? "Checking session..." : "Loading media browser..."}
-							</span>
-						</div>
-					)}
-
-					{/* Downloading state */}
-					{state.phase === "downloading" && (
-						<div className="absolute inset-0 flex flex-col items-center justify-center bg-[#09090b]/90 backdrop-blur-sm">
-							<Loader2 className="w-8 h-8 text-orange-400 animate-spin mb-4" />
-							<span className="text-sm font-medium text-slate-200 mb-1">
-								Downloading: {state.entryName}
-							</span>
-							<div className="w-64 h-2 bg-white/10 rounded-full overflow-hidden mt-2">
-								<div
-									className="h-full bg-orange-500 rounded-full transition-all duration-300"
-									style={{ width: `${state.percentage}%` }}
-								/>
+						{(state.phase === "checking_session" || state.phase === "loading_manager") && (
+							<div className="absolute inset-0 flex items-center justify-center bg-[#09090b]">
+								<Loader2 className="w-8 h-8 text-orange-400 animate-spin" />
+								<span className="ml-3 text-sm text-slate-400">
+									{state.phase === "checking_session"
+										? t("browse.checkingSession")
+										: t("browse.loadingBrowser")}
+								</span>
 							</div>
-							<span className="text-xs text-slate-500 mt-2">{state.percentage}%</span>
-						</div>
-					)}
+						)}
+
+						{state.phase === "downloading" && (
+							<div className="absolute inset-0 flex flex-col items-center justify-center bg-[#09090b]/90 backdrop-blur-sm">
+								<Loader2 className="w-8 h-8 text-orange-400 animate-spin mb-4" />
+								<span className="text-sm font-medium text-slate-200 mb-1">
+									{t("browse.downloading", { name: state.entryName })}
+								</span>
+								<div className="w-64 h-2 bg-white/10 rounded-full overflow-hidden mt-2">
+									<div
+										className="h-full bg-orange-500 rounded-full transition-all duration-300"
+										style={{ width: `${state.percentage}%` }}
+									/>
+								</div>
+								<span className="text-xs text-slate-500 mt-2">{state.percentage}%</span>
+							</div>
+						)}
 					</div>
 				</div>
 			)}
@@ -572,7 +425,7 @@ export function KalturaBrowsePage() {
 								onClick={handleClose}
 								className="mt-3 text-slate-400 hover:text-white"
 							>
-								Close
+								{t("upload.cancel")}
 							</Button>
 						</div>
 					</div>

--- a/src/components/video-editor/KalturaLoginForm.tsx
+++ b/src/components/video-editor/KalturaLoginForm.tsx
@@ -111,9 +111,9 @@ export function KalturaLoginForm({
 		[t, onPartnerSelected, onError],
 	);
 
-	const handleSignup = useCallback(() => {
+	const handleSignup = useCallback(async () => {
+		await window.electronAPI.kalturaOpenSignup();
 		setClickedSignup(true);
-		window.electronAPI.kalturaOpenSignup();
 	}, []);
 
 	const handleKeyDown = useCallback(

--- a/src/components/video-editor/KalturaLoginForm.tsx
+++ b/src/components/video-editor/KalturaLoginForm.tsx
@@ -1,0 +1,261 @@
+import { AlertCircle, ArrowLeft, Check, ExternalLink, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useScopedT } from "@/contexts/I18nContext";
+
+interface KalturaPartner {
+	id: number;
+	name: string;
+}
+
+interface KalturaLoginFormProps {
+	/** Called when login succeeds. Receives the API result for the caller to handle. */
+	onLoginSuccess: (result: {
+		partners?: KalturaPartner[];
+		state?: {
+			connected: boolean;
+			partnerId?: number;
+			serviceUrl?: string;
+			userId?: string;
+			displayName?: string;
+			ksExpiry?: number;
+		};
+	}) => void;
+	/** Called when partner selection succeeds. */
+	onPartnerSelected: (result: {
+		state?: {
+			connected: boolean;
+			partnerId?: number;
+			serviceUrl?: string;
+			userId?: string;
+			displayName?: string;
+			ksExpiry?: number;
+		};
+	}) => void;
+	/** Called when an error occurs during login or partner selection. */
+	onError: (error: string) => void;
+	/** Error message to display, if any. */
+	error?: string;
+	/** Partner list — when provided, shows account selection instead of login form. */
+	partners?: KalturaPartner[];
+	/** Called to go back from account selection to login form. */
+	onBack?: () => void;
+}
+
+export function KalturaLoginForm({
+	onLoginSuccess,
+	onPartnerSelected,
+	onError,
+	error,
+	partners,
+	onBack,
+}: KalturaLoginFormProps) {
+	const t = useScopedT("kaltura");
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [clickedSignup, setClickedSignup] = useState(false);
+	const [loggingIn, setLoggingIn] = useState(false);
+	const [selectingPartner, setSelectingPartner] = useState(false);
+	const emailInputRef = useRef<HTMLInputElement>(null);
+
+	const handleLogin = useCallback(async () => {
+		if (!email.trim() || !password.trim()) return;
+
+		setLoggingIn(true);
+
+		try {
+			const result = await window.electronAPI.kalturaLogin({
+				serviceUrl: "https://www.kaltura.com",
+				loginId: email.trim(),
+				password: password.trim(),
+			});
+
+			setPassword("");
+			setLoggingIn(false);
+
+			if (!result.success) {
+				onError(result.error || t("login.loginFailed"));
+				return;
+			}
+
+			onLoginSuccess(result);
+		} catch (err) {
+			setPassword("");
+			setLoggingIn(false);
+			onError(String(err));
+		}
+	}, [email, password, t, onLoginSuccess, onError]);
+
+	const handleSelectPartner = useCallback(
+		async (partnerId: number) => {
+			setSelectingPartner(true);
+
+			try {
+				const result = await window.electronAPI.kalturaSelectPartner({ partnerId });
+
+				setSelectingPartner(false);
+
+				if (!result.success) {
+					onError(result.error || t("login.failedSelectAccount"));
+					return;
+				}
+
+				setPassword("");
+				onPartnerSelected(result);
+			} catch (err) {
+				setSelectingPartner(false);
+				onError(String(err));
+			}
+		},
+		[t, onPartnerSelected, onError],
+	);
+
+	const handleSignup = useCallback(() => {
+		setClickedSignup(true);
+		window.electronAPI.kalturaOpenSignup();
+	}, []);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" && !loggingIn) {
+				handleLogin();
+			}
+		},
+		[loggingIn, handleLogin],
+	);
+
+	// Auto-focus email input when user returns from signup
+	useEffect(() => {
+		if (!clickedSignup) return;
+		const onFocus = () => {
+			setTimeout(() => emailInputRef.current?.focus(), 100);
+		};
+		window.addEventListener("focus", onFocus);
+		return () => window.removeEventListener("focus", onFocus);
+	}, [clickedSignup]);
+
+	if (loggingIn || selectingPartner) {
+		return (
+			<div className="flex items-center justify-center py-8">
+				<Loader2 className="w-6 h-6 text-orange-400 animate-spin" />
+				<span className="ml-3 text-sm text-slate-400">
+					{loggingIn ? t("connection.signingIn") : t("connection.connecting")}
+				</span>
+			</div>
+		);
+	}
+
+	if (partners && partners.length > 0) {
+		return (
+			<div className="space-y-3">
+				{onBack && (
+					<button
+						type="button"
+						onClick={onBack}
+						className="flex items-center gap-2 text-sm text-slate-400 hover:text-white transition-colors mb-2"
+					>
+						<ArrowLeft className="w-4 h-4" />
+						{t("connection.backToLogin")}
+					</button>
+				)}
+				<div className="space-y-2 max-h-64 overflow-y-auto">
+					{partners.map((partner) => (
+						<button
+							key={partner.id}
+							type="button"
+							onClick={() => handleSelectPartner(partner.id)}
+							className="w-full text-left p-4 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 hover:border-orange-500/30 transition-all flex items-center justify-between group"
+						>
+							<div>
+								<span className="text-sm font-medium text-slate-200 block">{partner.name}</span>
+								<span className="text-xs text-slate-500">
+									{t("connection.partnerId", { id: partner.id })}
+								</span>
+							</div>
+							<ArrowLeft className="w-4 h-4 text-slate-600 group-hover:text-orange-400 rotate-180 transition-colors" />
+						</button>
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4" onKeyDown={handleKeyDown}>
+			{/* Post-signup welcome banner */}
+			{clickedSignup && (
+				<div className="animate-in fade-in slide-in-from-top-2 duration-300">
+					<div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-4 flex items-start gap-3">
+						<Check className="w-4 h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
+						<p className="text-sm text-emerald-300 leading-relaxed">{t("login.signupSuccess")}</p>
+					</div>
+				</div>
+			)}
+
+			{/* Error message */}
+			{error && (
+				<div className="animate-in slide-in-from-top-2">
+					<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+						<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+						<p className="text-sm text-red-400 leading-relaxed">{error}</p>
+					</div>
+				</div>
+			)}
+
+			<div>
+				<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+					{t("login.email")}
+				</label>
+				<Input
+					ref={emailInputRef}
+					type="email"
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+					disabled={loggingIn}
+					placeholder={t("login.emailPlaceholder")}
+					autoComplete="email"
+					className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
+				/>
+			</div>
+
+			<div>
+				<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+					{t("login.password")}
+				</label>
+				<Input
+					type="password"
+					value={password}
+					onChange={(e) => setPassword(e.target.value)}
+					disabled={loggingIn}
+					placeholder={t("login.passwordPlaceholder")}
+					autoComplete="current-password"
+					className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
+				/>
+			</div>
+
+			<div className="flex items-center justify-between pt-2">
+				{clickedSignup ? (
+					<span className="text-xs text-slate-500">{t("login.signupVerify")}</span>
+				) : (
+					<button
+						type="button"
+						onClick={handleSignup}
+						className="text-xs text-slate-400 hover:text-orange-400 transition-colors flex items-center gap-1"
+					>
+						{t("login.signupPrompt")}
+						<ExternalLink className="w-3 h-3" />
+					</button>
+				)}
+				<Button
+					onClick={handleLogin}
+					disabled={!email.trim() || !password.trim() || loggingIn}
+					className="bg-orange-500 hover:bg-orange-600 text-white"
+				>
+					{loggingIn ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
+					{t("connection.signIn")}
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/video-editor/KalturaSettingsDialog.tsx
+++ b/src/components/video-editor/KalturaSettingsDialog.tsx
@@ -1,16 +1,9 @@
-import {
-	AlertCircle,
-	ArrowLeft,
-	Check,
-	ExternalLink,
-	Loader2,
-	LogOut,
-	RefreshCw,
-	Settings2,
-	X,
-} from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, LogOut, RefreshCw, Settings2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useScopedT } from "@/contexts/I18nContext";
+import { KalturaLoginForm } from "./KalturaLoginForm";
 
 interface KalturaSettingsDialogProps {
 	isOpen: boolean;
@@ -18,376 +11,218 @@ interface KalturaSettingsDialogProps {
 	onLogout?: () => void;
 }
 
-type DialogState =
-	| { phase: "logged_out"; error?: string }
-	| { phase: "logging_in" }
-	| { phase: "account_selection"; partners: Array<{ id: number; name: string }> }
-	| { phase: "connecting_partner" }
-	| {
-			phase: "connected";
-			partnerId: number;
-			serviceUrl: string;
-			userId: string;
-			displayName?: string;
-			ksExpiry: number;
-	  };
+interface ConnectedState {
+	partnerId: number;
+	serviceUrl: string;
+	userId: string;
+	displayName?: string;
+	ksExpiry: number;
+}
+
+type DialogPhase = "logged_out" | "account_selection" | "connected";
 
 export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSettingsDialogProps) {
-	const [dialogState, setDialogState] = useState<DialogState>({ phase: "logged_out" });
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
-	const [clickedSignup, setClickedSignup] = useState(false);
-	const emailInputRef = useRef<HTMLInputElement>(null);
+	const t = useScopedT("kaltura");
+	const [phase, setPhase] = useState<DialogPhase>("logged_out");
+	const [error, setError] = useState<string | undefined>();
+	const [partners, setPartners] = useState<Array<{ id: number; name: string }>>([]);
+	const [connected, setConnected] = useState<ConnectedState | null>(null);
 
 	// Load existing session on open
 	useEffect(() => {
 		if (!isOpen) return;
 
-		setPassword("");
-		setClickedSignup(false);
-		setDialogState({ phase: "logged_out" });
+		setError(undefined);
+		setPhase("logged_out");
 
 		window.electronAPI.kalturaLoadSession().then((result) => {
 			if (result.success && result.state?.connected) {
-				setDialogState({
-					phase: "connected",
+				setConnected({
 					partnerId: result.state.partnerId!,
 					serviceUrl: result.state.serviceUrl!,
 					userId: result.state.userId!,
 					displayName: result.state.displayName,
 					ksExpiry: result.state.ksExpiry!,
 				});
+				setPhase("connected");
 			}
 		});
 	}, [isOpen]);
 
-	const handleLogin = useCallback(async () => {
-		if (!email.trim() || !password.trim()) return;
-
-		setDialogState({ phase: "logging_in" });
-
-		try {
-			const result = await window.electronAPI.kalturaLogin({
-				serviceUrl: "https://www.kaltura.com",
-				loginId: email.trim(),
-				password: password.trim(),
-			});
-
-			if (!result.success) {
-				setDialogState({ phase: "logged_out", error: result.error || "Login failed" });
-				return;
-			}
-
+	const handleLoginSuccess = useCallback(
+		(result: {
+			partners?: Array<{ id: number; name: string }>;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}) => {
 			if (result.partners && result.partners.length > 1) {
-				setDialogState({ phase: "account_selection", partners: result.partners });
+				setPartners(result.partners);
+				setPhase("account_selection");
 				return;
 			}
 
 			if (result.state?.connected) {
-				setPassword("");
-				setDialogState({
-					phase: "connected",
+				setConnected({
 					partnerId: result.state.partnerId!,
 					serviceUrl: result.state.serviceUrl!,
 					userId: result.state.userId!,
 					displayName: result.state.displayName,
 					ksExpiry: result.state.ksExpiry!,
 				});
+				setPhase("connected");
 			}
-		} catch (error) {
-			setDialogState({ phase: "logged_out", error: String(error) });
-		}
-	}, [email, password]);
+		},
+		[],
+	);
 
-	const handleSelectPartner = useCallback(async (partnerId: number) => {
-		setDialogState({ phase: "connecting_partner" });
-
-		try {
-			const result = await window.electronAPI.kalturaSelectPartner({ partnerId });
-
-			if (!result.success) {
-				setDialogState({
-					phase: "logged_out",
-					error: result.error || "Failed to select account",
-				});
-				return;
-			}
-
+	const handlePartnerSelected = useCallback(
+		(result: {
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}) => {
 			if (result.state?.connected) {
-				setPassword("");
-				setDialogState({
-					phase: "connected",
+				setConnected({
 					partnerId: result.state.partnerId!,
 					serviceUrl: result.state.serviceUrl!,
 					userId: result.state.userId!,
 					displayName: result.state.displayName,
 					ksExpiry: result.state.ksExpiry!,
 				});
+				setPhase("connected");
 			}
-		} catch (error) {
-			setDialogState({ phase: "logged_out", error: String(error) });
-		}
+		},
+		[],
+	);
+
+	const handleError = useCallback((msg: string) => {
+		setError(msg);
+		setPhase("logged_out");
 	}, []);
 
 	const handleLogout = useCallback(async () => {
 		await window.electronAPI.kalturaLogout();
-		setEmail("");
-		setPassword("");
-		setDialogState({ phase: "logged_out" });
+		setConnected(null);
+		setPhase("logged_out");
 		onLogout?.();
 	}, [onLogout]);
 
 	const handleSwitchAccount = useCallback(async () => {
 		const result = await window.electronAPI.kalturaListPartners();
 		if (result.success && result.partners && result.partners.length > 1) {
-			setDialogState({ phase: "account_selection", partners: result.partners });
+			setPartners(result.partners);
+			setPhase("account_selection");
 		} else if (!result.success) {
 			await window.electronAPI.kalturaLogout();
-			setEmail("");
-			setPassword("");
-			setDialogState({ phase: "logged_out", error: result.error || "Please sign in again to switch accounts." });
+			setConnected(null);
+			setError(result.error || t("connection.switchError"));
+			setPhase("logged_out");
 		}
-	}, []);
-
-	const handleSignup = useCallback(() => {
-		setClickedSignup(true);
-		window.electronAPI.kalturaOpenSignup();
-	}, []);
-
-	// When user returns to the app after signup, auto-focus the email input
-	useEffect(() => {
-		if (!clickedSignup || !isOpen) return;
-		const onFocus = () => {
-			setTimeout(() => emailInputRef.current?.focus(), 100);
-		};
-		window.addEventListener("focus", onFocus);
-		return () => window.removeEventListener("focus", onFocus);
-	}, [clickedSignup, isOpen]);
-
-	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent) => {
-			if (e.key === "Enter" && dialogState.phase === "logged_out") {
-				handleLogin();
-			}
-		},
-		[dialogState.phase, handleLogin],
-	);
-
-	if (!isOpen) return null;
-
-	const isLoggingIn = dialogState.phase === "logging_in";
-	const isConnecting = dialogState.phase === "connecting_partner";
+	}, [t]);
 
 	return (
-		<>
-			<div
-				className="fixed inset-0 bg-black/80 backdrop-blur-md z-50 animate-in fade-in duration-200"
-				onClick={isLoggingIn || isConnecting ? undefined : onClose}
-			/>
-			<div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[60] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-8 w-[90vw] max-w-lg animate-in zoom-in-95 duration-200">
+		<Dialog
+			open={isOpen}
+			onOpenChange={(open) => {
+				if (!open) onClose();
+			}}
+		>
+			<DialogContent className="bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-8 w-[90vw] max-w-lg">
 				{/* Header */}
-				<div className="flex items-center justify-between mb-6">
-					<div className="flex items-center gap-3">
-						{dialogState.phase === "account_selection" ? (
-							<button
-								type="button"
-								onClick={() => setDialogState({ phase: "logged_out" })}
-								className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center ring-1 ring-white/10 hover:bg-white/10 transition-colors"
-							>
-								<ArrowLeft className="w-5 h-5 text-slate-300" />
-							</button>
+				<div className="flex items-center gap-3 mb-6">
+					<div
+						className={`w-10 h-10 rounded-full flex items-center justify-center ring-1 ${
+							phase === "connected"
+								? "bg-emerald-500/20 ring-emerald-500/50"
+								: "bg-orange-500/20 ring-orange-500/50"
+						}`}
+					>
+						{phase === "connected" ? (
+							<Check className="w-5 h-5 text-emerald-400" />
 						) : (
-							<div
-								className={`w-10 h-10 rounded-full flex items-center justify-center ring-1 ${
-									dialogState.phase === "connected"
-										? "bg-emerald-500/20 ring-emerald-500/50"
-										: "bg-orange-500/20 ring-orange-500/50"
-								}`}
-							>
-								{dialogState.phase === "connected" ? (
-									<Check className="w-5 h-5 text-emerald-400" />
-								) : (
-									<Settings2 className="w-5 h-5 text-orange-400" />
-								)}
-							</div>
+							<Settings2 className="w-5 h-5 text-orange-400" />
 						)}
-						<div>
-							<span className="text-lg font-bold text-slate-200 block">
-								{dialogState.phase === "connected"
-									? "Connected to Kaltura"
-									: dialogState.phase === "account_selection"
-										? "Select Account"
-										: "Kaltura Connection"}
-							</span>
-							<span className="text-xs text-slate-500">
-								{dialogState.phase === "connected" && "partnerId" in dialogState
-									? `Partner ${dialogState.partnerId}`
-									: dialogState.phase === "account_selection"
-										? "Choose a Kaltura account to connect"
-										: clickedSignup
-											? "Welcome back \u2014 sign in with your new account"
-											: "Sign in to your Kaltura account"}
-							</span>
-						</div>
 					</div>
-					{!isLoggingIn && !isConnecting && (
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={onClose}
-							className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full"
-						>
-							<X className="w-5 h-5" />
-						</Button>
-					)}
+					<div>
+						<span className="text-lg font-bold text-slate-200 block">
+							{phase === "connected"
+								? t("connection.connected")
+								: phase === "account_selection"
+									? t("connection.selectAccount")
+									: t("connection.title")}
+						</span>
+						<span className="text-xs text-slate-500">
+							{phase === "connected" && connected
+								? t("connection.partnerId", { id: connected.partnerId })
+								: phase === "account_selection"
+									? t("connection.chooseAccount")
+									: t("connection.connectPrompt")}
+						</span>
+					</div>
 				</div>
 
-				{/* Post-signup welcome banner */}
-				{dialogState.phase === "logged_out" && clickedSignup && (
-					<div className="mb-4 animate-in fade-in slide-in-from-top-2 duration-300">
-						<div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-4 flex items-start gap-3">
-							<Check className="w-4 h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
-							<p className="text-sm text-emerald-300 leading-relaxed">Account created? Sign in with your new credentials below.</p>
-						</div>
-					</div>
-				)}
-
-				{/* Error Message */}
-				{dialogState.phase === "logged_out" && dialogState.error && (
-					<div className="mb-4 animate-in slide-in-from-top-2">
-						<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
-							<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-							<p className="text-sm text-red-400 leading-relaxed">{dialogState.error}</p>
-						</div>
-					</div>
-				)}
-
-				{/* Login Form */}
-				{(dialogState.phase === "logged_out" || dialogState.phase === "logging_in") && (
-					<div className="space-y-4" onKeyDown={handleKeyDown}>
-						<div>
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Email
-							</label>
-							<input
-								ref={emailInputRef}
-								type="email"
-								value={email}
-								onChange={(e) => setEmail(e.target.value)}
-								disabled={isLoggingIn}
-								placeholder="you@example.com"
-								autoComplete="email"
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
-							/>
-						</div>
-
-						<div>
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Password
-							</label>
-							<input
-								type="password"
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								disabled={isLoggingIn}
-								placeholder="Enter your password"
-								autoComplete="current-password"
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
-							/>
-						</div>
-
-						<div className="flex items-center justify-between pt-2">
-							{clickedSignup ? (
-								<span className="text-xs text-slate-500">
-									After verifying your email, sign in here.
-								</span>
-							) : (
-								<button
-									type="button"
-									onClick={handleSignup}
-									className="text-xs text-slate-400 hover:text-orange-400 transition-colors flex items-center gap-1"
-								>
-									Don&apos;t have an account? Sign up free
-									<ExternalLink className="w-3 h-3" />
-								</button>
-							)}
-							<Button
-								onClick={handleLogin}
-								disabled={!email.trim() || !password.trim() || isLoggingIn}
-								className="bg-orange-500 hover:bg-orange-600 text-white"
-							>
-								{isLoggingIn ? (
-									<Loader2 className="w-4 h-4 mr-2 animate-spin" />
-								) : null}
-								Sign In
-							</Button>
-						</div>
-					</div>
-				)}
-
-				{/* Account Selection */}
-				{(dialogState.phase === "account_selection" || dialogState.phase === "connecting_partner") && (
-					<div className="space-y-2 max-h-64 overflow-y-auto">
-						{dialogState.phase === "account_selection" &&
-							dialogState.partners.map((partner) => (
-								<button
-									key={partner.id}
-									type="button"
-									onClick={() => handleSelectPartner(partner.id)}
-									className="w-full text-left p-4 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 hover:border-orange-500/30 transition-all flex items-center justify-between group"
-								>
-									<div>
-										<span className="text-sm font-medium text-slate-200 block">
-											{partner.name}
-										</span>
-										<span className="text-xs text-slate-500">
-											Partner ID: {partner.id}
-										</span>
-									</div>
-									<ArrowLeft className="w-4 h-4 text-slate-600 group-hover:text-orange-400 rotate-180 transition-colors" />
-								</button>
-							))}
-						{isConnecting && (
-							<div className="flex items-center justify-center py-8">
-								<Loader2 className="w-6 h-6 text-orange-400 animate-spin" />
-								<span className="ml-3 text-sm text-slate-400">Connecting...</span>
-							</div>
-						)}
-					</div>
+				{/* Login / Account Selection */}
+				{phase !== "connected" && (
+					<KalturaLoginForm
+						error={error}
+						partners={phase === "account_selection" ? partners : undefined}
+						onLoginSuccess={handleLoginSuccess}
+						onPartnerSelected={handlePartnerSelected}
+						onError={handleError}
+						onBack={() => {
+							setError(undefined);
+							setPhase("logged_out");
+						}}
+					/>
 				)}
 
 				{/* Connected State */}
-				{dialogState.phase === "connected" && (
+				{phase === "connected" && connected && (
 					<div className="space-y-4">
 						<div className="space-y-3">
 							<div className="flex items-center justify-between py-2 border-b border-white/5">
-								<span className="text-xs text-slate-500 uppercase tracking-wider">Account</span>
-								<span className="text-sm text-slate-200">
-									{dialogState.partnerId}
+								<span className="text-xs text-slate-500 uppercase tracking-wider">
+									{t("labels.account")}
 								</span>
+								<span className="text-sm text-slate-200">{connected.partnerId}</span>
 							</div>
 							<div className="flex items-center justify-between py-2 border-b border-white/5">
-								<span className="text-xs text-slate-500 uppercase tracking-wider">User</span>
+								<span className="text-xs text-slate-500 uppercase tracking-wider">
+									{t("labels.user")}
+								</span>
 								<span className="text-sm text-slate-200">
-									{dialogState.displayName || dialogState.userId}
+									{connected.displayName || connected.userId}
 								</span>
 							</div>
-							{dialogState.displayName && (
+							{connected.displayName && (
 								<div className="flex items-center justify-between py-2 border-b border-white/5">
-									<span className="text-xs text-slate-500 uppercase tracking-wider">Email</span>
-									<span className="text-sm text-slate-200">
-										{dialogState.userId}
+									<span className="text-xs text-slate-500 uppercase tracking-wider">
+										{t("labels.emailLabel")}
 									</span>
+									<span className="text-sm text-slate-200">{connected.userId}</span>
 								</div>
 							)}
 							<div className="flex items-center justify-between py-2 border-b border-white/5">
-								<span className="text-xs text-slate-500 uppercase tracking-wider">Session</span>
+								<span className="text-xs text-slate-500 uppercase tracking-wider">
+									{t("labels.session")}
+								</span>
 								<span className="text-sm text-emerald-400 flex items-center gap-1.5">
 									<span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-									Active
+									{t("connection.sessionActive")}
 								</span>
 							</div>
-							</div>
+						</div>
 
 						<div className="flex items-center gap-3 pt-2 border-t border-white/5">
 							<Button
@@ -396,7 +231,7 @@ export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSett
 								className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
 							>
 								<LogOut className="w-4 h-4 mr-2" />
-								Sign Out
+								{t("connection.signOut")}
 							</Button>
 							<Button
 								onClick={handleSwitchAccount}
@@ -404,19 +239,16 @@ export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSett
 								className="text-slate-400 hover:text-slate-200 hover:bg-white/10"
 							>
 								<RefreshCw className="w-4 h-4 mr-2" />
-								Switch Account
+								{t("connection.switchAccount")}
 							</Button>
 							<div className="flex-1" />
-							<Button
-								onClick={onClose}
-								className="bg-white/10 hover:bg-white/20 text-slate-200"
-							>
-								Done
+							<Button onClick={onClose} className="bg-white/10 hover:bg-white/20 text-slate-200">
+								{t("connection.done")}
 							</Button>
 						</div>
 					</div>
 				)}
-			</div>
-		</>
+			</DialogContent>
+		</Dialog>
 	);
 }

--- a/src/components/video-editor/KalturaSettingsDialog.tsx
+++ b/src/components/video-editor/KalturaSettingsDialog.tsx
@@ -1,0 +1,422 @@
+import {
+	AlertCircle,
+	ArrowLeft,
+	Check,
+	ExternalLink,
+	Loader2,
+	LogOut,
+	RefreshCw,
+	Settings2,
+	X,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface KalturaSettingsDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onLogout?: () => void;
+}
+
+type DialogState =
+	| { phase: "logged_out"; error?: string }
+	| { phase: "logging_in" }
+	| { phase: "account_selection"; partners: Array<{ id: number; name: string }> }
+	| { phase: "connecting_partner" }
+	| {
+			phase: "connected";
+			partnerId: number;
+			serviceUrl: string;
+			userId: string;
+			displayName?: string;
+			ksExpiry: number;
+	  };
+
+export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSettingsDialogProps) {
+	const [dialogState, setDialogState] = useState<DialogState>({ phase: "logged_out" });
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [clickedSignup, setClickedSignup] = useState(false);
+	const emailInputRef = useRef<HTMLInputElement>(null);
+
+	// Load existing session on open
+	useEffect(() => {
+		if (!isOpen) return;
+
+		setPassword("");
+		setClickedSignup(false);
+		setDialogState({ phase: "logged_out" });
+
+		window.electronAPI.kalturaLoadSession().then((result) => {
+			if (result.success && result.state?.connected) {
+				setDialogState({
+					phase: "connected",
+					partnerId: result.state.partnerId!,
+					serviceUrl: result.state.serviceUrl!,
+					userId: result.state.userId!,
+					displayName: result.state.displayName,
+					ksExpiry: result.state.ksExpiry!,
+				});
+			}
+		});
+	}, [isOpen]);
+
+	const handleLogin = useCallback(async () => {
+		if (!email.trim() || !password.trim()) return;
+
+		setDialogState({ phase: "logging_in" });
+
+		try {
+			const result = await window.electronAPI.kalturaLogin({
+				serviceUrl: "https://www.kaltura.com",
+				loginId: email.trim(),
+				password: password.trim(),
+			});
+
+			if (!result.success) {
+				setDialogState({ phase: "logged_out", error: result.error || "Login failed" });
+				return;
+			}
+
+			if (result.partners && result.partners.length > 1) {
+				setDialogState({ phase: "account_selection", partners: result.partners });
+				return;
+			}
+
+			if (result.state?.connected) {
+				setPassword("");
+				setDialogState({
+					phase: "connected",
+					partnerId: result.state.partnerId!,
+					serviceUrl: result.state.serviceUrl!,
+					userId: result.state.userId!,
+					displayName: result.state.displayName,
+					ksExpiry: result.state.ksExpiry!,
+				});
+			}
+		} catch (error) {
+			setDialogState({ phase: "logged_out", error: String(error) });
+		}
+	}, [email, password]);
+
+	const handleSelectPartner = useCallback(async (partnerId: number) => {
+		setDialogState({ phase: "connecting_partner" });
+
+		try {
+			const result = await window.electronAPI.kalturaSelectPartner({ partnerId });
+
+			if (!result.success) {
+				setDialogState({
+					phase: "logged_out",
+					error: result.error || "Failed to select account",
+				});
+				return;
+			}
+
+			if (result.state?.connected) {
+				setPassword("");
+				setDialogState({
+					phase: "connected",
+					partnerId: result.state.partnerId!,
+					serviceUrl: result.state.serviceUrl!,
+					userId: result.state.userId!,
+					displayName: result.state.displayName,
+					ksExpiry: result.state.ksExpiry!,
+				});
+			}
+		} catch (error) {
+			setDialogState({ phase: "logged_out", error: String(error) });
+		}
+	}, []);
+
+	const handleLogout = useCallback(async () => {
+		await window.electronAPI.kalturaLogout();
+		setEmail("");
+		setPassword("");
+		setDialogState({ phase: "logged_out" });
+		onLogout?.();
+	}, [onLogout]);
+
+	const handleSwitchAccount = useCallback(async () => {
+		const result = await window.electronAPI.kalturaListPartners();
+		if (result.success && result.partners && result.partners.length > 1) {
+			setDialogState({ phase: "account_selection", partners: result.partners });
+		} else if (!result.success) {
+			await window.electronAPI.kalturaLogout();
+			setEmail("");
+			setPassword("");
+			setDialogState({ phase: "logged_out", error: result.error || "Please sign in again to switch accounts." });
+		}
+	}, []);
+
+	const handleSignup = useCallback(() => {
+		setClickedSignup(true);
+		window.electronAPI.kalturaOpenSignup();
+	}, []);
+
+	// When user returns to the app after signup, auto-focus the email input
+	useEffect(() => {
+		if (!clickedSignup || !isOpen) return;
+		const onFocus = () => {
+			setTimeout(() => emailInputRef.current?.focus(), 100);
+		};
+		window.addEventListener("focus", onFocus);
+		return () => window.removeEventListener("focus", onFocus);
+	}, [clickedSignup, isOpen]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" && dialogState.phase === "logged_out") {
+				handleLogin();
+			}
+		},
+		[dialogState.phase, handleLogin],
+	);
+
+	if (!isOpen) return null;
+
+	const isLoggingIn = dialogState.phase === "logging_in";
+	const isConnecting = dialogState.phase === "connecting_partner";
+
+	return (
+		<>
+			<div
+				className="fixed inset-0 bg-black/80 backdrop-blur-md z-50 animate-in fade-in duration-200"
+				onClick={isLoggingIn || isConnecting ? undefined : onClose}
+			/>
+			<div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[60] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-8 w-[90vw] max-w-lg animate-in zoom-in-95 duration-200">
+				{/* Header */}
+				<div className="flex items-center justify-between mb-6">
+					<div className="flex items-center gap-3">
+						{dialogState.phase === "account_selection" ? (
+							<button
+								type="button"
+								onClick={() => setDialogState({ phase: "logged_out" })}
+								className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center ring-1 ring-white/10 hover:bg-white/10 transition-colors"
+							>
+								<ArrowLeft className="w-5 h-5 text-slate-300" />
+							</button>
+						) : (
+							<div
+								className={`w-10 h-10 rounded-full flex items-center justify-center ring-1 ${
+									dialogState.phase === "connected"
+										? "bg-emerald-500/20 ring-emerald-500/50"
+										: "bg-orange-500/20 ring-orange-500/50"
+								}`}
+							>
+								{dialogState.phase === "connected" ? (
+									<Check className="w-5 h-5 text-emerald-400" />
+								) : (
+									<Settings2 className="w-5 h-5 text-orange-400" />
+								)}
+							</div>
+						)}
+						<div>
+							<span className="text-lg font-bold text-slate-200 block">
+								{dialogState.phase === "connected"
+									? "Connected to Kaltura"
+									: dialogState.phase === "account_selection"
+										? "Select Account"
+										: "Kaltura Connection"}
+							</span>
+							<span className="text-xs text-slate-500">
+								{dialogState.phase === "connected" && "partnerId" in dialogState
+									? `Partner ${dialogState.partnerId}`
+									: dialogState.phase === "account_selection"
+										? "Choose a Kaltura account to connect"
+										: clickedSignup
+											? "Welcome back \u2014 sign in with your new account"
+											: "Sign in to your Kaltura account"}
+							</span>
+						</div>
+					</div>
+					{!isLoggingIn && !isConnecting && (
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={onClose}
+							className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full"
+						>
+							<X className="w-5 h-5" />
+						</Button>
+					)}
+				</div>
+
+				{/* Post-signup welcome banner */}
+				{dialogState.phase === "logged_out" && clickedSignup && (
+					<div className="mb-4 animate-in fade-in slide-in-from-top-2 duration-300">
+						<div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-4 flex items-start gap-3">
+							<Check className="w-4 h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
+							<p className="text-sm text-emerald-300 leading-relaxed">Account created? Sign in with your new credentials below.</p>
+						</div>
+					</div>
+				)}
+
+				{/* Error Message */}
+				{dialogState.phase === "logged_out" && dialogState.error && (
+					<div className="mb-4 animate-in slide-in-from-top-2">
+						<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+							<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+							<p className="text-sm text-red-400 leading-relaxed">{dialogState.error}</p>
+						</div>
+					</div>
+				)}
+
+				{/* Login Form */}
+				{(dialogState.phase === "logged_out" || dialogState.phase === "logging_in") && (
+					<div className="space-y-4" onKeyDown={handleKeyDown}>
+						<div>
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Email
+							</label>
+							<input
+								ref={emailInputRef}
+								type="email"
+								value={email}
+								onChange={(e) => setEmail(e.target.value)}
+								disabled={isLoggingIn}
+								placeholder="you@example.com"
+								autoComplete="email"
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
+							/>
+						</div>
+
+						<div>
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Password
+							</label>
+							<input
+								type="password"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								disabled={isLoggingIn}
+								placeholder="Enter your password"
+								autoComplete="current-password"
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 disabled:opacity-50"
+							/>
+						</div>
+
+						<div className="flex items-center justify-between pt-2">
+							{clickedSignup ? (
+								<span className="text-xs text-slate-500">
+									After verifying your email, sign in here.
+								</span>
+							) : (
+								<button
+									type="button"
+									onClick={handleSignup}
+									className="text-xs text-slate-400 hover:text-orange-400 transition-colors flex items-center gap-1"
+								>
+									Don&apos;t have an account? Sign up free
+									<ExternalLink className="w-3 h-3" />
+								</button>
+							)}
+							<Button
+								onClick={handleLogin}
+								disabled={!email.trim() || !password.trim() || isLoggingIn}
+								className="bg-orange-500 hover:bg-orange-600 text-white"
+							>
+								{isLoggingIn ? (
+									<Loader2 className="w-4 h-4 mr-2 animate-spin" />
+								) : null}
+								Sign In
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{/* Account Selection */}
+				{(dialogState.phase === "account_selection" || dialogState.phase === "connecting_partner") && (
+					<div className="space-y-2 max-h-64 overflow-y-auto">
+						{dialogState.phase === "account_selection" &&
+							dialogState.partners.map((partner) => (
+								<button
+									key={partner.id}
+									type="button"
+									onClick={() => handleSelectPartner(partner.id)}
+									className="w-full text-left p-4 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 hover:border-orange-500/30 transition-all flex items-center justify-between group"
+								>
+									<div>
+										<span className="text-sm font-medium text-slate-200 block">
+											{partner.name}
+										</span>
+										<span className="text-xs text-slate-500">
+											Partner ID: {partner.id}
+										</span>
+									</div>
+									<ArrowLeft className="w-4 h-4 text-slate-600 group-hover:text-orange-400 rotate-180 transition-colors" />
+								</button>
+							))}
+						{isConnecting && (
+							<div className="flex items-center justify-center py-8">
+								<Loader2 className="w-6 h-6 text-orange-400 animate-spin" />
+								<span className="ml-3 text-sm text-slate-400">Connecting...</span>
+							</div>
+						)}
+					</div>
+				)}
+
+				{/* Connected State */}
+				{dialogState.phase === "connected" && (
+					<div className="space-y-4">
+						<div className="space-y-3">
+							<div className="flex items-center justify-between py-2 border-b border-white/5">
+								<span className="text-xs text-slate-500 uppercase tracking-wider">Account</span>
+								<span className="text-sm text-slate-200">
+									{dialogState.partnerId}
+								</span>
+							</div>
+							<div className="flex items-center justify-between py-2 border-b border-white/5">
+								<span className="text-xs text-slate-500 uppercase tracking-wider">User</span>
+								<span className="text-sm text-slate-200">
+									{dialogState.displayName || dialogState.userId}
+								</span>
+							</div>
+							{dialogState.displayName && (
+								<div className="flex items-center justify-between py-2 border-b border-white/5">
+									<span className="text-xs text-slate-500 uppercase tracking-wider">Email</span>
+									<span className="text-sm text-slate-200">
+										{dialogState.userId}
+									</span>
+								</div>
+							)}
+							<div className="flex items-center justify-between py-2 border-b border-white/5">
+								<span className="text-xs text-slate-500 uppercase tracking-wider">Session</span>
+								<span className="text-sm text-emerald-400 flex items-center gap-1.5">
+									<span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+									Active
+								</span>
+							</div>
+							</div>
+
+						<div className="flex items-center gap-3 pt-2 border-t border-white/5">
+							<Button
+								onClick={handleLogout}
+								variant="ghost"
+								className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
+							>
+								<LogOut className="w-4 h-4 mr-2" />
+								Sign Out
+							</Button>
+							<Button
+								onClick={handleSwitchAccount}
+								variant="ghost"
+								className="text-slate-400 hover:text-slate-200 hover:bg-white/10"
+							>
+								<RefreshCw className="w-4 h-4 mr-2" />
+								Switch Account
+							</Button>
+							<div className="flex-1" />
+							<Button
+								onClick={onClose}
+								className="bg-white/10 hover:bg-white/20 text-slate-200"
+							>
+								Done
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/src/components/video-editor/KalturaSettingsDialog.tsx
+++ b/src/components/video-editor/KalturaSettingsDialog.tsx
@@ -35,18 +35,23 @@ export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSett
 		setError(undefined);
 		setPhase("logged_out");
 
-		window.electronAPI.kalturaLoadSession().then((result) => {
-			if (result.success && result.state?.connected) {
-				setConnected({
-					partnerId: result.state.partnerId!,
-					serviceUrl: result.state.serviceUrl!,
-					userId: result.state.userId!,
-					displayName: result.state.displayName,
-					ksExpiry: result.state.ksExpiry!,
-				});
-				setPhase("connected");
-			}
-		});
+		window.electronAPI
+			.kalturaLoadSession()
+			.then((result) => {
+				if (result.success && result.state?.connected) {
+					setConnected({
+						partnerId: result.state.partnerId!,
+						serviceUrl: result.state.serviceUrl!,
+						userId: result.state.userId!,
+						displayName: result.state.displayName,
+						ksExpiry: result.state.ksExpiry!,
+					});
+					setPhase("connected");
+				}
+			})
+			.catch(() => {
+				// Session restore failed — stay on login screen
+			});
 	}, [isOpen]);
 
 	const handleLoginSuccess = useCallback(
@@ -112,22 +117,31 @@ export function KalturaSettingsDialog({ isOpen, onClose, onLogout }: KalturaSett
 	}, []);
 
 	const handleLogout = useCallback(async () => {
-		await window.electronAPI.kalturaLogout();
+		try {
+			await window.electronAPI.kalturaLogout();
+		} catch (err) {
+			console.error("Logout failed:", err);
+		}
 		setConnected(null);
 		setPhase("logged_out");
 		onLogout?.();
 	}, [onLogout]);
 
 	const handleSwitchAccount = useCallback(async () => {
-		const result = await window.electronAPI.kalturaListPartners();
-		if (result.success && result.partners && result.partners.length > 1) {
-			setPartners(result.partners);
-			setPhase("account_selection");
-		} else if (!result.success) {
-			await window.electronAPI.kalturaLogout();
-			setConnected(null);
-			setError(result.error || t("connection.switchError"));
-			setPhase("logged_out");
+		try {
+			const result = await window.electronAPI.kalturaListPartners();
+			if (result.success && result.partners && result.partners.length > 1) {
+				setPartners(result.partners);
+				setPhase("account_selection");
+			} else if (!result.success) {
+				await window.electronAPI.kalturaLogout();
+				setConnected(null);
+				setError(result.error || t("connection.switchError"));
+				setPhase("logged_out");
+			}
+		} catch (err) {
+			console.error("Switch account failed:", err);
+			setError(t("connection.switchError"));
 		}
 	}, [t]);
 

--- a/src/components/video-editor/KalturaUploadDialog.tsx
+++ b/src/components/video-editor/KalturaUploadDialog.tsx
@@ -1,6 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { AlertCircle, Check, Cloud, ExternalLink, Loader2, Upload, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -47,6 +47,7 @@ export function KalturaUploadDialog({
 	const [isUploading, setIsUploading] = useState(false);
 	const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null);
 	const [uploadError, setUploadError] = useState<string | null>(null);
+	const currentUploadIdRef = useRef<string | null>(null);
 
 	// Initialize form and load categories
 	useEffect(() => {
@@ -63,7 +64,9 @@ export function KalturaUploadDialog({
 		setDescription("");
 		setTags("");
 		setSelectedCategory("none");
+		setCategories([]);
 		setUploadProgress(null);
+		currentUploadIdRef.current = null;
 		setUploadError(null);
 		setIsUploading(false);
 
@@ -79,11 +82,13 @@ export function KalturaUploadDialog({
 			.finally(() => setIsLoadingCategories(false));
 	}, [isOpen, filePath, defaultName]);
 
-	// Listen for upload progress
+	// Listen for upload progress (filtered by uploadId to ignore stale events)
 	useEffect(() => {
 		if (!isOpen) return;
 
 		const cleanup = window.electronAPI.onKalturaUploadProgress((progress) => {
+			if (currentUploadIdRef.current && progress.uploadId !== currentUploadIdRef.current) return;
+			if (progress.uploadId) currentUploadIdRef.current = progress.uploadId;
 			setUploadProgress(progress);
 			if (progress.phase === "complete") {
 				setIsUploading(false);
@@ -112,6 +117,8 @@ export function KalturaUploadDialog({
 				tags: tags.trim() || undefined,
 				categoryIds: categoryValue || undefined,
 			});
+
+			if (result.uploadId) currentUploadIdRef.current = result.uploadId;
 
 			if (!result.success) {
 				setUploadError(result.error || t("upload.failed"));

--- a/src/components/video-editor/KalturaUploadDialog.tsx
+++ b/src/components/video-editor/KalturaUploadDialog.tsx
@@ -1,14 +1,18 @@
-import {
-	AlertCircle,
-	Check,
-	ChevronDown,
-	Cloud,
-	Loader2,
-	Upload,
-	X,
-} from "lucide-react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { AlertCircle, Check, Cloud, ExternalLink, Loader2, Upload, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { useScopedT } from "@/contexts/I18nContext";
+import { cn } from "@/lib/utils";
 
 interface KalturaUploadDialogProps {
 	isOpen: boolean;
@@ -31,10 +35,11 @@ export function KalturaUploadDialog({
 	filePath,
 	defaultName,
 }: KalturaUploadDialogProps) {
+	const t = useScopedT("kaltura");
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
 	const [tags, setTags] = useState("");
-	const [selectedCategory, setSelectedCategory] = useState("");
+	const [selectedCategory, setSelectedCategory] = useState("none");
 	const [categories, setCategories] = useState<
 		Array<{ id: number; name: string; fullName: string }>
 	>([]);
@@ -42,16 +47,22 @@ export function KalturaUploadDialog({
 	const [isUploading, setIsUploading] = useState(false);
 	const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null);
 	const [uploadError, setUploadError] = useState<string | null>(null);
-	const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
 
 	// Initialize form and load categories
 	useEffect(() => {
 		if (!isOpen) return;
 
-		setName(defaultName || filePath.split("/").pop()?.replace(/\.[^.]+$/, "") || "Recording");
+		setName(
+			defaultName ||
+				filePath
+					.split(/[/\\]/)
+					.pop()
+					?.replace(/\.[^.]+$/, "") ||
+				"Recording",
+		);
 		setDescription("");
 		setTags("");
-		setSelectedCategory("");
+		setSelectedCategory("none");
 		setUploadProgress(null);
 		setUploadError(null);
 		setIsUploading(false);
@@ -78,12 +89,12 @@ export function KalturaUploadDialog({
 				setIsUploading(false);
 			} else if (progress.phase === "error") {
 				setIsUploading(false);
-				setUploadError(progress.error || "Upload failed");
+				setUploadError(progress.error || t("upload.failed"));
 			}
 		});
 
 		return cleanup;
-	}, [isOpen]);
+	}, [isOpen, t]);
 
 	const handleUpload = useCallback(async () => {
 		if (!name.trim()) return;
@@ -93,16 +104,17 @@ export function KalturaUploadDialog({
 		setUploadProgress({ uploadId: "", phase: "uploading", percentage: 0 });
 
 		try {
+			const categoryValue = selectedCategory === "none" ? "" : selectedCategory;
 			const result = await window.electronAPI.kalturaUpload({
 				filePath,
 				name: name.trim(),
 				description: description.trim() || undefined,
 				tags: tags.trim() || undefined,
-				categoryIds: selectedCategory || undefined,
+				categoryIds: categoryValue || undefined,
 			});
 
 			if (!result.success) {
-				setUploadError(result.error || "Upload failed");
+				setUploadError(result.error || t("upload.failed"));
 				setIsUploading(false);
 			}
 			// Success is handled by the progress listener (phase: "complete")
@@ -110,23 +122,40 @@ export function KalturaUploadDialog({
 			setUploadError(String(error));
 			setIsUploading(false);
 		}
-	}, [filePath, name, description, tags, selectedCategory]);
-
-	if (!isOpen) return null;
+	}, [filePath, name, description, tags, selectedCategory, t]);
 
 	const isComplete = uploadProgress?.phase === "complete";
 	const hasError = uploadProgress?.phase === "error" || uploadError;
 
 	return (
-		<>
-			<div
-				className="fixed inset-0 bg-black/80 backdrop-blur-md z-[70] animate-in fade-in duration-200"
-				onClick={isUploading ? undefined : onClose}
-			/>
-			<div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[80] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-8 w-[90vw] max-w-lg animate-in zoom-in-95 duration-200">
-				{/* Header */}
-				<div className="flex items-center justify-between mb-6">
-					<div className="flex items-center gap-3">
+		<Dialog
+			open={isOpen}
+			onOpenChange={(open) => {
+				if (!open && !isUploading) onClose();
+			}}
+		>
+			<DialogPortal>
+				<DialogOverlay className="z-[70] backdrop-blur-md" />
+				<DialogPrimitive.Content
+					onInteractOutside={(e) => {
+						if (isUploading) e.preventDefault();
+					}}
+					className={cn(
+						"fixed left-[50%] top-[50%] z-[80] grid w-[90vw] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-0 border p-8 shadow-lg duration-200",
+						"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+						"bg-[#09090b] rounded-2xl shadow-2xl border-white/10",
+					)}
+				>
+					{/* Built-in close X (hidden during upload) */}
+					{!isUploading && (
+						<DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+							<X className="h-4 w-4" />
+							<span className="sr-only">{t("upload.cancel")}</span>
+						</DialogPrimitive.Close>
+					)}
+
+					{/* Header */}
+					<div className="flex items-center gap-3 mb-6">
 						<div
 							className={`w-10 h-10 rounded-full flex items-center justify-center ring-1 ${
 								isComplete
@@ -142,212 +171,179 @@ export function KalturaUploadDialog({
 						</div>
 						<div>
 							<span className="text-lg font-bold text-slate-200 block">
-								{isComplete ? "Uploaded to Kaltura" : "Upload to Kaltura"}
+								{isComplete ? t("upload.uploaded") : t("upload.title")}
 							</span>
 							<span className="text-xs text-slate-500">
 								{isComplete
-									? `Entry ID: ${uploadProgress?.entryId}`
-									: filePath.split("/").pop()}
+									? t("upload.entryId", { id: uploadProgress?.entryId ?? "" })
+									: filePath.split(/[/\\]/).pop()}
 							</span>
 						</div>
 					</div>
-					{!isUploading && (
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={onClose}
-							className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full"
-						>
-							<X className="w-5 h-5" />
-						</Button>
+
+					{/* Success State */}
+					{isComplete && (
+						<div className="text-center py-6 animate-in zoom-in-95">
+							<div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-4 ring-1 ring-emerald-500/50">
+								<Check className="w-8 h-8 text-emerald-400" />
+							</div>
+							<p className="text-lg text-slate-200 font-medium mb-1">{t("upload.complete")}</p>
+							<p className="text-sm text-slate-400">{t("upload.success")}</p>
+							{uploadProgress?.entryId && (
+								<p className="text-xs text-slate-500 mt-2 font-mono">
+									{t("upload.entryId", { id: uploadProgress.entryId })}
+								</p>
+							)}
+							<div className="flex items-center justify-center gap-3 mt-6">
+								{uploadProgress?.entryId && (
+									<Button
+										onClick={() =>
+											window.electronAPI.openExternalUrl(
+												`https://kmc.kaltura.com/index.php/kmcng/content/entries/entry/${uploadProgress.entryId}/metadata`,
+											)
+										}
+										className="bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-300 border border-emerald-500/30"
+									>
+										<ExternalLink className="w-4 h-4 mr-2" />
+										{t("upload.openInKaltura")}
+									</Button>
+								)}
+								<Button onClick={onClose} className="bg-white/10 hover:bg-white/20 text-slate-200">
+									{t("connection.done")}
+								</Button>
+							</div>
+						</div>
 					)}
-				</div>
 
-				{/* Success State */}
-				{isComplete && (
-					<div className="text-center py-6 animate-in zoom-in-95">
-						<div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-4 ring-1 ring-emerald-500/50">
-							<Check className="w-8 h-8 text-emerald-400" />
-						</div>
-						<p className="text-lg text-slate-200 font-medium mb-1">
-							Upload Complete
-						</p>
-						<p className="text-sm text-slate-400">
-							Your recording is now available in Kaltura
-						</p>
-						<Button
-							onClick={onClose}
-							className="mt-6 bg-white/10 hover:bg-white/20 text-slate-200"
-						>
-							Done
-						</Button>
-					</div>
-				)}
-
-				{/* Upload Progress */}
-				{isUploading && uploadProgress && !isComplete && (
-					<div className="space-y-4 py-2">
-						<div className="space-y-2">
-							<div className="flex justify-between text-xs font-medium text-slate-400 uppercase tracking-wider">
-								<span>
-									{uploadProgress.phase === "processing"
-										? "Processing"
-										: "Uploading"}
-								</span>
-								<span className="font-mono text-slate-200">
-									{uploadProgress.percentage}%
-								</span>
+					{/* Upload Progress */}
+					{isUploading && uploadProgress && !isComplete && (
+						<div className="space-y-4 py-2">
+							<div className="space-y-2">
+								<div className="flex justify-between text-xs font-medium text-slate-400 uppercase tracking-wider">
+									<span>
+										{uploadProgress.phase === "processing"
+											? t("upload.processing")
+											: t("upload.title")}
+									</span>
+									<span className="font-mono text-slate-200">{uploadProgress.percentage}%</span>
+								</div>
+								<div className="h-2 bg-white/5 rounded-full overflow-hidden border border-white/5">
+									<div
+										className="h-full bg-orange-500 shadow-[0_0_10px_rgba(249,115,22,0.3)] transition-all duration-300 ease-out"
+										style={{
+											width: `${Math.min(uploadProgress.percentage, 100)}%`,
+										}}
+									/>
+								</div>
 							</div>
-							<div className="h-2 bg-white/5 rounded-full overflow-hidden border border-white/5">
-								<div
-									className="h-full bg-orange-500 shadow-[0_0_10px_rgba(249,115,22,0.3)] transition-all duration-300 ease-out"
-									style={{
-										width: `${Math.min(uploadProgress.percentage, 100)}%`,
-									}}
-								/>
-							</div>
-						</div>
-						<p className="text-sm text-slate-400 text-center">
-							{uploadProgress.phase === "processing"
-								? "Creating media entry in Kaltura..."
-								: "Uploading file to Kaltura..."}
-						</p>
-					</div>
-				)}
-
-				{/* Error State */}
-				{hasError && !isUploading && !isComplete && (
-					<div className="mb-4 animate-in slide-in-from-top-2">
-						<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
-							<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-							<p className="text-sm text-red-400 leading-relaxed">
-								{uploadError || uploadProgress?.error || "Upload failed"}
+							<p className="text-sm text-slate-400 text-center">
+								{uploadProgress.phase === "processing"
+									? t("upload.processing")
+									: t("upload.uploading")}
 							</p>
 						</div>
-					</div>
-				)}
+					)}
 
-				{/* Form (only when not uploading/complete) */}
-				{!isUploading && !isComplete && (
-					<div className="space-y-4">
-						<div>
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Title *
-							</label>
-							<input
-								type="text"
-								value={name}
-								onChange={(e) => setName(e.target.value)}
-								placeholder="Recording title"
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
-							/>
+					{/* Error State */}
+					{hasError && !isUploading && !isComplete && (
+						<div className="mb-4 animate-in slide-in-from-top-2">
+							<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+								<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+								<p className="text-sm text-red-400 leading-relaxed">
+									{uploadError || uploadProgress?.error || t("upload.failed")}
+								</p>
+							</div>
 						</div>
+					)}
 
-						<div>
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Description
-							</label>
-							<textarea
-								value={description}
-								onChange={(e) => setDescription(e.target.value)}
-								placeholder="Optional description..."
-								rows={2}
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 resize-none"
-							/>
-						</div>
+					{/* Form (only when not uploading/complete) */}
+					{!isUploading && !isComplete && (
+						<div className="space-y-4">
+							<div>
+								<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+									{t("upload.titleRequired")}
+								</label>
+								<Input
+									type="text"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder={t("upload.titlePlaceholder")}
+									className="bg-white/5 border-white/10 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:ring-orange-500/50 focus-visible:ring-1 focus-visible:ring-offset-0"
+								/>
+							</div>
 
-						<div>
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Tags
-							</label>
-							<input
-								type="text"
-								value={tags}
-								onChange={(e) => setTags(e.target.value)}
-								placeholder="Comma-separated tags"
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
-							/>
-						</div>
+							<div>
+								<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+									{t("upload.description")}
+								</label>
+								<textarea
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									placeholder={t("upload.descriptionPlaceholder")}
+									rows={2}
+									className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 resize-none"
+								/>
+							</div>
 
-						<div className="relative">
-							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
-								Category
-							</label>
-							<button
-								type="button"
-								onClick={() => setShowCategoryDropdown(!showCategoryDropdown)}
-								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-left flex items-center justify-between focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
-							>
-								<span
-									className={
-										selectedCategory ? "text-slate-200" : "text-slate-600"
-									}
+							<div>
+								<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+									{t("upload.tags")}
+								</label>
+								<Input
+									type="text"
+									value={tags}
+									onChange={(e) => setTags(e.target.value)}
+									placeholder={t("upload.tagsPlaceholder")}
+									className="bg-white/5 border-white/10 text-sm text-slate-200 placeholder:text-slate-600 focus-visible:ring-orange-500/50 focus-visible:ring-1 focus-visible:ring-offset-0"
+								/>
+							</div>
+
+							<div>
+								<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+									{t("upload.category")}
+								</label>
+								<Select value={selectedCategory} onValueChange={setSelectedCategory}>
+									<SelectTrigger className="bg-white/5 border-white/10 text-sm text-slate-200 focus:ring-orange-500/50 focus:ring-1 focus:ring-offset-0 [&>span]:text-slate-200">
+										{isLoadingCategories ? (
+											<Loader2 className="w-4 h-4 text-slate-500 animate-spin" />
+										) : (
+											<SelectValue placeholder={t("upload.categoryPlaceholder")} />
+										)}
+									</SelectTrigger>
+									<SelectContent className="bg-[#111] border-white/10 z-[90]">
+										<SelectItem value="none" className="text-slate-500">
+											{t("upload.categoryNone")}
+										</SelectItem>
+										{categories.map((cat) => (
+											<SelectItem key={cat.id} value={String(cat.id)} className="text-slate-200">
+												{cat.fullName}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+
+							<div className="flex justify-end gap-3 pt-2">
+								<Button
+									onClick={onClose}
+									variant="ghost"
+									className="text-slate-300 hover:text-white hover:bg-white/10"
 								>
-									{selectedCategory
-										? categories.find(
-												(c) => String(c.id) === selectedCategory,
-											)?.fullName || "Select category"
-										: "Select category (optional)"}
-								</span>
-								{isLoadingCategories ? (
-									<Loader2 className="w-4 h-4 text-slate-500 animate-spin" />
-								) : (
-									<ChevronDown className="w-4 h-4 text-slate-500" />
-								)}
-							</button>
-							{showCategoryDropdown && categories.length > 0 && (
-								<div className="absolute top-full left-0 right-0 mt-1 bg-[#111] border border-white/10 rounded-lg shadow-xl z-10 max-h-48 overflow-y-auto">
-									<button
-										type="button"
-										onClick={() => {
-											setSelectedCategory("");
-											setShowCategoryDropdown(false);
-										}}
-										className="w-full px-3 py-2 text-sm text-left text-slate-500 hover:bg-white/5"
-									>
-										None
-									</button>
-									{categories.map((cat) => (
-										<button
-											key={cat.id}
-											type="button"
-											onClick={() => {
-												setSelectedCategory(String(cat.id));
-												setShowCategoryDropdown(false);
-											}}
-											className={`w-full px-3 py-2 text-sm text-left hover:bg-white/5 ${
-												String(cat.id) === selectedCategory
-													? "text-orange-400"
-													: "text-slate-200"
-											}`}
-										>
-											{cat.fullName}
-										</button>
-									))}
-								</div>
-							)}
+									{t("upload.cancel")}
+								</Button>
+								<Button
+									onClick={handleUpload}
+									disabled={!name.trim()}
+									className="bg-orange-500 hover:bg-orange-600 text-white"
+								>
+									<Upload className="w-4 h-4 mr-2" />
+									{t("upload.uploadButton")}
+								</Button>
+							</div>
 						</div>
-
-						<div className="flex justify-end gap-3 pt-2">
-							<Button
-								onClick={onClose}
-								variant="ghost"
-								className="text-slate-300 hover:text-white hover:bg-white/10"
-							>
-								Cancel
-							</Button>
-							<Button
-								onClick={handleUpload}
-								disabled={!name.trim()}
-								className="bg-orange-500 hover:bg-orange-600 text-white"
-							>
-								<Upload className="w-4 h-4 mr-2" />
-								Upload
-							</Button>
-						</div>
-					</div>
-				)}
-			</div>
-		</>
+					)}
+				</DialogPrimitive.Content>
+			</DialogPortal>
+		</Dialog>
 	);
 }

--- a/src/components/video-editor/KalturaUploadDialog.tsx
+++ b/src/components/video-editor/KalturaUploadDialog.tsx
@@ -1,0 +1,353 @@
+import {
+	AlertCircle,
+	Check,
+	ChevronDown,
+	Cloud,
+	Loader2,
+	Upload,
+	X,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface KalturaUploadDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	filePath: string;
+	defaultName?: string;
+}
+
+interface UploadProgress {
+	uploadId: string;
+	phase: "uploading" | "processing" | "complete" | "error";
+	percentage: number;
+	entryId?: string;
+	error?: string;
+}
+
+export function KalturaUploadDialog({
+	isOpen,
+	onClose,
+	filePath,
+	defaultName,
+}: KalturaUploadDialogProps) {
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [tags, setTags] = useState("");
+	const [selectedCategory, setSelectedCategory] = useState("");
+	const [categories, setCategories] = useState<
+		Array<{ id: number; name: string; fullName: string }>
+	>([]);
+	const [isLoadingCategories, setIsLoadingCategories] = useState(false);
+	const [isUploading, setIsUploading] = useState(false);
+	const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null);
+	const [uploadError, setUploadError] = useState<string | null>(null);
+	const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
+
+	// Initialize form and load categories
+	useEffect(() => {
+		if (!isOpen) return;
+
+		setName(defaultName || filePath.split("/").pop()?.replace(/\.[^.]+$/, "") || "Recording");
+		setDescription("");
+		setTags("");
+		setSelectedCategory("");
+		setUploadProgress(null);
+		setUploadError(null);
+		setIsUploading(false);
+
+		// Load categories
+		setIsLoadingCategories(true);
+		window.electronAPI
+			.kalturaListCategories()
+			.then((result) => {
+				if (result.success && result.categories) {
+					setCategories(result.categories);
+				}
+			})
+			.finally(() => setIsLoadingCategories(false));
+	}, [isOpen, filePath, defaultName]);
+
+	// Listen for upload progress
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const cleanup = window.electronAPI.onKalturaUploadProgress((progress) => {
+			setUploadProgress(progress);
+			if (progress.phase === "complete") {
+				setIsUploading(false);
+			} else if (progress.phase === "error") {
+				setIsUploading(false);
+				setUploadError(progress.error || "Upload failed");
+			}
+		});
+
+		return cleanup;
+	}, [isOpen]);
+
+	const handleUpload = useCallback(async () => {
+		if (!name.trim()) return;
+
+		setIsUploading(true);
+		setUploadError(null);
+		setUploadProgress({ uploadId: "", phase: "uploading", percentage: 0 });
+
+		try {
+			const result = await window.electronAPI.kalturaUpload({
+				filePath,
+				name: name.trim(),
+				description: description.trim() || undefined,
+				tags: tags.trim() || undefined,
+				categoryIds: selectedCategory || undefined,
+			});
+
+			if (!result.success) {
+				setUploadError(result.error || "Upload failed");
+				setIsUploading(false);
+			}
+			// Success is handled by the progress listener (phase: "complete")
+		} catch (error) {
+			setUploadError(String(error));
+			setIsUploading(false);
+		}
+	}, [filePath, name, description, tags, selectedCategory]);
+
+	if (!isOpen) return null;
+
+	const isComplete = uploadProgress?.phase === "complete";
+	const hasError = uploadProgress?.phase === "error" || uploadError;
+
+	return (
+		<>
+			<div
+				className="fixed inset-0 bg-black/80 backdrop-blur-md z-[70] animate-in fade-in duration-200"
+				onClick={isUploading ? undefined : onClose}
+			/>
+			<div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[80] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-8 w-[90vw] max-w-lg animate-in zoom-in-95 duration-200">
+				{/* Header */}
+				<div className="flex items-center justify-between mb-6">
+					<div className="flex items-center gap-3">
+						<div
+							className={`w-10 h-10 rounded-full flex items-center justify-center ring-1 ${
+								isComplete
+									? "bg-emerald-500/20 ring-emerald-500/50"
+									: "bg-orange-500/20 ring-orange-500/50"
+							}`}
+						>
+							{isComplete ? (
+								<Check className="w-5 h-5 text-emerald-400" />
+							) : (
+								<Cloud className="w-5 h-5 text-orange-400" />
+							)}
+						</div>
+						<div>
+							<span className="text-lg font-bold text-slate-200 block">
+								{isComplete ? "Uploaded to Kaltura" : "Upload to Kaltura"}
+							</span>
+							<span className="text-xs text-slate-500">
+								{isComplete
+									? `Entry ID: ${uploadProgress?.entryId}`
+									: filePath.split("/").pop()}
+							</span>
+						</div>
+					</div>
+					{!isUploading && (
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={onClose}
+							className="hover:bg-white/10 text-slate-400 hover:text-white rounded-full"
+						>
+							<X className="w-5 h-5" />
+						</Button>
+					)}
+				</div>
+
+				{/* Success State */}
+				{isComplete && (
+					<div className="text-center py-6 animate-in zoom-in-95">
+						<div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-4 ring-1 ring-emerald-500/50">
+							<Check className="w-8 h-8 text-emerald-400" />
+						</div>
+						<p className="text-lg text-slate-200 font-medium mb-1">
+							Upload Complete
+						</p>
+						<p className="text-sm text-slate-400">
+							Your recording is now available in Kaltura
+						</p>
+						<Button
+							onClick={onClose}
+							className="mt-6 bg-white/10 hover:bg-white/20 text-slate-200"
+						>
+							Done
+						</Button>
+					</div>
+				)}
+
+				{/* Upload Progress */}
+				{isUploading && uploadProgress && !isComplete && (
+					<div className="space-y-4 py-2">
+						<div className="space-y-2">
+							<div className="flex justify-between text-xs font-medium text-slate-400 uppercase tracking-wider">
+								<span>
+									{uploadProgress.phase === "processing"
+										? "Processing"
+										: "Uploading"}
+								</span>
+								<span className="font-mono text-slate-200">
+									{uploadProgress.percentage}%
+								</span>
+							</div>
+							<div className="h-2 bg-white/5 rounded-full overflow-hidden border border-white/5">
+								<div
+									className="h-full bg-orange-500 shadow-[0_0_10px_rgba(249,115,22,0.3)] transition-all duration-300 ease-out"
+									style={{
+										width: `${Math.min(uploadProgress.percentage, 100)}%`,
+									}}
+								/>
+							</div>
+						</div>
+						<p className="text-sm text-slate-400 text-center">
+							{uploadProgress.phase === "processing"
+								? "Creating media entry in Kaltura..."
+								: "Uploading file to Kaltura..."}
+						</p>
+					</div>
+				)}
+
+				{/* Error State */}
+				{hasError && !isUploading && !isComplete && (
+					<div className="mb-4 animate-in slide-in-from-top-2">
+						<div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+							<AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+							<p className="text-sm text-red-400 leading-relaxed">
+								{uploadError || uploadProgress?.error || "Upload failed"}
+							</p>
+						</div>
+					</div>
+				)}
+
+				{/* Form (only when not uploading/complete) */}
+				{!isUploading && !isComplete && (
+					<div className="space-y-4">
+						<div>
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Title *
+							</label>
+							<input
+								type="text"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder="Recording title"
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
+							/>
+						</div>
+
+						<div>
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Description
+							</label>
+							<textarea
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								placeholder="Optional description..."
+								rows={2}
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50 resize-none"
+							/>
+						</div>
+
+						<div>
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Tags
+							</label>
+							<input
+								type="text"
+								value={tags}
+								onChange={(e) => setTags(e.target.value)}
+								placeholder="Comma-separated tags"
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
+							/>
+						</div>
+
+						<div className="relative">
+							<label className="text-xs text-slate-400 uppercase tracking-wider block mb-1.5">
+								Category
+							</label>
+							<button
+								type="button"
+								onClick={() => setShowCategoryDropdown(!showCategoryDropdown)}
+								className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-left flex items-center justify-between focus:outline-none focus:ring-1 focus:ring-orange-500/50 focus:border-orange-500/50"
+							>
+								<span
+									className={
+										selectedCategory ? "text-slate-200" : "text-slate-600"
+									}
+								>
+									{selectedCategory
+										? categories.find(
+												(c) => String(c.id) === selectedCategory,
+											)?.fullName || "Select category"
+										: "Select category (optional)"}
+								</span>
+								{isLoadingCategories ? (
+									<Loader2 className="w-4 h-4 text-slate-500 animate-spin" />
+								) : (
+									<ChevronDown className="w-4 h-4 text-slate-500" />
+								)}
+							</button>
+							{showCategoryDropdown && categories.length > 0 && (
+								<div className="absolute top-full left-0 right-0 mt-1 bg-[#111] border border-white/10 rounded-lg shadow-xl z-10 max-h-48 overflow-y-auto">
+									<button
+										type="button"
+										onClick={() => {
+											setSelectedCategory("");
+											setShowCategoryDropdown(false);
+										}}
+										className="w-full px-3 py-2 text-sm text-left text-slate-500 hover:bg-white/5"
+									>
+										None
+									</button>
+									{categories.map((cat) => (
+										<button
+											key={cat.id}
+											type="button"
+											onClick={() => {
+												setSelectedCategory(String(cat.id));
+												setShowCategoryDropdown(false);
+											}}
+											className={`w-full px-3 py-2 text-sm text-left hover:bg-white/5 ${
+												String(cat.id) === selectedCategory
+													? "text-orange-400"
+													: "text-slate-200"
+											}`}
+										>
+											{cat.fullName}
+										</button>
+									))}
+								</div>
+							)}
+						</div>
+
+						<div className="flex justify-end gap-3 pt-2">
+							<Button
+								onClick={onClose}
+								variant="ghost"
+								className="text-slate-300 hover:text-white hover:bg-white/10"
+							>
+								Cancel
+							</Button>
+							<Button
+								onClick={handleUpload}
+								disabled={!name.trim()}
+								className="bg-orange-500 hover:bg-orange-600 text-white"
+							>
+								<Upload className="w-4 h-4 mr-2" />
+								Upload
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import Block from "@uiw/react-color-block";
 import {
 	Bug,
+	CloudUpload,
 	Crop,
 	Download,
 	Film,
@@ -198,6 +199,7 @@ interface SettingsPanelProps {
 	onGifSizePresetChange?: (preset: GifSizePreset) => void;
 	gifOutputDimensions?: { width: number; height: number };
 	onExport?: () => void;
+	onUploadToKaltura?: () => void;
 	unsavedExport?: {
 		arrayBuffer: ArrayBuffer;
 		fileName: string;
@@ -283,6 +285,7 @@ export function SettingsPanel({
 	onGifSizePresetChange,
 	gifOutputDimensions = { width: 1280, height: 720 },
 	onExport,
+	onUploadToKaltura,
 	unsavedExport,
 	onSaveUnsavedExport,
 	selectedAnnotationId,
@@ -1443,6 +1446,18 @@ export function SettingsPanel({
 					<Download className="w-4 h-4" />
 					{exportFormat === "gif" ? t("export.gifButton") : t("export.videoButton")}
 				</Button>
+
+				{exportFormat === "mp4" && (
+					<Button
+						type="button"
+						size="lg"
+						onClick={onUploadToKaltura}
+						className="w-full mt-2 py-5 text-sm font-semibold flex items-center justify-center gap-2 bg-orange-500 text-white rounded-xl shadow-lg shadow-orange-500/20 hover:bg-orange-500/90 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200"
+					>
+						<CloudUpload className="w-4 h-4" />
+						Upload to Kaltura
+					</Button>
+				)}
 
 				<div className="flex gap-2 mt-3">
 					<button

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1447,15 +1447,15 @@ export function SettingsPanel({
 					{exportFormat === "gif" ? t("export.gifButton") : t("export.videoButton")}
 				</Button>
 
-				{exportFormat === "mp4" && (
+				{exportFormat === "mp4" && onUploadToKaltura && (
 					<Button
 						type="button"
 						size="lg"
 						onClick={onUploadToKaltura}
-						className="w-full mt-2 py-5 text-sm font-semibold flex items-center justify-center gap-2 bg-orange-500 text-white rounded-xl shadow-lg shadow-orange-500/20 hover:bg-orange-500/90 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200"
+						className="w-full mt-2 py-5 text-sm font-semibold flex items-center justify-center gap-2 bg-white/10 text-white rounded-xl hover:bg-white/15 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200"
 					>
 						<CloudUpload className="w-4 h-4" />
-						Upload to Kaltura
+						{t("cloud.uploadTo", { provider: "Kaltura" })}
 					</Button>
 				)}
 

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1,5 +1,5 @@
 import type { Span } from "dnd-timeline";
-import { Cloud, FolderOpen, Languages, Save, Settings2, Video } from "lucide-react";
+import { Cloud, FolderOpen, Languages, Save, Video } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { toast } from "sonner";
@@ -11,6 +11,13 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useI18n, useScopedT } from "@/contexts/I18nContext";
 import { useShortcuts } from "@/contexts/ShortcutsContext";
 import { INITIAL_EDITOR_STATE, useEditorHistory } from "@/hooks/useEditorHistory";
@@ -1664,9 +1671,15 @@ export default function VideoEditor() {
 			setShowKalturaSettings(true);
 			return;
 		}
-		// Connected — open upload dialog directly (uses source video)
-		setShowKalturaUpload(true);
-	}, [kalturaConnected]);
+		if (exportedFilePath) {
+			// Already exported — open upload dialog with the exported file
+			setShowKalturaUpload(true);
+		} else {
+			// No export yet — export first, then auto-open upload on completion
+			autoUploadAfterExportRef.current = true;
+			handleOpenExportDialog();
+		}
+	}, [kalturaConnected, exportedFilePath, handleOpenExportDialog]);
 
 	const handleLoadFromKaltura = useCallback(() => {
 		if (!kalturaConnected) {
@@ -1817,29 +1830,48 @@ export default function VideoEditor() {
 						{ts("project.save")}
 					</button>
 					<div className="w-px h-4 bg-white/10 mx-1" />
-					<button
-						type="button"
-						onClick={() => setShowKalturaSettings(true)}
-						className={`flex items-center gap-1 px-2 py-1 rounded-md transition-all duration-150 text-[11px] font-medium ${
-							kalturaConnected
-								? "text-orange-400/70 hover:text-orange-300 hover:bg-orange-500/10"
-								: "text-white/50 hover:text-white/90 hover:bg-white/10"
-						}`}
-					>
-						<Settings2 size={14} />
-						Kaltura
-						{kalturaConnected && (
-							<span className="w-1.5 h-1.5 rounded-full bg-emerald-400 ml-0.5" />
-						)}
-					</button>
-					<button
-						type="button"
-						onClick={handleLoadFromKaltura}
-						className="flex items-center gap-1 px-2 py-1 rounded-md text-orange-400/70 hover:text-orange-300 hover:bg-orange-500/10 transition-all duration-150 text-[11px] font-medium"
-					>
-						<Cloud size={14} />
-						Load from Kaltura
-					</button>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<button
+								type="button"
+								className="flex items-center gap-1 px-2 py-1 rounded-md text-white/50 hover:text-white/90 hover:bg-white/10 transition-all duration-150 text-[11px] font-medium"
+							>
+								<Cloud size={14} />
+								{ts("cloud.title")}
+								{kalturaConnected && (
+									<span className="w-1.5 h-1.5 rounded-full bg-emerald-400 ml-0.5" />
+								)}
+							</button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent
+							className="bg-[#1a1a1f] border-white/10 min-w-[180px]"
+							sideOffset={8}
+						>
+							<DropdownMenuItem
+								className="text-slate-200 focus:bg-white/10 focus:text-white cursor-pointer"
+								onSelect={() => setShowKalturaSettings(true)}
+							>
+								{ts("cloud.settings", { provider: "Kaltura" })}
+							</DropdownMenuItem>
+							{kalturaConnected && (
+								<>
+									<DropdownMenuSeparator className="bg-white/10" />
+									<DropdownMenuItem
+										className="text-slate-200 focus:bg-white/10 focus:text-white cursor-pointer"
+										onSelect={handleLoadFromKaltura}
+									>
+										{ts("cloud.loadFrom", { provider: "Kaltura" })}
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										className="text-slate-200 focus:bg-white/10 focus:text-white cursor-pointer"
+										onSelect={handleUploadToKaltura}
+									>
+										{ts("cloud.uploadTo", { provider: "Kaltura" })}
+									</DropdownMenuItem>
+								</>
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
 				</div>
 			</div>
 
@@ -2072,7 +2104,7 @@ export default function VideoEditor() {
 								: getAspectRatioValue(aspectRatio),
 						)}
 						onExport={handleOpenExportDialog}
-						onUploadToKaltura={handleUploadToKaltura}
+						onUploadToKaltura={kalturaConnected ? handleUploadToKaltura : undefined}
 						selectedAnnotationId={selectedAnnotationId}
 						annotationRegions={annotationOnlyRegions}
 						onAnnotationContentChange={handleAnnotationContentChange}
@@ -2153,10 +2185,12 @@ export default function VideoEditor() {
 			<KalturaUploadDialog
 				isOpen={showKalturaUpload}
 				onClose={() => setShowKalturaUpload(false)}
-				filePath={exportedFilePath || videoSourcePath || ""}
-				defaultName={(exportedFilePath || videoSourcePath)?.split("/").pop()?.replace(/\.[^.]+$/, "")}
+				filePath={exportedFilePath || ""}
+				defaultName={exportedFilePath
+					?.split("/")
+					.pop()
+					?.replace(/\.[^.]+$/, "")}
 			/>
-
 		</div>
 	);
 }

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2164,7 +2164,7 @@ export default function VideoEditor() {
 						if (pendingKalturaUploadRef.current && state.connected) {
 							pendingKalturaUploadRef.current = false;
 							pendingKalturaBrowseRef.current = false;
-							setShowKalturaUpload(true);
+							handleUploadToKaltura();
 						} else if (pendingKalturaBrowseRef.current && state.connected) {
 							pendingKalturaBrowseRef.current = false;
 							pendingKalturaUploadRef.current = false;
@@ -2178,7 +2178,6 @@ export default function VideoEditor() {
 				onLogout={() => {
 					setShowKalturaSettings(false);
 					setKalturaConnected(false);
-					window.electronAPI.startNewRecording();
 				}}
 			/>
 

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1,5 +1,5 @@
 import type { Span } from "dnd-timeline";
-import { FolderOpen, Languages, Save, Video } from "lucide-react";
+import { Cloud, FolderOpen, Languages, Save, Settings2, Video } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { toast } from "sonner";
@@ -38,6 +38,8 @@ import {
 	isPortraitAspectRatio,
 } from "@/utils/aspectRatioUtils";
 import { ExportDialog } from "./ExportDialog";
+import { KalturaSettingsDialog } from "./KalturaSettingsDialog";
+import { KalturaUploadDialog } from "./KalturaUploadDialog";
 import PlaybackControls from "./PlaybackControls";
 import {
 	createProjectData,
@@ -143,6 +145,12 @@ export default function VideoEditor() {
 		format: string;
 	} | null>(null);
 	const [isFullscreen, setIsFullscreen] = useState(false);
+	const [showKalturaSettings, setShowKalturaSettings] = useState(false);
+	const [showKalturaUpload, setShowKalturaUpload] = useState(false);
+	const [kalturaConnected, setKalturaConnected] = useState(false);
+	const pendingKalturaUploadRef = useRef(false);
+	const pendingKalturaBrowseRef = useRef(false);
+	const autoUploadAfterExportRef = useRef(false);
 
 	const playerContainerRef = useRef<HTMLDivElement>(null);
 	const videoPlaybackRef = useRef<VideoPlaybackRef>(null);
@@ -168,6 +176,13 @@ export default function VideoEditor() {
 		() => annotationRegions.filter((region) => region.type === "blur"),
 		[annotationRegions],
 	);
+
+	// Check Kaltura connection status on mount (loadSession restores from disk)
+	useEffect(() => {
+		window.electronAPI.kalturaLoadSession().then((result) => {
+			setKalturaConnected(result.success && !!result.state?.connected);
+		});
+	}, []);
 
 	const currentProjectMedia = useMemo<ProjectMedia | null>(() => {
 		const screenVideoPath = videoSourcePath ?? (videoPath ? fromFileUrl(videoPath) : null);
@@ -1254,6 +1269,13 @@ export default function VideoEditor() {
 	const handleExportSaved = useCallback(
 		(formatLabel: "GIF" | "Video", filePath: string) => {
 			setExportedFilePath(filePath);
+			// Auto-open Kaltura upload if triggered from "Upload to Kaltura" button
+			if (autoUploadAfterExportRef.current) {
+				autoUploadAfterExportRef.current = false;
+				setShowExportDialog(false);
+				setShowKalturaUpload(true);
+				return;
+			}
 			toast.success(`${formatLabel} exported successfully`, {
 				description: filePath,
 				action: {
@@ -1635,6 +1657,62 @@ export default function VideoEditor() {
 		}
 	}, []);
 
+	const handleUploadToKaltura = useCallback(() => {
+		if (!kalturaConnected) {
+			// Not connected — open settings first, flag pending upload
+			pendingKalturaUploadRef.current = true;
+			setShowKalturaSettings(true);
+			return;
+		}
+		// Connected — open upload dialog directly (uses source video)
+		setShowKalturaUpload(true);
+	}, [kalturaConnected]);
+
+	const handleLoadFromKaltura = useCallback(() => {
+		if (!kalturaConnected) {
+			pendingKalturaBrowseRef.current = true;
+			setShowKalturaSettings(true);
+			return;
+		}
+		window.electronAPI.openKalturaBrowse();
+	}, [kalturaConnected]);
+
+	// Listen for video loaded from the Kaltura browse window
+	useEffect(() => {
+		const unsub = window.electronAPI.onKalturaVideoLoaded((filePath: string) => {
+			try {
+				videoPlaybackRef.current?.pause();
+			} catch {
+				// no-op
+			}
+			setIsPlaying(false);
+			setCurrentTime(0);
+			setDuration(0);
+			setError(null);
+			setVideoSourcePath(filePath);
+			setVideoPath(toFileUrl(filePath));
+			setWebcamVideoSourcePath(null);
+			setWebcamVideoPath(null);
+			setCurrentProjectPath(null);
+			setExportedFilePath(null);
+
+			pushState(INITIAL_EDITOR_STATE);
+			setSelectedZoomId(null);
+			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
+			setSelectedAnnotationId(null);
+
+			window.electronAPI.setCurrentVideoPath(filePath);
+			// Note: don't call setCurrentRecordingSession(null) — setCurrentVideoPath already
+			// creates a recording session with the video path.
+
+			setLastSavedSnapshot(
+				createProjectSnapshot({ screenVideoPath: filePath }, INITIAL_EDITOR_STATE),
+			);
+		});
+		return unsub;
+	}, [pushState]);
+
 	if (loading) {
 		return (
 			<div className="flex items-center justify-center h-screen bg-background">
@@ -1737,6 +1815,30 @@ export default function VideoEditor() {
 					>
 						<Save size={14} />
 						{ts("project.save")}
+					</button>
+					<div className="w-px h-4 bg-white/10 mx-1" />
+					<button
+						type="button"
+						onClick={() => setShowKalturaSettings(true)}
+						className={`flex items-center gap-1 px-2 py-1 rounded-md transition-all duration-150 text-[11px] font-medium ${
+							kalturaConnected
+								? "text-orange-400/70 hover:text-orange-300 hover:bg-orange-500/10"
+								: "text-white/50 hover:text-white/90 hover:bg-white/10"
+						}`}
+					>
+						<Settings2 size={14} />
+						Kaltura
+						{kalturaConnected && (
+							<span className="w-1.5 h-1.5 rounded-full bg-emerald-400 ml-0.5" />
+						)}
+					</button>
+					<button
+						type="button"
+						onClick={handleLoadFromKaltura}
+						className="flex items-center gap-1 px-2 py-1 rounded-md text-orange-400/70 hover:text-orange-300 hover:bg-orange-500/10 transition-all duration-150 text-[11px] font-medium"
+					>
+						<Cloud size={14} />
+						Load from Kaltura
 					</button>
 				</div>
 			</div>
@@ -1970,6 +2072,7 @@ export default function VideoEditor() {
 								: getAspectRatioValue(aspectRatio),
 						)}
 						onExport={handleOpenExportDialog}
+						onUploadToKaltura={handleUploadToKaltura}
 						selectedAnnotationId={selectedAnnotationId}
 						annotationRegions={annotationOnlyRegions}
 						onAnnotationContentChange={handleAnnotationContentChange}
@@ -2008,7 +2111,52 @@ export default function VideoEditor() {
 				onShowInFolder={
 					exportedFilePath ? () => void handleShowExportedFile(exportedFilePath) : undefined
 				}
+				onUploadToKaltura={
+					kalturaConnected && exportedFilePath
+						? () => {
+								setShowExportDialog(false);
+								setShowKalturaUpload(true);
+							}
+						: undefined
+				}
 			/>
+
+			<KalturaSettingsDialog
+				isOpen={showKalturaSettings}
+				onClose={() => {
+					setShowKalturaSettings(false);
+					// Refresh connection status
+					window.electronAPI.kalturaGetSessionState().then((state) => {
+						setKalturaConnected(state.connected);
+						// If user just connected and there's a pending action, open the relevant dialog
+						if (pendingKalturaUploadRef.current && state.connected) {
+							pendingKalturaUploadRef.current = false;
+							pendingKalturaBrowseRef.current = false;
+							setShowKalturaUpload(true);
+						} else if (pendingKalturaBrowseRef.current && state.connected) {
+							pendingKalturaBrowseRef.current = false;
+							pendingKalturaUploadRef.current = false;
+							window.electronAPI.openKalturaBrowse();
+						} else {
+							pendingKalturaUploadRef.current = false;
+							pendingKalturaBrowseRef.current = false;
+						}
+					});
+				}}
+				onLogout={() => {
+					setShowKalturaSettings(false);
+					setKalturaConnected(false);
+					window.electronAPI.startNewRecording();
+				}}
+			/>
+
+			<KalturaUploadDialog
+				isOpen={showKalturaUpload}
+				onClose={() => setShowKalturaUpload(false)}
+				filePath={exportedFilePath || videoSourcePath || ""}
+				defaultName={(exportedFilePath || videoSourcePath)?.split("/").pop()?.replace(/\.[^.]+$/, "")}
+			/>
+
 		</div>
 	);
 }

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -4,6 +4,7 @@ export const I18N_NAMESPACES = [
 	"common",
 	"dialogs",
 	"editor",
+	"kaltura",
 	"launch",
 	"settings",
 	"shortcuts",

--- a/src/i18n/locales/en/kaltura.json
+++ b/src/i18n/locales/en/kaltura.json
@@ -1,0 +1,77 @@
+{
+	"connection": {
+		"title": "Kaltura Connection",
+		"connected": "Connected to Kaltura",
+		"selectAccount": "Select Account",
+		"chooseAccount": "Choose a Kaltura account to connect",
+		"connectPrompt": "Sign in to your Kaltura account",
+		"signIn": "Sign In",
+		"signingIn": "Signing in...",
+		"connecting": "Connecting...",
+		"signOut": "Sign Out",
+		"switchAccount": "Switch Account",
+		"done": "Done",
+		"partnerId": "Partner {{id}}",
+		"sessionActive": "Active",
+		"sessionExpired": "Session expired. Please sign in again.",
+		"noAccounts": "No accounts found for this user.",
+		"switchError": "Please sign in again to switch accounts.",
+		"backToLogin": "Back"
+	},
+	"login": {
+		"email": "Email",
+		"emailPlaceholder": "you@example.com",
+		"password": "Password",
+		"passwordPlaceholder": "Enter your password",
+		"signupPrompt": "Don't have an account? Sign up free",
+		"signupVerify": "After verifying your email, sign in here.",
+		"signupSuccess": "Account created? Sign in with your new credentials below.",
+		"loginFailed": "Login failed",
+		"failedSelectAccount": "Failed to select account"
+	},
+	"labels": {
+		"account": "Account",
+		"user": "User",
+		"emailLabel": "Email",
+		"session": "Session"
+	},
+	"upload": {
+		"title": "Upload to Kaltura",
+		"uploaded": "Uploaded to Kaltura",
+		"complete": "Upload Complete",
+		"success": "Your recording is now available in Kaltura",
+		"uploading": "Uploading file to Kaltura...",
+		"processing": "Creating media entry in Kaltura...",
+		"failed": "Upload failed",
+		"titleRequired": "Title *",
+		"titlePlaceholder": "Recording title",
+		"description": "Description",
+		"descriptionPlaceholder": "Optional description...",
+		"tags": "Tags",
+		"tagsPlaceholder": "Comma-separated tags",
+		"category": "Category",
+		"categoryPlaceholder": "Select category (optional)",
+		"categoryNone": "None",
+		"uploadButton": "Upload",
+		"cancel": "Cancel",
+		"entryId": "Entry ID: {{id}}",
+		"openInKaltura": "Open in Kaltura"
+	},
+	"browse": {
+		"title": "Load from Kaltura",
+		"signInTitle": "Sign in to Kaltura",
+		"connectPrompt": "Connect to browse your video library",
+		"selectPrompt": "Select a video from your library",
+		"selectionHint": "Double-click a video to select and load it into the editor",
+		"checkingSession": "Checking session...",
+		"loadingBrowser": "Loading media browser...",
+		"downloading": "Downloading: {{name}}",
+		"downloadFailed": "Download failed",
+		"loadFailed": "Failed to load media browser: {{error}}",
+		"entryNotFound": "Entry not found"
+	},
+	"toolbar": {
+		"kaltura": "Kaltura",
+		"loadFromKaltura": "Load from Kaltura"
+	}
+}

--- a/src/i18n/locales/en/launch.json
+++ b/src/i18n/locales/en/launch.json
@@ -7,7 +7,8 @@
 		"pauseRecording": "Pause recording",
 		"resumeRecording": "Resume recording",
 		"openVideoFile": "Open video file",
-		"openProject": "Open project"
+		"openProject": "Open project",
+		"cloudSources": "Cloud Sources"
 	},
 	"audio": {
 		"enableSystemAudio": "Enable system audio",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -164,5 +164,12 @@
 	},
 	"language": {
 		"title": "Language"
+	},
+	"cloud": {
+		"title": "Cloud",
+		"sources": "Cloud Sources",
+		"settings": "{{provider}} Settings",
+		"loadFrom": "Load from {{provider}}",
+		"uploadTo": "Upload to {{provider}}"
 	}
 }

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -1,4 +1,10 @@
 {
+	"newRecording": {
+		"title": "Volver al grabador",
+		"description": "Tu sesión actual ha sido guardada.",
+		"cancel": "Cancelar",
+		"confirm": "Confirmar"
+	},
 	"errors": {
 		"noVideoLoaded": "No hay video cargado",
 		"videoNotReady": "El video no está listo",

--- a/src/i18n/locales/es/kaltura.json
+++ b/src/i18n/locales/es/kaltura.json
@@ -1,0 +1,77 @@
+{
+	"connection": {
+		"title": "Conexión con Kaltura",
+		"connected": "Conectado a Kaltura",
+		"selectAccount": "Seleccionar cuenta",
+		"chooseAccount": "Elige una cuenta de Kaltura para conectar",
+		"connectPrompt": "Inicia sesión en tu cuenta de Kaltura",
+		"signIn": "Iniciar sesión",
+		"signingIn": "Iniciando sesión...",
+		"connecting": "Conectando...",
+		"signOut": "Cerrar sesión",
+		"switchAccount": "Cambiar cuenta",
+		"done": "Listo",
+		"partnerId": "Partner {{id}}",
+		"sessionActive": "Activa",
+		"sessionExpired": "Sesión expirada. Por favor inicia sesión de nuevo.",
+		"noAccounts": "No se encontraron cuentas para este usuario.",
+		"switchError": "Por favor inicia sesión de nuevo para cambiar de cuenta.",
+		"backToLogin": "Volver"
+	},
+	"login": {
+		"email": "Correo electrónico",
+		"emailPlaceholder": "tu@ejemplo.com",
+		"password": "Contraseña",
+		"passwordPlaceholder": "Ingresa tu contraseña",
+		"signupPrompt": "¿No tienes cuenta? Regístrate gratis",
+		"signupVerify": "Después de verificar tu correo, inicia sesión aquí.",
+		"signupSuccess": "¿Cuenta creada? Inicia sesión con tus nuevas credenciales.",
+		"loginFailed": "Error al iniciar sesión",
+		"failedSelectAccount": "Error al seleccionar cuenta"
+	},
+	"labels": {
+		"account": "Cuenta",
+		"user": "Usuario",
+		"emailLabel": "Correo",
+		"session": "Sesión"
+	},
+	"upload": {
+		"title": "Subir a Kaltura",
+		"uploaded": "Subido a Kaltura",
+		"complete": "Subida completa",
+		"success": "Tu grabación ya está disponible en Kaltura",
+		"uploading": "Subiendo archivo a Kaltura...",
+		"processing": "Creando entrada de medios en Kaltura...",
+		"failed": "Error al subir",
+		"titleRequired": "Título *",
+		"titlePlaceholder": "Título de la grabación",
+		"description": "Descripción",
+		"descriptionPlaceholder": "Descripción opcional...",
+		"tags": "Etiquetas",
+		"tagsPlaceholder": "Etiquetas separadas por comas",
+		"category": "Categoría",
+		"categoryPlaceholder": "Seleccionar categoría (opcional)",
+		"categoryNone": "Ninguna",
+		"uploadButton": "Subir",
+		"cancel": "Cancelar",
+		"entryId": "ID de entrada: {{id}}",
+		"openInKaltura": "Abrir en Kaltura"
+	},
+	"browse": {
+		"title": "Cargar desde Kaltura",
+		"signInTitle": "Iniciar sesión en Kaltura",
+		"connectPrompt": "Conéctate para explorar tu biblioteca de videos",
+		"selectPrompt": "Selecciona un video de tu biblioteca",
+		"selectionHint": "Haz doble clic en un video para seleccionarlo y cargarlo en el editor",
+		"checkingSession": "Verificando sesión...",
+		"loadingBrowser": "Cargando explorador de medios...",
+		"downloading": "Descargando: {{name}}",
+		"downloadFailed": "Error al descargar",
+		"loadFailed": "Error al cargar el explorador de medios: {{error}}",
+		"entryNotFound": "Entrada no encontrada"
+	},
+	"toolbar": {
+		"kaltura": "Kaltura",
+		"loadFromKaltura": "Cargar desde Kaltura"
+	}
+}

--- a/src/i18n/locales/es/launch.json
+++ b/src/i18n/locales/es/launch.json
@@ -7,7 +7,8 @@
 		"pauseRecording": "Pausar grabación",
 		"resumeRecording": "Reanudar grabación",
 		"openVideoFile": "Abrir archivo de video",
-		"openProject": "Abrir proyecto"
+		"openProject": "Abrir proyecto",
+		"cloudSources": "Fuentes en la nube"
 	},
 	"audio": {
 		"enableSystemAudio": "Activar audio del sistema",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -164,5 +164,12 @@
 	},
 	"language": {
 		"title": "Idioma"
+	},
+	"cloud": {
+		"title": "Nube",
+		"sources": "Fuentes en la nube",
+		"settings": "Configuración de {{provider}}",
+		"loadFrom": "Cargar desde {{provider}}",
+		"uploadTo": "Subir a {{provider}}"
 	}
 }

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -1,4 +1,10 @@
 {
+	"newRecording": {
+		"title": "返回录制器",
+		"description": "您的当前会话已保存。",
+		"cancel": "取消",
+		"confirm": "确认"
+	},
 	"errors": {
 		"noVideoLoaded": "未加载视频",
 		"videoNotReady": "视频未就绪",

--- a/src/i18n/locales/zh-CN/kaltura.json
+++ b/src/i18n/locales/zh-CN/kaltura.json
@@ -1,0 +1,77 @@
+{
+	"connection": {
+		"title": "Kaltura 连接",
+		"connected": "已连接 Kaltura",
+		"selectAccount": "选择账户",
+		"chooseAccount": "选择一个 Kaltura 账户进行连接",
+		"connectPrompt": "登录您的 Kaltura 账户",
+		"signIn": "登录",
+		"signingIn": "正在登录...",
+		"connecting": "正在连接...",
+		"signOut": "退出登录",
+		"switchAccount": "切换账户",
+		"done": "完成",
+		"partnerId": "合作伙伴 {{id}}",
+		"sessionActive": "活跃",
+		"sessionExpired": "会话已过期，请重新登录。",
+		"noAccounts": "未找到此用户的账户。",
+		"switchError": "请重新登录以切换账户。",
+		"backToLogin": "返回"
+	},
+	"login": {
+		"email": "邮箱",
+		"emailPlaceholder": "you@example.com",
+		"password": "密码",
+		"passwordPlaceholder": "输入您的密码",
+		"signupPrompt": "没有账户？免费注册",
+		"signupVerify": "验证邮箱后，请在此登录。",
+		"signupSuccess": "账户已创建？请使用新凭据登录。",
+		"loginFailed": "登录失败",
+		"failedSelectAccount": "选择账户失败"
+	},
+	"labels": {
+		"account": "账户",
+		"user": "用户",
+		"emailLabel": "邮箱",
+		"session": "会话"
+	},
+	"upload": {
+		"title": "上传到 Kaltura",
+		"uploaded": "已上传到 Kaltura",
+		"complete": "上传完成",
+		"success": "您的录制现已在 Kaltura 中可用",
+		"uploading": "正在上传文件到 Kaltura...",
+		"processing": "正在 Kaltura 中创建媒体条目...",
+		"failed": "上传失败",
+		"titleRequired": "标题 *",
+		"titlePlaceholder": "录制标题",
+		"description": "描述",
+		"descriptionPlaceholder": "可选描述...",
+		"tags": "标签",
+		"tagsPlaceholder": "逗号分隔的标签",
+		"category": "分类",
+		"categoryPlaceholder": "选择分类（可选）",
+		"categoryNone": "无",
+		"uploadButton": "上传",
+		"cancel": "取消",
+		"entryId": "条目 ID: {{id}}",
+		"openInKaltura": "在 Kaltura 中打开"
+	},
+	"browse": {
+		"title": "从 Kaltura 加载",
+		"signInTitle": "登录 Kaltura",
+		"connectPrompt": "连接以浏览您的视频库",
+		"selectPrompt": "从您的视频库中选择视频",
+		"selectionHint": "双击视频以选择并加载到编辑器",
+		"checkingSession": "正在检查会话...",
+		"loadingBrowser": "正在加载媒体浏览器...",
+		"downloading": "正在下载: {{name}}",
+		"downloadFailed": "下载失败",
+		"loadFailed": "加载媒体浏览器失败: {{error}}",
+		"entryNotFound": "未找到条目"
+	},
+	"toolbar": {
+		"kaltura": "Kaltura",
+		"loadFromKaltura": "从 Kaltura 加载"
+	}
+}

--- a/src/i18n/locales/zh-CN/launch.json
+++ b/src/i18n/locales/zh-CN/launch.json
@@ -7,7 +7,8 @@
 		"pauseRecording": "暂停录制",
 		"resumeRecording": "继续录制",
 		"openVideoFile": "打开视频文件",
-		"openProject": "打开项目"
+		"openProject": "打开项目",
+		"cloudSources": "云端来源"
 	},
 	"audio": {
 		"enableSystemAudio": "启用系统音频",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -164,5 +164,12 @@
 	},
 	"language": {
 		"title": "语言"
+	},
+	"cloud": {
+		"title": "云端",
+		"sources": "云端来源",
+		"settings": "{{provider}} 设置",
+		"loadFrom": "从 {{provider}} 加载",
+		"uploadTo": "上传到 {{provider}}"
 	}
 }

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,9 @@
 	* {
 		@apply border-border;
 	}
+	html, body, #root {
+		height: 100%;
+	}
 	body {
 		@apply bg-background text-foreground;
 		-webkit-user-select: none;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -122,5 +122,113 @@ interface Window {
 		setHasUnsavedChanges: (hasChanges: boolean) => void;
 		onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => () => void;
 		setLocale: (locale: string) => Promise<void>;
+
+		// --- Kaltura Integration ---
+		kalturaLogin: (params: {
+			serviceUrl: string;
+			loginId: string;
+			password: string;
+		}) => Promise<{
+			success: boolean;
+			error?: string;
+			partners?: Array<{ id: number; name: string }>;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaSelectPartner: (params: {
+			partnerId: number;
+		}) => Promise<{
+			success: boolean;
+			error?: string;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaListPartners: () => Promise<{
+			success: boolean;
+			partners?: Array<{ id: number; name: string }>;
+			error?: string;
+		}>;
+		kalturaLogout: () => Promise<{ success: boolean }>;
+		kalturaLoadSession: () => Promise<{
+			success: boolean;
+			state?: {
+				connected: boolean;
+				partnerId?: number;
+				serviceUrl?: string;
+				userId?: string;
+				displayName?: string;
+				ksExpiry?: number;
+			};
+		}>;
+		kalturaGetSessionState: () => Promise<{
+			connected: boolean;
+			partnerId?: number;
+			serviceUrl?: string;
+			userId?: string;
+			displayName?: string;
+			ksExpiry?: number;
+		}>;
+		kalturaOpenSignup: () => Promise<{ success: boolean }>;
+		kalturaUpload: (options: {
+			filePath: string;
+			name: string;
+			description?: string;
+			tags?: string;
+			categoryIds?: string;
+		}) => Promise<{
+			success: boolean;
+			entryId?: string;
+			uploadId?: string;
+			error?: string;
+		}>;
+		kalturaListCategories: () => Promise<{
+			success: boolean;
+			categories?: Array<{ id: number; name: string; fullName: string }>;
+			error?: string;
+		}>;
+		onKalturaUploadProgress: (
+			callback: (progress: {
+				uploadId: string;
+				phase: "uploading" | "processing" | "complete" | "error";
+				percentage: number;
+				entryId?: string;
+				error?: string;
+			}) => void,
+		) => () => void;
+		kalturaGetSessionInfo: () => Promise<{
+			success: boolean;
+			ks?: string;
+			partnerId?: number;
+			serviceUrl?: string;
+		}>;
+		kalturaDownload: (params: { entryId: string }) => Promise<{
+			success: boolean;
+			filePath?: string;
+			error?: string;
+		}>;
+		onKalturaDownloadProgress: (
+			callback: (progress: {
+				phase: "downloading" | "complete" | "error";
+				percentage: number;
+				filePath?: string;
+				error?: string;
+			}) => void,
+		) => () => void;
+		openKalturaBrowse: () => Promise<void>;
+		closeKalturaBrowse: () => Promise<void>;
+		kalturaBrowseVideoLoaded: (filePath: string) => Promise<void>;
+		onKalturaVideoLoaded: (callback: (filePath: string) => void) => () => void;
 	};
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -124,11 +124,7 @@ interface Window {
 		setLocale: (locale: string) => Promise<void>;
 
 		// --- Kaltura Integration ---
-		kalturaLogin: (params: {
-			serviceUrl: string;
-			loginId: string;
-			password: string;
-		}) => Promise<{
+		kalturaLogin: (params: { serviceUrl: string; loginId: string; password: string }) => Promise<{
 			success: boolean;
 			error?: string;
 			partners?: Array<{ id: number; name: string }>;
@@ -141,9 +137,7 @@ interface Window {
 				ksExpiry?: number;
 			};
 		}>;
-		kalturaSelectPartner: (params: {
-			partnerId: number;
-		}) => Promise<{
+		kalturaSelectPartner: (params: { partnerId: number }) => Promise<{
 			success: boolean;
 			error?: string;
 			state?: {


### PR DESCRIPTION
## Summary

This PR adds a **cloud integration layer** to OpenScreen, with Kaltura as the first provider. Users can browse, download, edit, and re-upload recordings to their Kaltura account — all without leaving the app.

The architecture is designed to be **provider-agnostic**: the UI presents a generic "Cloud" menu, and Kaltura is simply the first item. Adding YouTube, Facebook, Vimeo, or any other provider later requires only a new service module and a menu item — no structural changes.

### What users get

- **Browse & import**: Open a Kaltura media browser, double-click any entry to download it directly into the editor
- **Upload with metadata**: Export an edited recording and upload it to Kaltura with title, description, tags, and category assignment
- **Session management**: Sign in once, session persists across app restarts (stored securely via Electron safeStorage)
- **Multi-account support**: Users with multiple Kaltura partner accounts can switch between them
- **Full i18n**: All strings localized in English, Spanish, and Chinese (zh-CN), matching the existing locale system

### Architecture highlights

- **Generic cloud dropdown** in both the HUD (launch window) and editor toolbar — not a hardcoded "Kaltura" button
- **Clean separation**: `electron/kaltura/` contains all Kaltura-specific logic (API service + IPC handlers), completely isolated from the rest of the app
- **Shared login form**: `KalturaLoginForm` component extracted and reused by both the settings dialog and the browse window
- **Proper Kaltura API usage**: Category assignment via `categoryEntry` service with `disableentitlement` privilege, chunked uploads for large files, proper KS lifecycle management
- **No new runtime dependencies** beyond the Kaltura client library (`kaltura-client`)

### File overview

| Area | Files | What changed |
|------|-------|-------------|
| Electron backend | `electron/kaltura/*`, `electron/main.ts`, `electron/preload.ts`, `electron/windows.ts` | Kaltura service (login, upload, download, browse), IPC bridge, browse window management |
| UI components | `src/components/video-editor/Kaltura*.tsx` | Settings dialog, upload dialog, browse page, shared login form |
| Cloud menu | `LaunchWindow.tsx`, `VideoEditor.tsx`, `ExportDialog.tsx`, `SettingsPanel.tsx` | Generic cloud dropdown, upload/download triggers |
| i18n | `src/i18n/locales/*/kaltura.json`, `settings.json`, `launch.json` | All cloud & Kaltura strings in 3 locales |
| Docs | `KALTURA.md` | Architecture guide for contributors |

### Future enhancements (zero structural changes needed)

- **Add YouTube provider**: new `electron/youtube/` module + menu item
- **Add Facebook/Vimeo/etc.**: same pattern
- **Cloud provider settings page**: list all configured providers with connect/disconnect
- **Batch operations**: upload multiple recordings at once

### Screenshots

The integration uses the existing dark theme and design system (shadcn/ui). The cloud menu blends into the toolbar as a subtle Cloud icon — it doesn't dominate the UI or push any specific provider.

---

Happy to address any feedback. This was built to be contributor-friendly — `KALTURA.md` documents the full architecture for anyone who wants to add the next cloud provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kaltura cloud integration: sign-in (multi-account), encrypted session restore, browse/download window, chunked upload with progress, upload dialog, settings UI, cloud menu actions, and editor load-on-ready.

* **Localization**
  * Added Kaltura/cloud UI translations for English, Spanish, and Chinese; new cloud-related tooltips.

* **Documentation**
  * README updated and new KALTURA.md documenting integration and workflows.

* **Chore**
  * Updated .gitignore, small CSS/layout fix, and added Kaltura client dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->