### PR TITLE
fix: recover stale macOS screen recording permissions

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -37,6 +37,17 @@ interface Window {
 			status: string;
 			error?: string;
 		}>;
+		getScreenAccessStatus: () => Promise<{
+			success: boolean;
+			status: string;
+			error?: string;
+		}>;
+		openScreenCaptureSettings: () => Promise<{ success: boolean; error?: string }>;
+		resetScreenCapturePermission: () => Promise<{
+			success: boolean;
+			bundleId?: string;
+			error?: string;
+		}>;
 		getAssetBasePath: () => Promise<string | null>;
 		storeRecordedVideo: (
 			videoData: ArrayBuffer,

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import {
 	app,
 	BrowserWindow,
@@ -25,6 +27,10 @@ const PROJECT_FILE_EXTENSION = "openscreen";
 const SHORTCUTS_FILE = path.join(app.getPath("userData"), "shortcuts.json");
 const RECORDING_SESSION_SUFFIX = ".session.json";
 const ALLOWED_IMPORT_VIDEO_EXTENSIONS = new Set([".webm", ".mp4", ".mov", ".avi", ".mkv"]);
+const MACOS_SCREEN_CAPTURE_SETTINGS_URL =
+	"x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
+const APP_BUNDLE_ID = "com.siddharthvaddem.openscreen";
+const execFileAsync = promisify(execFile);
 
 /**
  * Paths explicitly approved by the user via file picker dialogs or project loads.
@@ -424,6 +430,58 @@ export function registerIpcHandlers(
 				success: false,
 				granted: false,
 				status: "unknown",
+				error: String(error),
+			};
+		}
+	});
+
+	ipcMain.handle("get-screen-access-status", () => {
+		if (process.platform !== "darwin") {
+			return { success: true, status: "granted" };
+		}
+
+		try {
+			return {
+				success: true,
+				status: systemPreferences.getMediaAccessStatus("screen"),
+			};
+		} catch (error) {
+			console.error("Failed to read screen recording access status:", error);
+			return {
+				success: false,
+				status: "unknown",
+				error: String(error),
+			};
+		}
+	});
+
+	ipcMain.handle("open-screen-capture-settings", async () => {
+		if (process.platform !== "darwin") {
+			return { success: false, error: "Screen capture settings are only available on macOS." };
+		}
+
+		try {
+			await shell.openExternal(MACOS_SCREEN_CAPTURE_SETTINGS_URL);
+			return { success: true };
+		} catch (error) {
+			console.error("Failed to open Screen Recording settings:", error);
+			return { success: false, error: String(error) };
+		}
+	});
+
+	ipcMain.handle("reset-screen-capture-permission", async () => {
+		if (process.platform !== "darwin") {
+			return { success: false, error: "Screen capture reset is only available on macOS." };
+		}
+
+		try {
+			const bundleId = APP_BUNDLE_ID;
+			await execFileAsync("tccutil", ["reset", "ScreenCapture", bundleId]);
+			return { success: true, bundleId };
+		} catch (error) {
+			console.error("Failed to reset Screen Recording permission:", error);
+			return {
+				success: false,
 				error: String(error),
 			};
 		}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -36,6 +36,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	requestCameraAccess: () => {
 		return ipcRenderer.invoke("request-camera-access");
 	},
+	getScreenAccessStatus: () => {
+		return ipcRenderer.invoke("get-screen-access-status");
+	},
+	openScreenCaptureSettings: () => {
+		return ipcRenderer.invoke("open-screen-capture-settings");
+	},
+	resetScreenCapturePermission: () => {
+		return ipcRenderer.invoke("reset-screen-capture-permission");
+	},
 
 	storeRecordedVideo: (videoData: ArrayBuffer, fileName: string) => {
 		return ipcRenderer.invoke("store-recorded-video", videoData, fileName);

--- a/src/components/launch/SourceSelector.tsx
+++ b/src/components/launch/SourceSelector.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { MdCheck } from "react-icons/md";
 import { useScopedT } from "@/contexts/I18nContext";
+import { isMac as getIsMac } from "@/utils/platformUtils";
 import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import styles from "./SourceSelector.module.css";
+import { getSourceSelectorRecoveryState, type ScreenAccessStatus } from "./sourceSelectorRecovery";
 
 interface DesktopSource {
 	id: string;
@@ -19,43 +21,139 @@ export function SourceSelector() {
 	const [sources, setSources] = useState<DesktopSource[]>([]);
 	const [selectedSource, setSelectedSource] = useState<DesktopSource | null>(null);
 	const [loading, setLoading] = useState(true);
+	const [isMac, setIsMac] = useState(false);
+	const [screenAccessStatus, setScreenAccessStatus] = useState<ScreenAccessStatus>("unknown");
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [isResettingPermission, setIsResettingPermission] = useState(false);
+
+	const fetchSources = useCallback(async () => {
+		setLoading(true);
+		setLoadError(null);
+		try {
+			const macPlatform = await getIsMac();
+			const screenStatusResult = await window.electronAPI.getScreenAccessStatus();
+
+			setIsMac(macPlatform);
+			setScreenAccessStatus((screenStatusResult.status || "unknown") as ScreenAccessStatus);
+			const rawSources = await window.electronAPI.getSources({
+				types: ["screen", "window"],
+				thumbnailSize: { width: 320, height: 180 },
+				fetchWindowIcons: true,
+			});
+			setSources(
+				rawSources.map((source) => ({
+					id: source.id,
+					name:
+						source.id.startsWith("window:") && source.name.includes(" — ")
+							? source.name.split(" — ")[1] || source.name
+							: source.name,
+					thumbnail: source.thumbnail,
+					display_id: source.display_id,
+					appIcon: source.appIcon,
+				})),
+			);
+		} catch (error) {
+			console.error("Error loading sources:", error);
+			setSources([]);
+			setLoadError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setLoading(false);
+		}
+	}, []);
 
 	useEffect(() => {
-		async function fetchSources() {
-			setLoading(true);
-			try {
-				const rawSources = await window.electronAPI.getSources({
-					types: ["screen", "window"],
-					thumbnailSize: { width: 320, height: 180 },
-					fetchWindowIcons: true,
-				});
-				setSources(
-					rawSources.map((source) => ({
-						id: source.id,
-						name:
-							source.id.startsWith("window:") && source.name.includes(" — ")
-								? source.name.split(" — ")[1] || source.name
-								: source.name,
-						thumbnail: source.thumbnail,
-						display_id: source.display_id,
-						appIcon: source.appIcon,
-					})),
-				);
-			} catch (error) {
-				console.error("Error loading sources:", error);
-			} finally {
-				setLoading(false);
-			}
-		}
-		fetchSources();
-	}, []);
+		void fetchSources();
+	}, [fetchSources]);
 
 	const screenSources = sources.filter((s) => s.id.startsWith("screen:"));
 	const windowSources = sources.filter((s) => s.id.startsWith("window:"));
+	const recoveryState = useMemo(
+		() =>
+			getSourceSelectorRecoveryState({
+				isMac,
+				sourceCount: sources.length,
+				screenAccessStatus,
+			}),
+		[isMac, screenAccessStatus, sources.length],
+	);
 
 	const handleSourceSelect = (source: DesktopSource) => setSelectedSource(source);
 	const handleShare = async () => {
 		if (selectedSource) await window.electronAPI.selectSource(selectedSource);
+	};
+	const handleOpenScreenSettings = async () => {
+		await window.electronAPI.openScreenCaptureSettings();
+	};
+	const handleResetPermission = async () => {
+		setIsResettingPermission(true);
+		try {
+			await window.electronAPI.resetScreenCapturePermission();
+			await fetchSources();
+		} finally {
+			setIsResettingPermission(false);
+		}
+	};
+
+	const renderRecoveryState = () => {
+		if (recoveryState === "none") {
+			return null;
+		}
+
+		let title = t("sourceSelector.empty.title");
+		let description = t("sourceSelector.empty.description");
+
+		if (recoveryState === "screen-permission-blocked") {
+			title = t("sourceSelector.permissionBlocked.title");
+			description = t("sourceSelector.permissionBlocked.description");
+		} else if (recoveryState === "screen-permission-stale") {
+			title = t("sourceSelector.permissionStale.title");
+			description = t("sourceSelector.permissionStale.description");
+		} else if (recoveryState === "screen-permission-missing") {
+			title = t("sourceSelector.permissionMissing.title");
+			description = t("sourceSelector.permissionMissing.description");
+		}
+
+		return (
+			<div className="h-full flex items-center justify-center px-3">
+				<div className="max-w-sm w-full rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-left">
+					<div className="text-sm font-medium text-white">{title}</div>
+					<p className="mt-2 text-xs leading-5 text-zinc-400">{description}</p>
+					{loadError && <p className="mt-2 text-[11px] text-amber-300">{loadError}</p>}
+					<div className="mt-4 flex flex-wrap gap-2">
+						<Button
+							type="button"
+							variant="secondary"
+							onClick={() => void fetchSources()}
+							className="text-xs"
+						>
+							{t("sourceSelector.actions.retry")}
+						</Button>
+						{isMac && (
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => void handleOpenScreenSettings()}
+								className="text-xs text-zinc-300 hover:text-white"
+							>
+								{t("sourceSelector.actions.openSettings")}
+							</Button>
+						)}
+						{isMac && recoveryState === "screen-permission-stale" && (
+							<Button
+								type="button"
+								onClick={() => void handleResetPermission()}
+								disabled={isResettingPermission}
+								className="text-xs bg-[#34B27B] text-white hover:bg-[#34B27B]/80 disabled:opacity-50"
+							>
+								{isResettingPermission
+									? t("sourceSelector.actions.resetting")
+									: t("sourceSelector.actions.resetPermission")}
+							</Button>
+						)}
+					</div>
+				</div>
+			</div>
+		);
 	};
 
 	if (loading) {
@@ -126,20 +224,26 @@ export function SourceSelector() {
 						</TabsTrigger>
 					</TabsList>
 					<div className="flex-1 min-h-0">
-						<TabsContent value="screens" className="h-full mt-0">
-							<div
-								className={`grid grid-cols-2 gap-3 h-[280px] overflow-y-auto pr-1 auto-rows-min ${styles.sourceGridScroll}`}
-							>
-								{screenSources.map(renderSourceCard)}
-							</div>
-						</TabsContent>
-						<TabsContent value="windows" className="h-full mt-0">
-							<div
-								className={`grid grid-cols-2 gap-3 h-[280px] overflow-y-auto pr-1 auto-rows-min ${styles.sourceGridScroll}`}
-							>
-								{windowSources.map(renderSourceCard)}
-							</div>
-						</TabsContent>
+						{sources.length === 0 ? (
+							renderRecoveryState()
+						) : (
+							<>
+								<TabsContent value="screens" className="h-full mt-0">
+									<div
+										className={`grid grid-cols-2 gap-3 h-[280px] overflow-y-auto pr-1 auto-rows-min ${styles.sourceGridScroll}`}
+									>
+										{screenSources.map(renderSourceCard)}
+									</div>
+								</TabsContent>
+								<TabsContent value="windows" className="h-full mt-0">
+									<div
+										className={`grid grid-cols-2 gap-3 h-[280px] overflow-y-auto pr-1 auto-rows-min ${styles.sourceGridScroll}`}
+									>
+										{windowSources.map(renderSourceCard)}
+									</div>
+								</TabsContent>
+							</>
+						)}
 					</div>
 				</Tabs>
 			</div>

--- a/src/components/launch/sourceSelectorRecovery.test.ts
+++ b/src/components/launch/sourceSelectorRecovery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getSourceSelectorRecoveryState } from "./sourceSelectorRecovery";
+
+describe("getSourceSelectorRecoveryState", () => {
+	it("returns none when at least one source is available", () => {
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: true,
+				sourceCount: 1,
+				screenAccessStatus: "granted",
+			}),
+		).toBe("none");
+	});
+
+	it("treats granted with zero sources on macOS as a stale permission entry", () => {
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: true,
+				sourceCount: 0,
+				screenAccessStatus: "granted",
+			}),
+		).toBe("screen-permission-stale");
+	});
+
+	it("treats denied screen access on macOS as blocked", () => {
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: true,
+				sourceCount: 0,
+				screenAccessStatus: "denied",
+			}),
+		).toBe("screen-permission-blocked");
+	});
+
+	it("treats unknown or not-determined status on macOS as missing permission", () => {
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: true,
+				sourceCount: 0,
+				screenAccessStatus: "unknown",
+			}),
+		).toBe("screen-permission-missing");
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: true,
+				sourceCount: 0,
+				screenAccessStatus: "not-determined",
+			}),
+		).toBe("screen-permission-missing");
+	});
+
+	it("falls back to a generic no-sources state off macOS", () => {
+		expect(
+			getSourceSelectorRecoveryState({
+				isMac: false,
+				sourceCount: 0,
+				screenAccessStatus: "granted",
+			}),
+		).toBe("no-sources");
+	});
+});

--- a/src/components/launch/sourceSelectorRecovery.ts
+++ b/src/components/launch/sourceSelectorRecovery.ts
@@ -1,0 +1,42 @@
+export type ScreenAccessStatus = "not-determined" | "granted" | "denied" | "restricted" | "unknown";
+
+export type SourceSelectorRecoveryState =
+	| "none"
+	| "screen-permission-blocked"
+	| "screen-permission-stale"
+	| "screen-permission-missing"
+	| "no-sources";
+
+interface RecoveryParams {
+	isMac: boolean;
+	sourceCount: number;
+	screenAccessStatus: ScreenAccessStatus;
+}
+
+export function getSourceSelectorRecoveryState({
+	isMac,
+	sourceCount,
+	screenAccessStatus,
+}: RecoveryParams): SourceSelectorRecoveryState {
+	if (sourceCount > 0) {
+		return "none";
+	}
+
+	if (!isMac) {
+		return "no-sources";
+	}
+
+	if (screenAccessStatus === "denied" || screenAccessStatus === "restricted") {
+		return "screen-permission-blocked";
+	}
+
+	if (screenAccessStatus === "granted") {
+		return "screen-permission-stale";
+	}
+
+	if (screenAccessStatus === "not-determined" || screenAccessStatus === "unknown") {
+		return "screen-permission-missing";
+	}
+
+	return "no-sources";
+}

--- a/src/i18n/locales/en/launch.json
+++ b/src/i18n/locales/en/launch.json
@@ -28,7 +28,29 @@
 		"loading": "Loading sources...",
 		"screens": "Screens ({{count}})",
 		"windows": "Windows ({{count}})",
-		"defaultSourceName": "Screen"
+		"defaultSourceName": "Screen",
+		"empty": {
+			"title": "No screens or windows available",
+			"description": "OpenScreen could not find any capture sources yet. Retry after your desktop finishes loading or after you reconnect your display."
+		},
+		"permissionBlocked": {
+			"title": "Screen Recording access is blocked",
+			"description": "macOS is blocking OpenScreen from listing capture sources. Open System Settings, enable OpenScreen under Screen Recording, then retry."
+		},
+		"permissionMissing": {
+			"title": "Screen Recording permission is still missing",
+			"description": "OpenScreen needs macOS Screen Recording access before it can list screens and windows. Open System Settings, grant the permission, then retry."
+		},
+		"permissionStale": {
+			"title": "Screen Recording permission looks stale",
+			"description": "macOS says OpenScreen is allowed, but it still returns zero capture sources. This usually happens after upgrading from an older build. Reset the Screen Recording permission, then retry to trigger a fresh macOS prompt."
+		},
+		"actions": {
+			"retry": "Retry",
+			"openSettings": "Open Settings",
+			"resetPermission": "Reset Permission",
+			"resetting": "Resetting..."
+		}
 	},
 	"recording": {
 		"selectSource": "Please select a source to record"

--- a/src/i18n/locales/es/launch.json
+++ b/src/i18n/locales/es/launch.json
@@ -28,7 +28,29 @@
 		"loading": "Cargando fuentes...",
 		"screens": "Pantallas ({{count}})",
 		"windows": "Ventanas ({{count}})",
-		"defaultSourceName": "Pantalla"
+		"defaultSourceName": "Pantalla",
+		"empty": {
+			"title": "No hay pantallas ni ventanas disponibles",
+			"description": "OpenScreen todavía no pudo encontrar fuentes de captura. Inténtalo de nuevo cuando tu escritorio termine de cargarse o después de reconectar la pantalla."
+		},
+		"permissionBlocked": {
+			"title": "El acceso a Grabación de Pantalla está bloqueado",
+			"description": "macOS está bloqueando a OpenScreen para listar las fuentes de captura. Abre Ajustes del Sistema, habilita OpenScreen en Grabación de Pantalla y vuelve a intentarlo."
+		},
+		"permissionMissing": {
+			"title": "Falta el permiso de Grabación de Pantalla",
+			"description": "OpenScreen necesita el permiso de Grabación de Pantalla de macOS antes de poder listar pantallas y ventanas. Abre Ajustes del Sistema, concede el permiso y vuelve a intentarlo."
+		},
+		"permissionStale": {
+			"title": "El permiso de Grabación de Pantalla parece obsoleto",
+			"description": "macOS dice que OpenScreen tiene permiso, pero aun así devuelve cero fuentes de captura. Esto suele pasar después de actualizar desde una versión anterior. Restablece el permiso y vuelve a intentarlo para forzar un nuevo aviso de macOS."
+		},
+		"actions": {
+			"retry": "Reintentar",
+			"openSettings": "Abrir ajustes",
+			"resetPermission": "Restablecer permiso",
+			"resetting": "Restableciendo..."
+		}
 	},
 	"recording": {
 		"selectSource": "Por favor selecciona una fuente para grabar"

--- a/src/i18n/locales/fr/launch.json
+++ b/src/i18n/locales/fr/launch.json
@@ -28,7 +28,29 @@
 		"loading": "Chargement des sources...",
 		"screens": "Écrans ({{count}})",
 		"windows": "Fenêtres ({{count}})",
-		"defaultSourceName": "Écran"
+		"defaultSourceName": "Écran",
+		"empty": {
+			"title": "Aucun écran ou fenêtre disponible",
+			"description": "OpenScreen n'a trouvé aucune source de capture pour le moment. Réessayez une fois votre bureau entièrement chargé ou après avoir reconnecté votre écran."
+		},
+		"permissionBlocked": {
+			"title": "L'accès à l'enregistrement de l'écran est bloqué",
+			"description": "macOS empêche OpenScreen de lister les sources de capture. Ouvrez Réglages Système, activez OpenScreen dans Enregistrement de l'écran, puis réessayez."
+		},
+		"permissionMissing": {
+			"title": "L'autorisation d'enregistrement de l'écran manque encore",
+			"description": "OpenScreen a besoin de l'autorisation macOS Enregistrement de l'écran avant de pouvoir lister les écrans et les fenêtres. Ouvrez Réglages Système, accordez l'autorisation, puis réessayez."
+		},
+		"permissionStale": {
+			"title": "L'autorisation d'enregistrement de l'écran semble obsolète",
+			"description": "macOS indique qu'OpenScreen est autorisé, mais il renvoie quand même zéro source de capture. Cela arrive souvent après une mise à jour depuis une ancienne version. Réinitialisez l'autorisation puis réessayez pour déclencher une nouvelle demande macOS."
+		},
+		"actions": {
+			"retry": "Réessayer",
+			"openSettings": "Ouvrir les réglages",
+			"resetPermission": "Réinitialiser l'autorisation",
+			"resetting": "Réinitialisation..."
+		}
 	},
 	"recording": {
 		"selectSource": "Veuillez sélectionner une source à enregistrer"

--- a/src/i18n/locales/tr/launch.json
+++ b/src/i18n/locales/tr/launch.json
@@ -39,7 +39,29 @@
 		"loading": "Kaynaklar yükleniyor...",
 		"screens": "Ekranlar ({{count}})",
 		"windows": "Pencereler ({{count}})",
-		"defaultSourceName": "Ekran"
+		"defaultSourceName": "Ekran",
+		"empty": {
+			"title": "Kayıt için ekran veya pencere bulunamadı",
+			"description": "OpenScreen henüz hiçbir kayıt kaynağı bulamadı. Masaüstünüz tamamen yüklendikten veya ekran bağlantınızı yeniden kurduktan sonra tekrar deneyin."
+		},
+		"permissionBlocked": {
+			"title": "Ekran Kaydı izni engellenmiş",
+			"description": "macOS, OpenScreen'in kayıt kaynaklarını listelemesini engelliyor. Sistem Ayarları'nı açın, Ekran Kaydı altında OpenScreen'e izin verin, sonra tekrar deneyin."
+		},
+		"permissionMissing": {
+			"title": "Ekran Kaydı izni hâlâ verilmemiş",
+			"description": "OpenScreen'in ekranları ve pencereleri listeleyebilmesi için macOS Ekran Kaydı iznine ihtiyacı var. Sistem Ayarları'nı açın, izni verin, sonra tekrar deneyin."
+		},
+		"permissionStale": {
+			"title": "Ekran Kaydı izni bozulmuş görünüyor",
+			"description": "macOS, OpenScreen için izin verilmiş görünüyor ama yine de hiç kayıt kaynağı dönmüyor. Bu genelde eski bir sürümden yükseltme yaptıktan sonra olur. İzni sıfırlayın ve macOS'un yeni izni istemesi için tekrar deneyin."
+		},
+		"actions": {
+			"retry": "Tekrar dene",
+			"openSettings": "Ayarları aç",
+			"resetPermission": "İzni sıfırla",
+			"resetting": "Sıfırlanıyor..."
+		}
 	},
 	"recording": {
 		"selectSource": "Lütfen kayıt için bir kaynak seçin"

--- a/src/i18n/locales/zh-CN/launch.json
+++ b/src/i18n/locales/zh-CN/launch.json
@@ -28,7 +28,29 @@
 		"loading": "正在加载源...",
 		"screens": "屏幕 ({{count}})",
 		"windows": "窗口 ({{count}})",
-		"defaultSourceName": "屏幕"
+		"defaultSourceName": "屏幕",
+		"empty": {
+			"title": "没有可用的屏幕或窗口",
+			"description": "OpenScreen 还没有找到任何可录制的来源。请在桌面完全加载完成后，或重新连接显示器后再试一次。"
+		},
+		"permissionBlocked": {
+			"title": "屏幕录制权限已被阻止",
+			"description": "macOS 正在阻止 OpenScreen 列出可录制来源。请打开系统设置，在“屏幕录制”中启用 OpenScreen，然后重试。"
+		},
+		"permissionMissing": {
+			"title": "仍然缺少屏幕录制权限",
+			"description": "OpenScreen 需要先获得 macOS 的屏幕录制权限，才能列出屏幕和窗口。请打开系统设置，授予权限后再重试。"
+		},
+		"permissionStale": {
+			"title": "屏幕录制权限看起来已失效",
+			"description": "macOS 显示 OpenScreen 已被允许，但仍然返回 0 个可录制来源。这通常发生在从旧版本升级之后。请重置该权限，然后重试以触发新的 macOS 授权提示。"
+		},
+		"actions": {
+			"retry": "重试",
+			"openSettings": "打开设置",
+			"resetPermission": "重置权限",
+			"resetting": "正在重置..."
+		}
 	},
 	"recording": {
 		"selectSource": "请选择要录制的源"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -30,6 +30,17 @@ interface Window {
 			status: string;
 			error?: string;
 		}>;
+		getScreenAccessStatus: () => Promise<{
+			success: boolean;
+			status: string;
+			error?: string;
+		}>;
+		openScreenCaptureSettings: () => Promise<{ success: boolean; error?: string }>;
+		resetScreenCapturePermission: () => Promise<{
+			success: boolean;
+			bundleId?: string;
+			error?: string;
+		}>;
 		storeRecordedVideo: (
 			videoData: ArrayBuffer,
 			fileName: string,


### PR DESCRIPTION
## Summary

This PR turns the current macOS permission workaround into an in-app recovery flow.

Root cause: after upgrading from an older OpenScreen build, macOS can keep a stale `Screen Recording` TCC entry. The permission toggle looks enabled, but `desktopCapturer.getSources()` still returns zero screens/windows. Today the only fix is tribal knowledge: remove the permission entry manually and reinstall.

This change makes the app detect that state and guide the user out of it.

## What changed

- Added macOS IPC handlers to:
  - read `systemPreferences.getMediaAccessStatus("screen")`
  - open the Screen Recording settings page
  - reset the app's `ScreenCapture` TCC permission with `tccutil reset ScreenCapture com.siddharthvaddem.openscreen`
- Updated the source picker empty state so it distinguishes between:
  - blocked screen recording access
  - missing screen recording access
  - stale-but-granted permission after upgrade
  - generic no-sources state
- Added a recovery UI in the source picker with:
  - `Retry`
  - `Open Settings`
  - `Reset Permission` (shown for the stale-permission case)
- Added a small unit-tested helper for recovery-state classification
- Localized the new source-picker recovery copy across existing launch locales

## Why this matters

The user-visible failure mode is misleading: macOS shows the switch as enabled, but OpenScreen still cannot see any screens or windows. Users currently have to find a GitHub comment telling them to remove the permission entry manually.

This PR keeps the same underlying workaround but moves it into the product, where users actually need it.

## Related issues

- Closes #410
- Related to #254

## Testing

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest --run src/components/launch/sourceSelectorRecovery.test.ts`

## Notes

I did not claim a full green baseline for the whole repo because current `main` already has unrelated failing checks in the browser exporter tests and translation sync script. This PR is scoped to the macOS screen-permission recovery flow only.