### PR TITLE
fix: improve performance on windows and macos by passing canvas direclty to `VideoFrame()`

### DIFF
--- a/scripts/i18n-check.mjs
+++ b/scripts/i18n-check.mjs
@@ -11,7 +11,6 @@ import path from "node:path";
 
 const LOCALES_DIR = path.resolve("src/i18n/locales");
 const BASE_LOCALE = "en";
-const COMPARE_LOCALES = ["zh-CN", "zh-TW", "es", "tr", "ko-KR"];
 
 function getKeys(obj, prefix = "") {
 	const keys = [];

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -78,6 +78,7 @@ interface FrameRenderConfig {
 	previewWidth?: number;
 	previewHeight?: number;
 	cursorTelemetry?: import("@/components/video-editor/types").CursorTelemetryPoint[];
+	platform: string;
 }
 
 interface AnimationState {
@@ -124,9 +125,11 @@ export class FrameRenderer {
 	private smoothedAutoFocus: { cx: number; cy: number } | null = null;
 	private prevAnimationTimeMs: number | null = null;
 	private prevTargetProgress = 0;
+	private isLinux = false;
 
 	constructor(config: FrameRenderConfig) {
 		this.config = config;
+		this.isLinux = config.platform === "linux";
 		this.animationState = {
 			scale: 1,
 			focusX: DEFAULT_FOCUS.cx,
@@ -189,10 +192,8 @@ export class FrameRenderer {
 		this.compositeCanvas.height = this.config.height;
 
 		// On Linux, getImageData() is called frequently causing frequent CPU readback
-		const isLinux = (await window.electronAPI.getPlatform()) === "linux";
-
 		this.compositeCtx = this.compositeCanvas.getContext("2d", {
-			willReadFrequently: isLinux,
+			willReadFrequently: this.isLinux,
 		});
 
 		if (!this.compositeCtx) {
@@ -730,7 +731,10 @@ export class FrameRenderer {
 	private compositeWithShadows(webcamFrame?: VideoFrame | null): void {
 		if (!this.compositeCanvas || !this.compositeCtx || !this.app) return;
 
-		const videoCanvas = this.readbackVideoCanvas();
+		const videoCanvas = this.isLinux
+			? this.readbackVideoCanvas()
+			: (this.app.canvas as HTMLCanvasElement);
+
 		const ctx = this.compositeCtx;
 		const w = this.compositeCanvas.width;
 		const h = this.compositeCanvas.height;

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -187,8 +187,12 @@ export class FrameRenderer {
 		this.compositeCanvas = document.createElement("canvas");
 		this.compositeCanvas.width = this.config.width;
 		this.compositeCanvas.height = this.config.height;
+
+		// On Linux, getImageData() is called frequently causing frequent CPU readback
+		const isLinux = (await window.electronAPI.getPlatform()) === "linux";
+
 		this.compositeCtx = this.compositeCanvas.getContext("2d", {
-			willReadFrequently: false,
+			willReadFrequently: isLinux,
 		});
 
 		if (!this.compositeCtx) {

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -115,7 +115,10 @@ export class GifExporter {
 
 	async export(): Promise<ExportResult> {
 		let webcamFrameQueue: AsyncVideoFrameQueue | null = null;
+
 		try {
+			const platform = await window.electronAPI.getPlatform();
+
 			this.cleanup();
 			this.cancelled = false;
 
@@ -153,6 +156,7 @@ export class GifExporter {
 				previewWidth: this.config.previewWidth,
 				previewHeight: this.config.previewHeight,
 				cursorTelemetry: this.config.cursorTelemetry,
+				platform,
 			});
 			await this.renderer.initialize();
 

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -8,6 +8,7 @@ import type {
 	WebcamSizePreset,
 	ZoomRegion,
 } from "@/components/video-editor/types";
+import { getPlatform } from "@/utils/platformUtils";
 import { AsyncVideoFrameQueue } from "./asyncVideoFrameQueue";
 import { FrameRenderer } from "./frameRenderer";
 import { StreamingVideoDecoder } from "./streamingDecoder";
@@ -117,7 +118,7 @@ export class GifExporter {
 		let webcamFrameQueue: AsyncVideoFrameQueue | null = null;
 
 		try {
-			const platform = await window.electronAPI.getPlatform();
+			const platform = await getPlatform();
 
 			this.cleanup();
 			this.cancelled = false;

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -111,9 +111,9 @@ export class VideoExporter {
 		this.cancelled = false;
 		this.fatalEncoderError = null;
 
-		const platform = await window.electronAPI.getPlatform();
-
 		try {
+			const platform = await window.electronAPI.getPlatform();
+
 			const streamingDecoder = new StreamingVideoDecoder();
 			this.streamingDecoder = streamingDecoder;
 			const videoInfo = await streamingDecoder.loadMetadata(this.config.videoUrl);
@@ -148,6 +148,7 @@ export class VideoExporter {
 				previewWidth: this.config.previewWidth,
 				previewHeight: this.config.previewHeight,
 				cursorTelemetry: this.config.cursorTelemetry,
+				platform,
 			});
 			this.renderer = renderer;
 			await renderer.initialize();

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -111,6 +111,8 @@ export class VideoExporter {
 		this.cancelled = false;
 		this.fatalEncoderError = null;
 
+		const platform = await window.electronAPI.getPlatform();
+
 		try {
 			const streamingDecoder = new StreamingVideoDecoder();
 			this.streamingDecoder = streamingDecoder;
@@ -237,25 +239,29 @@ export class VideoExporter {
 
 						const canvas = renderer.getCanvas();
 
-						// Read raw pixels from the canvas instead of passing
-						// the canvas directly to VideoFrame. On some Linux
-						// systems the GPU shared-image path (EGL/Ozone) fails
-						// silently, producing empty frames.
-						const canvasCtx = canvas.getContext("2d")!;
-						const imageData = canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
-						const exportFrame = new VideoFrame(imageData.data.buffer, {
-							format: "RGBA",
-							codedWidth: canvas.width,
-							codedHeight: canvas.height,
-							timestamp,
-							duration: frameDuration,
-							colorSpace: {
-								primaries: "bt709",
-								transfer: "iec61966-2-1",
-								matrix: "rgb",
-								fullRange: true,
-							},
-						});
+						let exportFrame: VideoFrame;
+
+						// On some Linux systems the GPU shared-image path (EGL/Ozone) fails
+						// silently, producing empty frames, so we force a CPU readback instead.
+						if (platform === "linux") {
+							const canvasCtx = canvas.getContext("2d")!;
+							const imageData = canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
+							exportFrame = new VideoFrame(imageData.data.buffer, {
+								format: "RGBA",
+								codedWidth: canvas.width,
+								codedHeight: canvas.height,
+								timestamp,
+								duration: frameDuration,
+								colorSpace: {
+									primaries: "bt709",
+									transfer: "iec61966-2-1",
+									matrix: "rgb",
+									fullRange: true,
+								},
+							});
+						} else {
+							exportFrame = new VideoFrame(canvas, { timestamp, duration: frameDuration });
+						}
 
 						while (
 							this.encoder &&

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -7,6 +7,7 @@ import type {
 	WebcamSizePreset,
 	ZoomRegion,
 } from "@/components/video-editor/types";
+import { getPlatform } from "@/utils/platformUtils";
 import { AsyncVideoFrameQueue } from "./asyncVideoFrameQueue";
 import { AudioProcessor } from "./audioEncoder";
 import { FrameRenderer } from "./frameRenderer";
@@ -112,7 +113,7 @@ export class VideoExporter {
 		this.fatalEncoderError = null;
 
 		try {
-			const platform = await window.electronAPI.getPlatform();
+			const platform = await getPlatform();
 
 			const streamingDecoder = new StreamingVideoDecoder();
 			this.streamingDecoder = streamingDecoder;

--- a/src/utils/platformUtils.ts
+++ b/src/utils/platformUtils.ts
@@ -3,7 +3,7 @@ let cachedPlatform: string | null = null;
 /**
  * Gets the current platform from Electron
  */
-const getPlatform = async (): Promise<string> => {
+export const getPlatform = async (): Promise<string> => {
 	if (cachedPlatform) return cachedPlatform;
 
 	try {
@@ -14,9 +14,14 @@ const getPlatform = async (): Promise<string> => {
 		console.warn("Failed to get platform from Electron, falling back to navigator:", error);
 		// Fallback for development/testing
 		let fallbackPlatform = "win32";
-		if (typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform)) {
-			fallbackPlatform = "darwin";
+		if (typeof navigator !== "undefined") {
+			if (/Mac|iPhone|iPad|iPod/.test(navigator.platform)) {
+				fallbackPlatform = "darwin";
+			} else if (/Linux/.test(navigator.platform)) {
+				fallbackPlatform = "linux";
+			}
 		}
+
 		cachedPlatform = fallbackPlatform;
 		return fallbackPlatform;
 	}


### PR DESCRIPTION
# Pull Request Template

## Description
Because of a potential bug on some Linux systems we were not able to pass the canvas directly to `VideoFrame(...)`. There was a workaround implemented to read the raw pixels from the canvas using `getImageData()` for every single frame which required a CPU readback and reduces performance. After this PR, this workaround is only used on Linux systems, to allow better performance at least for other OS'.

## Motivation
Rendering can take quite long. The current CPU readback workaround makes it take even longer and is not necessary for win and darwin systems.

Here is a quick benchmark I did (duration in ms):

|             | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 |   Avg |   Std |
|-------------|-------|-------|-------|-------|-------|-------|-------|
| Readback    | 44951 | 38267 | 33148 | 43556 | 44927 | **40970** |  **4619** |
| Direct      | 31125 | 28171 | 29122 | 30897 | 28146 | **29492** |  **1291** |

Info about the video used:
```
[VideoExporter] Original duration: 16.211 s
[VideoExporter] Effective duration: 8.8246 s
[VideoExporter] Total frames to export: 530
```

So for this video about a 30% speed up. I've seen similar speed ups with other videos as well. Additionally, there is this `willReadFrequently` attribute to `canvas.getContext`. Since for Linux we do read frequently from the canvas, I set it there to be `true`.

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] Other: Performance improvement

## Related Issue(s)

## Screenshots / Video

## Testing
You can time how long a video takes to export with and without the PR. A way to do that is to drop in this snippet:
```typescript
try {
    const benchmark = async (useReadback: boolean) => {
        const durations: number[] = [];
        let res;
        for (let i = 0; i < 5; i++) {
            const t = performance.now();
            res = await this.exportWithEncoderPreference(useReadback, encoderPreference);
            durations.push(performance.now() - t);
        }
        const avg = durations.reduce((acc, r) => acc + r, 0) / durations.length;
        const std = Math.sqrt(durations.reduce((acc, r) => acc + (r - avg) ** 2, 0) / durations.length);
        console.log(`useReadback=${useReadback} avg=${avg.toFixed(2)}ms std=${std.toFixed(2)}ms`);
        return res!;
    };

    await benchmark(true);
    return await benchmark(false);
}
. . . 
```
... where `this.exportWithEncoderPreference` is currently being called and check the console (CTRL+SHIFT+I).

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Exporters now detect the host OS and choose an optimized canvas handling path, improving export speed and reliability.
  * Non-Linux hosts avoid unnecessary CPU readbacks, reducing export overhead and stabilizing rendering performance.

* **Bug Fixes**
  * Frame capture and compositing adjusted per-platform to ensure consistent video/GIF output.
  * Reduced timing and color mismatches across operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->