### PR TITLE
Add documentation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ System audio capture relies on Electron's [desktopCapturer](https://www.electron
 
 _I'm new to open source, idk what I'm doing lol. If something is wrong please raise an issue 🙏_
 
+## Documentation
+
+See the documentation here:
+[OpenScreen Docs](https://deepwiki.com/siddharthvaddem/openscreen)
+
 ## Contributing
 
 Contributions are welcome! If you’d like to help out or see what’s currently being worked on, take a look at the open issues and the [project roadmap](https://github.com/users/siddharthvaddem/projects/3) to understand the current direction of the project and find ways to contribute.


### PR DESCRIPTION
Added a documentation section with a link to OpenScreen Docs.

# Pull Request Template

## Description
Clearer description of where to find the documentation for openscreen. 

## Motivation
Documentation took me a while to find as a developer, I would usually look for a documentation panel within the product's README.md file instead of a badge. Hence, to improve the documentation visibility for future developers, the addition of the documentation tab will help devs find documentation faster.

## Type of Change
Other (Miscellaneous fix)

## Related Issue(s)
Nil

## Screenshots / Video
Nil

**Screenshot** (if applicable):
Nil

**Video** (if applicable):
Nil

## Testing
Nil


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Documentation section with links to external OpenScreen resources, providing users with access to comprehensive guides and technical references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->