### PR TITLE
fix: validate export duration and fix audio trim in speed-aware path

### DIFF
--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -19,9 +19,9 @@ export class AudioProcessor {
 		demuxer: WebDemuxer,
 		muxer: VideoMuxer,
 		videoUrl: string,
-		trimRegions?: TrimRegion[],
-		speedRegions?: SpeedRegion[],
-		validatedDurationSec?: number,
+		trimRegions: TrimRegion[] | undefined,
+		speedRegions: SpeedRegion[] | undefined,
+		validatedDurationSec: number,
 	): Promise<void> {
 		const sortedTrims = trimRegions ? [...trimRegions].sort((a, b) => a.startMs - b.startMs) : [];
 		const sortedSpeedRegions = speedRegions
@@ -46,10 +46,9 @@ export class AudioProcessor {
 		}
 
 		// No speed edits: keep the original demux/decode/encode path with trim timestamp remap.
-		const readEndSec =
-			typeof validatedDurationSec === "number" && Number.isFinite(validatedDurationSec)
-				? validatedDurationSec + 0.5
-				: undefined;
+		// The +0.5s buffer mirrors streamingDecoder.decodeAll's read window so the trim-only
+		// and speed-aware paths agree on how far to read past the validated duration boundary.
+		const readEndSec = validatedDurationSec + 0.5;
 		await this.processTrimOnlyAudio(demuxer, muxer, sortedTrims, readEndSec);
 	}
 
@@ -193,7 +192,7 @@ export class AudioProcessor {
 		videoUrl: string,
 		trimRegions: TrimRegion[],
 		speedRegions: SpeedRegion[],
-		validatedDurationSec?: number,
+		validatedDurationSec: number,
 	): Promise<Blob> {
 		const media = document.createElement("audio");
 		media.src = videoUrl;
@@ -230,7 +229,7 @@ export class AudioProcessor {
 			// Skip past any initial trim region(s) before recording starts to avoid
 			// capturing trimmed audio during the first rAF frames of playback.
 			// Loops to handle back-to-back or overlapping trims at t=0.
-			const effectiveEnd = validatedDurationSec ?? media.duration;
+			const effectiveEnd = validatedDurationSec;
 			let startPosition = 0;
 			for (let i = 0; i <= trimRegions.length; i++) {
 				const activeTrim = this.findActiveTrimRegion(startPosition * 1000, trimRegions);
@@ -287,7 +286,7 @@ export class AudioProcessor {
 
 					// Stop playback at validated duration — browser's media.duration
 					// may be inflated from bad container metadata.
-					if (validatedDurationSec !== undefined && media.currentTime >= validatedDurationSec) {
+					if (media.currentTime >= validatedDurationSec) {
 						media.pause();
 						cleanup();
 						resolve();
@@ -299,10 +298,7 @@ export class AudioProcessor {
 
 					if (activeTrimRegion && !media.paused && !media.ended) {
 						const skipToTime = activeTrimRegion.endMs / 1000;
-						if (
-							skipToTime >= media.duration ||
-							(validatedDurationSec !== undefined && skipToTime >= validatedDurationSec)
-						) {
+						if (skipToTime >= media.duration || skipToTime >= validatedDurationSec) {
 							media.pause();
 							cleanup();
 							resolve();
@@ -379,7 +375,10 @@ export class AudioProcessor {
 		}
 
 		if (!recordedBlobPromise) {
-			return new Blob([], { type: "audio/webm" });
+			// Invariant: either an early return above fires, or startAudioRecording ran and
+			// populated recordedBlobPromise before the playback Promise resolved. Reaching
+			// here means that contract was broken — fail loud instead of returning silence.
+			throw new Error("Audio recorder finished without assigning recordedBlobPromise");
 		}
 		const recordedBlob = await recordedBlobPromise;
 		if (this.cancelled) {

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -227,15 +227,18 @@ export class AudioProcessor {
 				await audioContext.resume();
 			}
 
-			// Skip past any initial trim region before recording starts
-			// to avoid capturing trimmed audio during the first frames.
+			// Skip past any initial trim region(s) before recording starts to avoid
+			// capturing trimmed audio during the first rAF frames of playback.
+			// Loops to handle back-to-back or overlapping trims at t=0.
+			const effectiveEnd = validatedDurationSec ?? media.duration;
 			let startPosition = 0;
-			const initialTrim = this.findActiveTrimRegion(0, trimRegions);
-			if (initialTrim) {
-				startPosition = initialTrim.endMs / 1000;
+			for (let i = 0; i <= trimRegions.length; i++) {
+				const activeTrim = this.findActiveTrimRegion(startPosition * 1000, trimRegions);
+				if (!activeTrim) break;
+				startPosition = activeTrim.endMs / 1000;
+				if (startPosition >= effectiveEnd) break;
 			}
 
-			const effectiveEnd = validatedDurationSec ?? media.duration;
 			if (startPosition >= effectiveEnd) {
 				// All content is trimmed — return silent blob
 				return new Blob([], { type: "audio/webm" });

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -5,6 +5,7 @@ import type { VideoMuxer } from "./muxer";
 const AUDIO_BITRATE = 128_000;
 const DECODE_BACKPRESSURE_LIMIT = 20;
 const MIN_SPEED_REGION_DELTA_MS = 0.0001;
+const SEEK_TIMEOUT_MS = 5_000;
 
 export class AudioProcessor {
 	private cancelled = false;
@@ -20,7 +21,7 @@ export class AudioProcessor {
 		videoUrl: string,
 		trimRegions?: TrimRegion[],
 		speedRegions?: SpeedRegion[],
-		readEndSec?: number,
+		validatedDurationSec?: number,
 	): Promise<void> {
 		const sortedTrims = trimRegions ? [...trimRegions].sort((a, b) => a.startMs - b.startMs) : [];
 		const sortedSpeedRegions = speedRegions
@@ -35,14 +36,20 @@ export class AudioProcessor {
 				videoUrl,
 				sortedTrims,
 				sortedSpeedRegions,
+				validatedDurationSec,
 			);
-			if (!this.cancelled) {
+			if (!this.cancelled && renderedAudioBlob.size > 0) {
 				await this.muxRenderedAudioBlob(renderedAudioBlob, muxer);
 				return;
 			}
+			return;
 		}
 
 		// No speed edits: keep the original demux/decode/encode path with trim timestamp remap.
+		const readEndSec =
+			typeof validatedDurationSec === "number" && Number.isFinite(validatedDurationSec)
+				? validatedDurationSec + 0.5
+				: undefined;
 		await this.processTrimOnlyAudio(demuxer, muxer, sortedTrims, readEndSec);
 	}
 
@@ -187,6 +194,7 @@ export class AudioProcessor {
 		videoUrl: string,
 		trimRegions: TrimRegion[],
 		speedRegions: SpeedRegion[],
+		validatedDurationSec?: number,
 	): Promise<Blob> {
 		const media = document.createElement("audio");
 		media.src = videoUrl;
@@ -211,15 +219,41 @@ export class AudioProcessor {
 		const destinationNode = audioContext.createMediaStreamDestination();
 		sourceNode.connect(destinationNode);
 
-		const { recorder, recordedBlobPromise } = this.startAudioRecording(destinationNode.stream);
 		let rafId: number | null = null;
+		let recorder: MediaRecorder | null = null;
+		let recordedBlobPromise: Promise<Blob> | null = null;
 
 		try {
 			if (audioContext.state === "suspended") {
 				await audioContext.resume();
 			}
 
-			await this.seekTo(media, 0);
+			// Skip past any initial trim region before recording starts
+			// to avoid capturing trimmed audio during the first frames.
+			let startPosition = 0;
+			const initialTrim = this.findActiveTrimRegion(0, trimRegions);
+			if (initialTrim) {
+				startPosition = initialTrim.endMs / 1000;
+			}
+
+			const effectiveEnd = validatedDurationSec ?? media.duration;
+			if (startPosition >= effectiveEnd) {
+				// All content is trimmed — return silent blob
+				return new Blob([], { type: "audio/webm" });
+			}
+
+			await this.seekTo(media, startPosition);
+
+			// Set initial playback rate for the starting position
+			const initialSpeedRegion = this.findActiveSpeedRegion(startPosition * 1000, speedRegions);
+			if (initialSpeedRegion) {
+				media.playbackRate = initialSpeedRegion.speed;
+			}
+
+			// Start recording only AFTER seeking past trims
+			const recording = this.startAudioRecording(destinationNode.stream);
+			recorder = recording.recorder;
+			recordedBlobPromise = recording.recordedBlobPromise;
 			await media.play();
 
 			await new Promise<void>((resolve, reject) => {
@@ -249,24 +283,69 @@ export class AudioProcessor {
 						return;
 					}
 
+					// Stop playback at validated duration — browser's media.duration
+					// may be inflated from bad container metadata.
+					if (validatedDurationSec !== undefined && media.currentTime >= validatedDurationSec) {
+						media.pause();
+						cleanup();
+						resolve();
+						return;
+					}
+
 					const currentTimeMs = media.currentTime * 1000;
 					const activeTrimRegion = this.findActiveTrimRegion(currentTimeMs, trimRegions);
 
 					if (activeTrimRegion && !media.paused && !media.ended) {
 						const skipToTime = activeTrimRegion.endMs / 1000;
-						if (skipToTime >= media.duration) {
+						if (
+							skipToTime >= media.duration ||
+							(validatedDurationSec !== undefined && skipToTime >= validatedDurationSec)
+						) {
 							media.pause();
 							cleanup();
 							resolve();
 							return;
 						}
+						// Pause recording during trim seek to prevent capturing
+						// silence/noise as the audio element seeks.
+						media.pause();
+						if (recorder?.state === "recording") recorder.pause();
+						const onSeeked = () => {
+							clearTimeout(seekTimer);
+							if (this.cancelled) {
+								cleanup();
+								resolve();
+								return;
+							}
+							if (recorder?.state === "paused") recorder.resume();
+							media
+								.play()
+								.then(() => {
+									if (!this.cancelled) rafId = requestAnimationFrame(tick);
+								})
+								.catch((err) => {
+									cleanup();
+									reject(
+										new Error(
+											`Failed to resume playback after trim seek: ${err instanceof Error ? err.message : String(err)}`,
+										),
+									);
+								});
+						};
+						const seekTimer = window.setTimeout(() => {
+							media.removeEventListener("seeked", onSeeked);
+							cleanup();
+							reject(new Error("Audio seek timed out while skipping trim region"));
+						}, SEEK_TIMEOUT_MS);
+						media.addEventListener("seeked", onSeeked, { once: true });
 						media.currentTime = skipToTime;
-					} else {
-						const activeSpeedRegion = this.findActiveSpeedRegion(currentTimeMs, speedRegions);
-						const playbackRate = activeSpeedRegion ? activeSpeedRegion.speed : 1;
-						if (Math.abs(media.playbackRate - playbackRate) > 0.0001) {
-							media.playbackRate = playbackRate;
-						}
+						return;
+					}
+
+					const activeSpeedRegion = this.findActiveSpeedRegion(currentTimeMs, speedRegions);
+					const playbackRate = activeSpeedRegion ? activeSpeedRegion.speed : 1;
+					if (Math.abs(media.playbackRate - playbackRate) > 0.0001) {
+						media.playbackRate = playbackRate;
 					}
 
 					if (!media.paused && !media.ended) {
@@ -286,7 +365,7 @@ export class AudioProcessor {
 				cancelAnimationFrame(rafId);
 			}
 			media.pause();
-			if (recorder.state !== "inactive") {
+			if (recorder && recorder.state !== "inactive") {
 				recorder.stop();
 			}
 			destinationNode.stream.getTracks().forEach((track) => track.stop());
@@ -297,6 +376,9 @@ export class AudioProcessor {
 			media.load();
 		}
 
+		if (!recordedBlobPromise) {
+			return new Blob([], { type: "audio/webm" });
+		}
 		const recordedBlob = await recordedBlobPromise;
 		if (this.cancelled) {
 			throw new Error("Export cancelled");

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -62,7 +62,7 @@ export class AudioProcessor {
 	): Promise<void> {
 		let audioConfig: AudioDecoderConfig;
 		try {
-			audioConfig = (await demuxer.getDecoderConfig("audio")) as AudioDecoderConfig;
+			audioConfig = await demuxer.getDecoderConfig("audio");
 		} catch {
 			console.warn("[AudioProcessor] No audio track found, skipping");
 			return;
@@ -87,11 +87,10 @@ export class AudioProcessor {
 			typeof readEndSec === "number" && Number.isFinite(readEndSec)
 				? Math.max(0, readEndSec)
 				: undefined;
-		const audioStream = (
+		const audioStream =
 			safeReadEndSec !== undefined
 				? demuxer.read("audio", 0, safeReadEndSec)
-				: demuxer.read("audio")
-		) as ReadableStream<EncodedAudioChunk>;
+				: demuxer.read("audio");
 		const reader = audioStream.getReader();
 
 		try {
@@ -396,8 +395,8 @@ export class AudioProcessor {
 
 		try {
 			await demuxer.load(file);
-			const audioConfig = (await demuxer.getDecoderConfig("audio")) as AudioDecoderConfig;
-			const reader = (demuxer.read("audio") as ReadableStream<EncodedAudioChunk>).getReader();
+			const audioConfig = await demuxer.getDecoderConfig("audio");
+			const reader = demuxer.read("audio").getReader();
 			let isFirstChunk = true;
 
 			try {

--- a/src/lib/exporter/streamingDecoder.test.ts
+++ b/src/lib/exporter/streamingDecoder.test.ts
@@ -27,8 +27,16 @@ describe("validateDuration", () => {
 		expect(validateDuration(15.0, 15.3)).toBe(15.0);
 	});
 
+	it("returns scanned duration when container under-reports beyond threshold", () => {
+		expect(validateDuration(10, 15.3)).toBe(15.3);
+	});
+
 	it("returns container duration when scanned is zero (corrupted/empty file)", () => {
 		expect(validateDuration(10, 0)).toBe(10);
+	});
+
+	it("returns 0 when both container is NaN and scanned is zero", () => {
+		expect(validateDuration(NaN, 0)).toBe(0);
 	});
 });
 

--- a/src/lib/exporter/streamingDecoder.test.ts
+++ b/src/lib/exporter/streamingDecoder.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { shouldFailDecodeEndedEarly } from "./streamingDecoder";
+import { shouldFailDecodeEndedEarly, validateDuration } from "./streamingDecoder";
+
+describe("validateDuration", () => {
+	it("returns scanned duration when container reports Infinity", () => {
+		expect(validateDuration(Infinity, 15.3)).toBe(15.3);
+	});
+
+	it("returns scanned duration when container reports 0", () => {
+		expect(validateDuration(0, 15.3)).toBe(15.3);
+	});
+
+	it("returns scanned duration when container reports NaN", () => {
+		expect(validateDuration(NaN, 15.3)).toBe(15.3);
+	});
+
+	it("returns scanned duration when container is inflated beyond threshold", () => {
+		expect(validateDuration(42, 15.3)).toBe(15.3);
+	});
+
+	it("returns container duration when values are close", () => {
+		expect(validateDuration(15.5, 15.3)).toBe(15.5);
+	});
+
+	it("returns container duration when scanned is slightly higher", () => {
+		// container < scanned (scanned overshoot from last frame duration)
+		expect(validateDuration(15.0, 15.3)).toBe(15.0);
+	});
+
+	it("returns container duration when scanned is zero (corrupted/empty file)", () => {
+		expect(validateDuration(10, 0)).toBe(10);
+	});
+});
 
 describe("shouldFailDecodeEndedEarly", () => {
 	it("does not fail once every segment has been satisfied", () => {

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -230,9 +230,11 @@ export class StreamingVideoDecoder {
 		// Scan video packets to find the true content boundary.
 		// MediaRecorder (especially on Linux) writes unreliable container durations.
 		// Packet timestamps are ground truth — no decode needed, just timestamp reads.
+		// Pass explicit range because some containers are truncated without one.
+		const scanEndSec = Math.max(mediaInfo.duration, videoStream?.duration ?? 0, 0) + 0.5;
 		let maxPacketEndUs = 0;
 		const scanReader = (
-			this.demuxer.read("video") as ReadableStream<EncodedVideoChunk>
+			this.demuxer.read("video", 0, scanEndSec) as ReadableStream<EncodedVideoChunk>
 		).getReader();
 		try {
 			while (true) {

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -71,6 +71,11 @@ const EARLY_DECODE_END_THRESHOLD_SEC = 1;
 const METADATA_TAIL_TOLERANCE_SEC = 1.5;
 const STREAM_DURATION_MATCH_TOLERANCE_SEC = 0.25;
 const DURATION_DIVERGENCE_THRESHOLD_SEC = 1.5;
+// Fallback upper bound for the packet scan when no reliable duration hint is
+// available. Explicit end is required (some containers are truncated without
+// one), but the hint-derived bound would cap the scan prematurely when
+// container/stream duration are missing or corrupt.
+const SCAN_UNBOUNDED_FALLBACK_SEC = 24 * 60 * 60;
 
 /**
  * Validate container duration against actual packet timestamps.
@@ -238,7 +243,9 @@ export class StreamingVideoDecoder {
 			typeof videoStream?.duration === "number" && Number.isFinite(videoStream.duration)
 				? videoStream.duration
 				: 0;
-		const scanEndSec = Math.max(containerDurationSec, streamDurationSec, 0) + 0.5;
+		const hintedDurationSec = Math.max(containerDurationSec, streamDurationSec, 0);
+		const scanEndSec =
+			hintedDurationSec > 0 ? hintedDurationSec + 0.5 : SCAN_UNBOUNDED_FALLBACK_SEC;
 		let maxPacketEndUs = 0;
 		const scanReader = this.demuxer.read("video", 0, scanEndSec).getReader();
 		try {

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -86,12 +86,12 @@ export function validateDuration(containerDuration: number, scannedDuration: num
 	if (scannedDuration <= 0) {
 		// Zero scanned duration means corrupted/empty file — fall back to container
 		// (downstream shouldFailDecodeEndedEarly will catch truly empty files)
-		return Math.max(containerDuration, 0);
+		return Number.isFinite(containerDuration) ? Math.max(containerDuration, 0) : 0;
 	}
 	if (!Number.isFinite(containerDuration) || containerDuration <= 0) {
 		return scannedDuration;
 	}
-	if (containerDuration - scannedDuration > DURATION_DIVERGENCE_THRESHOLD_SEC) {
+	if (Math.abs(containerDuration - scannedDuration) > DURATION_DIVERGENCE_THRESHOLD_SEC) {
 		return scannedDuration;
 	}
 	return containerDuration;

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -231,11 +231,16 @@ export class StreamingVideoDecoder {
 		// MediaRecorder (especially on Linux) writes unreliable container durations.
 		// Packet timestamps are ground truth — no decode needed, just timestamp reads.
 		// Pass explicit range because some containers are truncated without one.
-		const scanEndSec = Math.max(mediaInfo.duration, videoStream?.duration ?? 0, 0) + 0.5;
+		// Sanitize because mediaInfo.duration can be NaN/Infinity (Chromium Linux bug),
+		// which would propagate into demuxer.read() as an invalid endpoint.
+		const containerDurationSec = Number.isFinite(mediaInfo.duration) ? mediaInfo.duration : 0;
+		const streamDurationSec =
+			typeof videoStream?.duration === "number" && Number.isFinite(videoStream.duration)
+				? videoStream.duration
+				: 0;
+		const scanEndSec = Math.max(containerDurationSec, streamDurationSec, 0) + 0.5;
 		let maxPacketEndUs = 0;
-		const scanReader = (
-			this.demuxer.read("video", 0, scanEndSec) as ReadableStream<EncodedVideoChunk>
-		).getReader();
+		const scanReader = this.demuxer.read("video", 0, scanEndSec).getReader();
 		try {
 			while (true) {
 				const { done, value } = await scanReader.read();

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -70,6 +70,32 @@ type EarlyDecodeEndCheck = {
 const EARLY_DECODE_END_THRESHOLD_SEC = 1;
 const METADATA_TAIL_TOLERANCE_SEC = 1.5;
 const STREAM_DURATION_MATCH_TOLERANCE_SEC = 0.25;
+const DURATION_DIVERGENCE_THRESHOLD_SEC = 1.5;
+
+/**
+ * Validate container duration against actual packet timestamps.
+ *
+ * Chrome/Electron's MediaRecorder writes WebM containers with unreliable
+ * Duration fields (often Infinity, 0, or inflated) — especially on Linux.
+ * This function picks the most trustworthy duration value.
+ *
+ * @param containerDuration  Duration from the container-level metadata
+ * @param scannedDuration    Duration derived from actual packet timestamps (ground truth)
+ */
+export function validateDuration(containerDuration: number, scannedDuration: number): number {
+	if (scannedDuration <= 0) {
+		// Zero scanned duration means corrupted/empty file — fall back to container
+		// (downstream shouldFailDecodeEndedEarly will catch truly empty files)
+		return Math.max(containerDuration, 0);
+	}
+	if (!Number.isFinite(containerDuration) || containerDuration <= 0) {
+		return scannedDuration;
+	}
+	if (containerDuration - scannedDuration > DURATION_DIVERGENCE_THRESHOLD_SEC) {
+		return scannedDuration;
+	}
+	return containerDuration;
+}
 
 export function shouldFailDecodeEndedEarly({
 	cancelled,
@@ -201,10 +227,34 @@ export class StreamingVideoDecoder {
 
 		const audioStream = mediaInfo.streams.find((s) => s.codec_type_string === "audio");
 
+		// Scan video packets to find the true content boundary.
+		// MediaRecorder (especially on Linux) writes unreliable container durations.
+		// Packet timestamps are ground truth — no decode needed, just timestamp reads.
+		let maxPacketEndUs = 0;
+		const scanReader = (
+			this.demuxer.read("video") as ReadableStream<EncodedVideoChunk>
+		).getReader();
+		try {
+			while (true) {
+				const { done, value } = await scanReader.read();
+				if (done || !value) break;
+				const endUs = value.timestamp + (value.duration ?? 0);
+				if (endUs > maxPacketEndUs) maxPacketEndUs = endUs;
+			}
+		} finally {
+			try {
+				await scanReader.cancel();
+			} catch {
+				/* already closed */
+			}
+		}
+		const scannedDuration = maxPacketEndUs / 1_000_000;
+		const validatedDuration = validateDuration(mediaInfo.duration, scannedDuration);
+
 		this.metadata = {
 			width: videoStream?.width || 1920,
 			height: videoStream?.height || 1080,
-			duration: mediaInfo.duration,
+			duration: validatedDuration,
 			streamDuration:
 				typeof videoStream?.duration === "number" && Number.isFinite(videoStream.duration)
 					? videoStream.duration
@@ -305,7 +355,7 @@ export class StreamingVideoDecoder {
 
 		// One forward stream through the whole file.
 		// Pass explicit range because some containers are truncated when no end is provided.
-		const readEndSec = Math.max(this.metadata.duration, this.metadata.streamDuration ?? 0) + 0.5;
+		const readEndSec = this.metadata.duration + 0.5;
 		const reader = this.demuxer.read("video", 0, readEndSec).getReader();
 
 		// Feed chunks to decoder in background with backpressure

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -157,17 +157,11 @@ export class VideoExporter {
 			this.muxer = muxer;
 			await muxer.initialize();
 
-			const { effectiveDuration, totalFrames } = streamingDecoder.getExportMetrics(
+			const { totalFrames } = streamingDecoder.getExportMetrics(
 				this.config.frameRate,
 				this.config.trimRegions,
 				this.config.speedRegions,
 			);
-			const readEndSec = Math.max(videoInfo.duration, videoInfo.streamDuration ?? 0) + 0.5;
-
-			console.log("[VideoExporter] Original duration:", videoInfo.duration, "s");
-			console.log("[VideoExporter] Effective duration:", effectiveDuration, "s");
-			console.log("[VideoExporter] Total frames to export:", totalFrames);
-			console.log("[VideoExporter] Using streaming decode (web-demuxer + VideoDecoder)");
 
 			const frameDuration = 1_000_000 / this.config.frameRate;
 			let frameIndex = 0;
@@ -346,7 +340,7 @@ export class VideoExporter {
 						this.config.videoUrl,
 						this.config.trimRegions,
 						this.config.speedRegions,
-						readEndSec,
+						videoInfo.duration,
 					);
 				}
 			}


### PR DESCRIPTION
## Summary

Two bugs in the export pipeline causing wrong duration, frozen video, misaligned audio, and "decode ended early" errors:

- **Duration validation**: Chrome/Electron's MediaRecorder writes WebM containers with unreliable Duration fields on Linux (Infinity, 0, or inflated). The pipeline trusted `mediaInfo.duration` as ground truth. Fix: scan actual packet timestamps in `loadMetadata()` and use packet-based ground truth when container diverges beyond threshold.

- **Audio trim in speed-aware path**: `renderPitchPreservedTimelineAudio` records audio in real-time via MediaRecorder + AudioContext. When skipping trim regions, `media.currentTime` was set without pausing the recorder — capturing seek dead time as real audio, inflating the audio track beyond the video duration. Fix: `recorder.pause()/resume()` around trim seeks, skip past initial trim before recording starts, wait for seek completion via `seeked` event with timeout.

### Changes

| File | What |
|---|---|
| `streamingDecoder.ts` | `validateDuration()` function + packet scan in `loadMetadata()`, simplified `readEndSec` |
| `audioEncoder.ts` | Recorder pause/resume around trim seeks, initial trim skip, seek timeout, consolidated `validatedDurationSec` parameter |
| `videoExporter.ts` | Pass validated duration to audio processor, removed redundant `readEndSec` |
| `streamingDecoder.test.ts` | 7 unit tests for `validateDuration()` |

### Issues addressed

| Issue | Status |
|---|---|
| #276 "Video decode ended early" | **Fixed** — validated duration → `requiredEndSec` matches reality → no false error |
| #433 Audio misaligned with trim+speed | **Fixed** — recorder paused during seeks, initial trim skipped |
| #428 "Can't export on Windows" | **Partially addressed** — same root cause as #276 (decode-ended-early). File path normalization from PR #423 is separate and still needed. |

### Note on PR #423

PR #423 suppresses the "decode ended early" error on Windows as a workaround. This PR fixes the root cause (duration validation), making that suppression unnecessary. PR #423's file path normalization fix (`electron/ipc/handlers.ts`) is orthogonal and still valuable.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files)
- [x] Unit tests — 11/11 pass (`validateDuration` + `shouldFailDecodeEndedEarly`)
- [x] `npx vite build` — succeeds
- [x] Manual test: record ~24s, add trim regions + speed region, export MP4 → correct duration, audio aligned, no frozen frames
- [ ] Verify on Windows: export should complete without "decode ended early" error
- [ ] Verify on Mac Silicon: same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip empty audio segments when speed regions are applied; return a silent export when all content is trimmed or recording yields no output
  * Start recording after initial trim regions and apply the correct playback rate from speed regions at export start
  * Add seek timeout protection and cap rendering by validated duration to prevent overshoot
  * Improve media-duration handling to prefer a validated duration when container metadata is inconsistent

* **Tests**
  * Added comprehensive tests covering duration-validation edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->