### PR TITLE
Added Sift+Arrow right/left for faster timeline peaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7222,13 +7222,16 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.8.15",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.15.tgz",
-			"integrity": "sha512-qsJ8/X+UypqxHXN75M7dF88jNK37dLBRW7LeUzCPz+TNs37G8cfWy9nWzS+LS//g600zrt2le9KuXt0rWfDz5Q==",
+			"version": "2.10.17",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+			"integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/bcrypt-pbkdf": {
@@ -7676,9 +7679,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001749",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
-			"integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
+			"version": "1.0.30001787",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1148,12 +1148,11 @@ export default function VideoEditor() {
 				return;
 			}
 
-			// Frame-step navigation (arrow keys, no modifiers)
+			// Frame-step navigation (arrow keys, optional Shift)
 			if (
 				(e.key === "ArrowLeft" || e.key === "ArrowRight") &&
 				!e.ctrlKey &&
 				!e.metaKey &&
-				!e.shiftKey &&
 				!e.altKey
 			) {
 				const target = e.target;
@@ -1177,6 +1176,7 @@ export default function VideoEditor() {
 					video.currentTime,
 					Number.isFinite(video.duration) ? video.duration : durationRef.current,
 					direction,
+					e.shiftKey,
 				);
 				video.currentTime = newTime;
 				return;

--- a/src/i18n/locales/en/shortcuts.json
+++ b/src/i18n/locales/en/shortcuts.json
@@ -32,6 +32,8 @@
 		"panTimeline": "Pan Timeline",
 		"zoomTimeline": "Zoom Timeline",
 		"frameBack": "Frame Back",
-		"frameForward": "Frame Forward"
+		"frameForward": "Frame Forward",
+		"largeFrameBack": "Large Frame Back",
+		"largeFrameForward": "Large Frame Forward"
 	}
 }

--- a/src/i18n/locales/es/shortcuts.json
+++ b/src/i18n/locales/es/shortcuts.json
@@ -32,6 +32,8 @@
 		"panTimeline": "Desplazar línea de tiempo",
 		"zoomTimeline": "Zoom en línea de tiempo",
 		"frameBack": "Fotograma anterior",
-		"frameForward": "Fotograma siguiente"
+		"frameForward": "Fotograma siguiente",
+		"largeFrameBack": "Gran salto hacia atrás",
+		"largeFrameForward": "Gran salto hacia adelante"
 	}
 }

--- a/src/i18n/locales/fr/shortcuts.json
+++ b/src/i18n/locales/fr/shortcuts.json
@@ -32,6 +32,8 @@
 		"panTimeline": "Panoramique de la timeline",
 		"zoomTimeline": "Zoom de la timeline",
 		"frameBack": "Image précédente",
-		"frameForward": "Image suivante"
+		"frameForward": "Image suivante",
+		"largeFrameBack": "Grand saut en arrière",
+		"largeFrameForward": "Grand saut en avant"
 	}
 }

--- a/src/i18n/locales/tr/shortcuts.json
+++ b/src/i18n/locales/tr/shortcuts.json
@@ -32,6 +32,8 @@
 		"panTimeline": "Zaman Çizelgesini Kaydır",
 		"zoomTimeline": "Zaman Çizelgesini Yakınlaştır",
 		"frameBack": "Önceki Kare",
-		"frameForward": "Sonraki Kare"
+		"frameForward": "Sonraki Kare",
+		"largeFrameBack": "Büyük Kare Geri",
+		"largeFrameForward": "Büyük Kare İleri"
 	}
 }

--- a/src/i18n/locales/zh-CN/shortcuts.json
+++ b/src/i18n/locales/zh-CN/shortcuts.json
@@ -32,6 +32,8 @@
 		"panTimeline": "平移时间轴",
 		"zoomTimeline": "缩放时间轴",
 		"frameBack": "上一帧",
-		"frameForward": "下一帧"
+		"frameForward": "下一帧",
+		"largeFrameBack": "大幅上一帧",
+		"largeFrameForward": "大幅下一帧"
 	}
 }

--- a/src/lib/__tests__/frameStepNavigation.test.ts
+++ b/src/lib/__tests__/frameStepNavigation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { computeFrameStepTime, FRAME_DURATION_SEC } from "@/lib/frameStep";
+import {
+	computeFrameStepTime,
+	FRAME_DURATION_SEC,
+	LARGE_FRAME_DURATION_SEC,
+} from "@/lib/frameStep";
 
 describe("computeFrameStepTime", () => {
 	const duration = 10;
@@ -38,5 +42,15 @@ describe("computeFrameStepTime", () => {
 	it("handles duration of 0 gracefully", () => {
 		expect(computeFrameStepTime(0, 0, "forward")).toBe(0);
 		expect(computeFrameStepTime(0, 0, "backward")).toBe(0);
+	});
+
+	it("moves forward by a large step when isFast is true", () => {
+		const result = computeFrameStepTime(5, duration, "forward", true);
+		expect(result).toBeCloseTo(5 + LARGE_FRAME_DURATION_SEC, 10);
+	});
+
+	it("moves backward by a large step when isFast is true", () => {
+		const result = computeFrameStepTime(5, duration, "backward", true);
+		expect(result).toBeCloseTo(5 - LARGE_FRAME_DURATION_SEC, 10);
 	});
 });

--- a/src/lib/frameStep.ts
+++ b/src/lib/frameStep.ts
@@ -1,5 +1,8 @@
-/** Duration of a single frame in seconds at 60 FPS (~16.67ms). */
+/** Duration of a single frame at 60 FPS (~16.67ms). */
 export const FRAME_DURATION_SEC = 1 / 60;
+
+/** Duration of a larger step (10 frames) at 60 FPS (~166.67ms). */
+export const LARGE_FRAME_DURATION_SEC = 10 / 60;
 
 /**
  * Compute the new playhead time after stepping one frame forward or backward.
@@ -9,7 +12,9 @@ export function computeFrameStepTime(
 	currentTime: number,
 	duration: number,
 	direction: "forward" | "backward",
+	isFast: boolean = false,
 ): number {
-	const delta = direction === "forward" ? FRAME_DURATION_SEC : -FRAME_DURATION_SEC;
+	const step = isFast ? LARGE_FRAME_DURATION_SEC : FRAME_DURATION_SEC;
+	const delta = direction === "forward" ? step : -step;
 	return Math.min(duration, Math.max(0, currentTime + delta));
 }

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -71,6 +71,18 @@ export const FIXED_SHORTCUTS: FixedShortcut[] = [
 		display: "→",
 		bindings: [{ key: "arrowright" }],
 	},
+	{
+		i18nKey: "largeFrameBack",
+		label: "Large Frame Back",
+		display: "Shift + ←",
+		bindings: [{ key: "arrowleft", shift: true }],
+	},
+	{
+		i18nKey: "largeFrameForward",
+		label: "Large Frame Forward",
+		display: "Shift + →",
+		bindings: [{ key: "arrowright", shift: true }],
+	},
 ];
 
 export type ShortcutConflict =


### PR DESCRIPTION
# Pull Request Template

## Description
Added `Shift + ArrowLeft` and `Shift + ArrowRight` keyboard shortcuts to allow jumping through the video timeline in larger 10-frame increments.

## Motivation
Makes scrubbing through the timeline significantly faster, as regular arrow keys only move one frame at a time.

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [x] Documentation Update *(Added to FIXED_SHORTCUTS)*
- [ ] Other (please specify)

## Related Issue(s)
#416 

## Screenshots / Video

https://github.com/user-attachments/assets/f7cf3a64-c428-4247-b9cc-b98c069c9d37


## Testing
1. Open the editor and load a video.
2. Hold `Shift` and press `→` or `←`.
3. Verify that the playhead jumps by 10 frames instead of the usual 1 frame.
4. Run tests with `npx vitest run`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster frame navigation: Shift + ← / Shift + → jump 10 frames in the video editor.
* **Tests**
  * Added unit tests validating large-step (10-frame) forward/back stepping.
* **Localization**
  * Added shortcut labels for the new large-step actions in English, Spanish, French, Turkish, and Chinese (zh-CN).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->