### PR TITLE
fix(windows): Fixed windows Export Issue and early decode Crash

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -639,16 +639,15 @@ export function registerIpcHandlers(
 		}
 	});
 
-/**
- * Handles saving an exported video file.
- * Shows a save dialog, normalizes the file path for the current OS,
- * ensures the directory exists, and writes the video data.
- * @param _ - Unused event parameter.
- * @param videoData - The exported video as an ArrayBuffer.
- * @param fileName - Suggested filename for the save dialog.
- * @returns Object with success status, optional file path, and error details.
- */
-
+	/**
+	 * Handles saving an exported video file.
+	 * Shows a save dialog, normalizes the file path for the current OS,
+	 * ensures the directory exists, and writes the video data.
+	 * @param _ - Unused event parameter.
+	 * @param videoData - The exported video as an ArrayBuffer.
+	 * @param fileName - Suggested filename for the save dialog.
+	 * @returns Object with success status, optional file path, and error details.
+	 */
 
 	ipcMain.handle("save-exported-video", async (_, videoData: ArrayBuffer, fileName: string) => {
 		try {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -638,6 +638,18 @@ export function registerIpcHandlers(
 			return null;
 		}
 	});
+
+/**
+ * Handles saving an exported video file.
+ * Shows a save dialog, normalizes the file path for the current OS,
+ * ensures the directory exists, and writes the video data.
+ * @param _ - Unused event parameter.
+ * @param videoData - The exported video as an ArrayBuffer.
+ * @param fileName - Suggested filename for the save dialog.
+ * @returns Object with success status, optional file path, and error details.
+ */
+
+
 	ipcMain.handle("save-exported-video", async (_, videoData: ArrayBuffer, fileName: string) => {
 		try {
 			// Determine file type from extension

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -638,7 +638,6 @@ export function registerIpcHandlers(
 			return null;
 		}
 	});
-
 	ipcMain.handle("save-exported-video", async (_, videoData: ArrayBuffer, fileName: string) => {
 		try {
 			// Determine file type from extension
@@ -664,11 +663,18 @@ export function registerIpcHandlers(
 				};
 			}
 
-			await fs.writeFile(result.filePath, Buffer.from(videoData));
+			// --- FIX: Normalize the path for Windows compatibility ---
+			const normalizedPath = path.normalize(result.filePath);
+
+			// Ensure the parent directory exists (Windows may fail if the folder is missing)
+			await fs.mkdir(path.dirname(normalizedPath), { recursive: true });
+			// --- END FIX ---
+
+			await fs.writeFile(normalizedPath, Buffer.from(videoData));
 
 			return {
 				success: true,
-				path: result.filePath,
+				path: normalizedPath,
 				message: "Video exported successfully",
 			};
 		} catch (error) {
@@ -680,7 +686,6 @@ export function registerIpcHandlers(
 			};
 		}
 	});
-
 	ipcMain.handle("open-video-file-picker", async () => {
 		try {
 			const result = await dialog.showOpenDialog({

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -320,7 +320,6 @@ export default function VideoEditor() {
 		aspectRatio,
 		webcamLayoutPreset,
 		webcamMaskShape,
-		webcamSizePreset,
 		webcamPosition,
 		exportQuality,
 		exportFormat,

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1313,7 +1313,6 @@ export default function TimelineEditor({
 		selectedBlurId,
 		selectedSpeedId,
 		annotationRegions,
-		blurRegions,
 		currentTime,
 		onSelectAnnotation,
 		keyShortcuts,

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -217,15 +217,15 @@ export class StreamingVideoDecoder {
 
 		return this.metadata;
 	}
-/**
- * Decodes all video frames from the loaded source and invokes a callback for each.
- * Handles trimming and speed adjustments, and resamples to the target frame rate.
- * On Windows, early decode termination is tolerated to work around driver quirks.
- * @param targetFrameRate - Desired output frame rate.
- * @param trimRegions - Array of time regions to keep (others discarded).
- * @param speedRegions - Array of speed adjustments for specific time ranges.
- * @param onFrame - Async callback receiving each decoded VideoFrame.
- */
+	/**
+	 * Decodes all video frames from the loaded source and invokes a callback for each.
+	 * Handles trimming and speed adjustments, and resamples to the target frame rate.
+	 * On Windows, early decode termination is tolerated to work around driver quirks.
+	 * @param targetFrameRate - Desired output frame rate.
+	 * @param trimRegions - Array of time regions to keep (others discarded).
+	 * @param speedRegions - Array of speed adjustments for specific time ranges.
+	 * @param onFrame - Async callback receiving each decoded VideoFrame.
+	 */
 	async decodeAll(
 		targetFrameRate: number,
 		trimRegions: TrimRegion[] | undefined,
@@ -501,31 +501,35 @@ export class StreamingVideoDecoder {
 		}
 		this.decoder = null;
 
-	const isWindows = typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
+		const isWindows = typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
 
-if (shouldFailDecodeEndedEarly({
-    cancelled: this.cancelled,
-    lastDecodedFrameSec,
-    requiredEndSec,
-    streamDurationSec: this.metadata.streamDuration,
-})) {
-    const decodedAtLabel = lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
-    const decodeGapSec = lastDecodedFrameSec === null ? Infinity : requiredEndSec - lastDecodedFrameSec;
+		if (
+			shouldFailDecodeEndedEarly({
+				cancelled: this.cancelled,
+				lastDecodedFrameSec,
+				requiredEndSec,
+				streamDurationSec: this.metadata.streamDuration,
+			})
+		) {
+			const decodedAtLabel =
+				lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
+			const decodeGapSec =
+				lastDecodedFrameSec === null ? Infinity : requiredEndSec - lastDecodedFrameSec;
 
-    // On Windows, tolerate a small decode gap: up to 10% of required duration, capped at 3 seconds.
-    const maxToleratedGap = Math.min(3.0, requiredEndSec * 0.1);
+			// On Windows, tolerate a small decode gap: up to 10% of required duration, capped at 3 seconds.
+			const maxToleratedGap = Math.min(3.0, requiredEndSec * 0.1);
 
-    if (isWindows && lastDecodedFrameSec !== null && decodeGapSec <= maxToleratedGap) {
-        console.warn(
-            `[StreamingVideoDecoder] Decode ended early on Windows with a gap of ${decodeGapSec.toFixed(2)}s ` +
-            `(max tolerated: ${maxToleratedGap.toFixed(2)}s) – proceeding anyway.`,
-        );
-    } else {
-        throw new Error(
-            `Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
-        );
-    }
-}
+			if (isWindows && lastDecodedFrameSec !== null && decodeGapSec <= maxToleratedGap) {
+				console.warn(
+					`[StreamingVideoDecoder] Decode ended early on Windows with a gap of ${decodeGapSec.toFixed(2)}s ` +
+						`(max tolerated: ${maxToleratedGap.toFixed(2)}s) – proceeding anyway.`,
+				);
+			} else {
+				throw new Error(
+					`Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
+				);
+			}
+		}
 	}
 
 	private computeSegments(

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -253,6 +253,8 @@ export class StreamingVideoDecoder {
 			this.computeSegments(this.metadata.duration, trimRegions),
 			speedRegions,
 		);
+		const requiredEndSec = segments[segments.length - 1]?.endSec ?? 0;
+
 		const segmentOutputFrameCounts = segments.map((segment) =>
 			Math.ceil(((segment.endSec - segment.startSec) / segment.speed) * targetFrameRate),
 		);
@@ -510,11 +512,13 @@ if (shouldFailDecodeEndedEarly({
     const decodedAtLabel = lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
     const decodeGapSec = lastDecodedFrameSec === null ? Infinity : requiredEndSec - lastDecodedFrameSec;
 
-    // On Windows, tolerate a small decode gap (<= 3 seconds) to work around driver quirks.
-    // For severe failures (no frames at all, or a large gap), still throw.
-    if (isWindows && lastDecodedFrameSec !== null && decodeGapSec <= 3.0) {
+    // On Windows, tolerate a small decode gap: up to 10% of required duration, capped at 3 seconds.
+    const maxToleratedGap = Math.min(3.0, requiredEndSec * 0.1);
+
+    if (isWindows && lastDecodedFrameSec !== null && decodeGapSec <= maxToleratedGap) {
         console.warn(
-            `[StreamingVideoDecoder] Decode ended early on Windows with a small gap (${decodeGapSec.toFixed(2)}s) – proceeding anyway.`,
+            `[StreamingVideoDecoder] Decode ended early on Windows with a gap of ${decodeGapSec.toFixed(2)}s ` +
+            `(max tolerated: ${maxToleratedGap.toFixed(2)}s) – proceeding anyway.`,
         );
     } else {
         throw new Error(
@@ -522,6 +526,8 @@ if (shouldFailDecodeEndedEarly({
         );
     }
 }
+	}
+
 	private computeSegments(
 		totalDuration: number,
 		trimRegions?: TrimRegion[],

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -217,7 +217,15 @@ export class StreamingVideoDecoder {
 
 		return this.metadata;
 	}
-
+/**
+ * Decodes all video frames from the loaded source and invokes a callback for each.
+ * Handles trimming and speed adjustments, and resamples to the target frame rate.
+ * On Windows, early decode termination is tolerated to work around driver quirks.
+ * @param targetFrameRate - Desired output frame rate.
+ * @param trimRegions - Array of time regions to keep (others discarded).
+ * @param speedRegions - Array of speed adjustments for specific time ranges.
+ * @param onFrame - Async callback receiving each decoded VideoFrame.
+ */
 	async decodeAll(
 		targetFrameRate: number,
 		trimRegions: TrimRegion[] | undefined,
@@ -491,33 +499,29 @@ export class StreamingVideoDecoder {
 		}
 		this.decoder = null;
 
-		const requiredEndSec = segments.length > 0 ? segments[segments.length - 1].endSec : 0;
-		const isWindows = typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
+	const isWindows = typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
 
-		if (
-			shouldFailDecodeEndedEarly({
-				cancelled: this.cancelled,
-				lastDecodedFrameSec,
-				requiredEndSec,
-				streamDurationSec: this.metadata.streamDuration,
-			})
-		) {
-			const decodedAtLabel =
-				lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
+if (shouldFailDecodeEndedEarly({
+    cancelled: this.cancelled,
+    lastDecodedFrameSec,
+    requiredEndSec,
+    streamDurationSec: this.metadata.streamDuration,
+})) {
+    const decodedAtLabel = lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
+    const decodeGapSec = lastDecodedFrameSec === null ? Infinity : requiredEndSec - lastDecodedFrameSec;
 
-			if (isWindows) {
-				console.warn(
-					`[StreamingVideoDecoder] Decode ended early on Windows at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s) – proceeding anyway.`,
-				);
-				// Do not throw on Windows; allow export to complete with the frames we have.
-			} else {
-				throw new Error(
-					`Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
-				);
-			}
-		}
-	}
-
+    // On Windows, tolerate a small decode gap (<= 3 seconds) to work around driver quirks.
+    // For severe failures (no frames at all, or a large gap), still throw.
+    if (isWindows && lastDecodedFrameSec !== null && decodeGapSec <= 3.0) {
+        console.warn(
+            `[StreamingVideoDecoder] Decode ended early on Windows with a small gap (${decodeGapSec.toFixed(2)}s) – proceeding anyway.`,
+        );
+    } else {
+        throw new Error(
+            `Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
+        );
+    }
+}
 	private computeSegments(
 		totalDuration: number,
 		trimRegions?: TrimRegion[],

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -253,6 +253,8 @@ export class StreamingVideoDecoder {
 			this.computeSegments(this.metadata.duration, trimRegions),
 			speedRegions,
 		);
+		const requiredEndSec = segments[segments.length - 1]?.endSec ?? 0;
+		
 		const segmentOutputFrameCounts = segments.map((segment) =>
 			Math.ceil(((segment.endSec - segment.startSec) / segment.speed) * targetFrameRate),
 		);

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -492,6 +492,8 @@ export class StreamingVideoDecoder {
 		this.decoder = null;
 
 		const requiredEndSec = segments.length > 0 ? segments[segments.length - 1].endSec : 0;
+		const isWindows = typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
+
 		if (
 			shouldFailDecodeEndedEarly({
 				cancelled: this.cancelled,
@@ -502,9 +504,17 @@ export class StreamingVideoDecoder {
 		) {
 			const decodedAtLabel =
 				lastDecodedFrameSec === null ? "no decoded frame" : `${lastDecodedFrameSec.toFixed(3)}s`;
-			throw new Error(
-				`Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
-			);
+
+			if (isWindows) {
+				console.warn(
+					`[StreamingVideoDecoder] Decode ended early on Windows at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s) – proceeding anyway.`,
+				);
+				// Do not throw on Windows; allow export to complete with the frames we have.
+			} else {
+				throw new Error(
+					`Video decode ended early at ${decodedAtLabel} (needed ${requiredEndSec.toFixed(3)}s).`,
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #428

## Description
I fixed two problems that stopped exports from working on Windows:

Export not saving – The latest release was supposed to fix this issue on windows but it still didnt work. The file save dialog appeared, but no file was created. This happened because the file path wasn't formatted correctly for Windows. I added code to clean up the path and make sure the folder exists before writing the file.

Export stopping early – Sometimes exports would fail with a "Decode ended early" error before finishing. On Windows, I made the app log a warning instead of crashing, so the export can finish with the frames it already has. Other operating systems keep the strict check.


## Motivation
Windows users couldn't reliably export their recordings. These changes make exports work as expected on Windows without affecting macOS or Linux.

## Type of Change

-  Bug Fix


## Related Issue(s)
None directly linked, but this addresses reports of export failures on Windows.

## Screenshots / Video
No visual changes.

## Testing
Recorded a short video and exported as MP4 on Windows 10 – file saved correctly.

Exported to folders with spaces in the name (like C:\My Videos) – worked fine.

Ran unit tests with npm test – 36 tests passed.


## Checklist
I have performed a self-review of my code.

I have added any necessary screenshots or videos. (None needed)

I have linked related issue(s) and updated the changelog if applicable. (No issue linked)

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable video exports: file paths are normalized and missing parent directories are created so saves succeed consistently.
  * Improved decoding robustness: refined error handling reduces failed exports, especially on Windows where certain early-decode gaps are tolerated.
  * Reduced unnecessary UI updates: webcam size and certain region changes no longer trigger redundant snapshot or key-handler recomputations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->