### PR TITLE
fix: guard getNativeAspectRatioValue against zero denominator

### DIFF
--- a/src/utils/aspectRatioUtils.test.ts
+++ b/src/utils/aspectRatioUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getNativeAspectRatioValue } from "./aspectRatioUtils";
+
+const FALLBACK = 16 / 9;
+
+describe("getNativeAspectRatioValue", () => {
+	it("returns the natural video ratio for a standard HD frame", () => {
+		expect(getNativeAspectRatioValue(1920, 1080)).toBeCloseTo(16 / 9);
+	});
+
+	it("applies the crop region when provided", () => {
+		const crop = { x: 0, y: 0, width: 0.5, height: 0.5 };
+		expect(getNativeAspectRatioValue(1920, 1080, crop)).toBeCloseTo(16 / 9);
+	});
+
+	it("falls back to 16/9 when video metadata is not yet loaded (height = 0)", () => {
+		expect(getNativeAspectRatioValue(1920, 0)).toBe(FALLBACK);
+	});
+
+	it("falls back to 16/9 when both dimensions are zero", () => {
+		expect(getNativeAspectRatioValue(0, 0)).toBe(FALLBACK);
+	});
+
+	it("falls back to 16/9 when the crop height collapses to zero", () => {
+		const crop = { x: 0, y: 0, width: 0.5, height: 0 };
+		expect(getNativeAspectRatioValue(1920, 1080, crop)).toBe(FALLBACK);
+	});
+
+	it("falls back to 16/9 when inputs are NaN", () => {
+		expect(getNativeAspectRatioValue(Number.NaN, 1080)).toBe(FALLBACK);
+		expect(getNativeAspectRatioValue(1920, Number.NaN)).toBe(FALLBACK);
+	});
+
+	it("falls back to 16/9 for non-positive dimensions", () => {
+		expect(getNativeAspectRatioValue(-1920, 1080)).toBe(FALLBACK);
+		expect(getNativeAspectRatioValue(1920, -1080)).toBe(FALLBACK);
+	});
+
+	it("never returns Infinity, NaN, or a non-positive ratio", () => {
+		const pathologicalInputs: Array<[number, number]> = [
+			[0, 0],
+			[1920, 0],
+			[0, 1080],
+			[Number.POSITIVE_INFINITY, 1080],
+			[1920, Number.POSITIVE_INFINITY],
+			[Number.NaN, Number.NaN],
+		];
+		for (const [w, h] of pathologicalInputs) {
+			const ratio = getNativeAspectRatioValue(w, h);
+			expect(Number.isFinite(ratio)).toBe(true);
+			expect(ratio).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/utils/aspectRatioUtils.test.ts
+++ b/src/utils/aspectRatioUtils.test.ts
@@ -9,8 +9,11 @@ describe("getNativeAspectRatioValue", () => {
 	});
 
 	it("applies the crop region when provided", () => {
-		const crop = { x: 0, y: 0, width: 0.5, height: 0.5 };
-		expect(getNativeAspectRatioValue(1920, 1080, crop)).toBeCloseTo(16 / 9);
+		// Use non-proportional crop dimensions so the ratio actually changes;
+		// equal width/height would cancel out and silently pass even if the
+		// crop were ignored.
+		const crop = { x: 0, y: 0, width: 0.75, height: 0.5 };
+		expect(getNativeAspectRatioValue(1920, 1080, crop)).toBeCloseTo((1920 * 0.75) / (1080 * 0.5));
 	});
 
 	it("falls back to 16/9 when video metadata is not yet loaded (height = 0)", () => {
@@ -37,16 +40,26 @@ describe("getNativeAspectRatioValue", () => {
 	});
 
 	it("never returns Infinity, NaN, or a non-positive ratio", () => {
-		const pathologicalInputs: Array<[number, number]> = [
+		const pathologicalInputs: Array<
+			[number, number, { x: number; y: number; width: number; height: number }?]
+		> = [
 			[0, 0],
 			[1920, 0],
 			[0, 1080],
 			[Number.POSITIVE_INFINITY, 1080],
 			[1920, Number.POSITIVE_INFINITY],
 			[Number.NaN, Number.NaN],
+			// Same idea, but exercising the crop-region branch so a future
+			// regression there can't slip past the dimension-only cases above.
+			[1920, 1080, { x: 0, y: 0, width: 0.5, height: 0 }],
+			[1920, 1080, { x: 0, y: 0, width: 0, height: 0.5 }],
+			[1920, 1080, { x: 0, y: 0, width: Number.NaN, height: 0.5 }],
+			[1920, 1080, { x: 0, y: 0, width: 0.5, height: Number.NaN }],
+			[1920, 1080, { x: 0, y: 0, width: Number.POSITIVE_INFINITY, height: 0.5 }],
+			[1920, 1080, { x: 0, y: 0, width: 0.5, height: -1 }],
 		];
-		for (const [w, h] of pathologicalInputs) {
-			const ratio = getNativeAspectRatioValue(w, h);
+		for (const [w, h, crop] of pathologicalInputs) {
+			const ratio = getNativeAspectRatioValue(w, h, crop);
 			expect(Number.isFinite(ratio)).toBe(true);
 			expect(ratio).toBeGreaterThan(0);
 		}

--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -41,6 +41,8 @@ export function getAspectRatioValue(aspectRatio: AspectRatio): number {
 	}
 }
 
+const NATIVE_ASPECT_FALLBACK = 16 / 9;
+
 export function getNativeAspectRatioValue(
 	videoWidth: number,
 	videoHeight: number,
@@ -48,7 +50,13 @@ export function getNativeAspectRatioValue(
 ): number {
 	const cropW = cropRegion?.width ?? 1;
 	const cropH = cropRegion?.height ?? 1;
-	return (videoWidth * cropW) / (videoHeight * cropH);
+	const numerator = videoWidth * cropW;
+	const denominator = videoHeight * cropH;
+	if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+		return NATIVE_ASPECT_FALLBACK;
+	}
+	const ratio = numerator / denominator;
+	return ratio > 0 && Number.isFinite(ratio) ? ratio : NATIVE_ASPECT_FALLBACK;
 }
 
 export function getAspectRatioDimensions(

--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -11,6 +11,8 @@ export const ASPECT_RATIOS = [
 
 export type AspectRatio = (typeof ASPECT_RATIOS)[number];
 
+const NATIVE_ASPECT_FALLBACK = 16 / 9;
+
 /**
  * Returns the numeric value of an aspect ratio.
  * For "native", returns a fallback ratio of 16/9.
@@ -33,15 +35,13 @@ export function getAspectRatioValue(aspectRatio: AspectRatio): number {
 		case "10:16":
 			return 10 / 16;
 		case "native":
-			return 16 / 9;
+			return NATIVE_ASPECT_FALLBACK;
 		default: {
 			const _exhaustiveCheck: never = aspectRatio;
 			return _exhaustiveCheck;
 		}
 	}
 }
-
-const NATIVE_ASPECT_FALLBACK = 16 / 9;
 
 export function getNativeAspectRatioValue(
 	videoWidth: number,
@@ -80,6 +80,6 @@ export function isPortraitAspectRatio(aspectRatio: AspectRatio): boolean {
 }
 
 export function formatAspectRatioForCSS(aspectRatio: AspectRatio, nativeRatio?: number): string {
-	if (aspectRatio === "native") return String(nativeRatio ?? 16 / 9);
+	if (aspectRatio === "native") return String(nativeRatio ?? NATIVE_ASPECT_FALLBACK);
 	return aspectRatio.replace(":", "/");
 }


### PR DESCRIPTION
## Description

`getNativeAspectRatioValue` in `src/utils/aspectRatioUtils.ts` performed an unguarded division and could return `Infinity`, `NaN`, or negative values. The result flows into nine call sites in `VideoEditor.tsx` and `VideoPlayback.tsx` that use it for canvas sizing and CSS `aspect-ratio`, so a bad value collapses the preview to 0×0 or produces a broken export.

This PR clamps the denominator and falls back to `16 / 9` — the same default `getAspectRatioValue` already returns for the `"native"` case — whenever the computed ratio is not a finite positive number. A new vitest suite locks the behaviour in.

## Motivation

Introduced in v1.3.0 when the `"native"` aspect ratio option was added. Two realistic paths hit the bug:

1. Switching the aspect ratio dropdown to **Native** before the underlying `<video>` element has fired `loadedmetadata` (`videoHeight === 0`).
2. Dragging a crop handle so the crop region height reaches `0` while **Native** is active.

Both cases reproduce with a one-liner against v1.3.0 source:

```
node -e 'const f=(w,h,c)=>{const cw=c?.width??1;const ch=c?.height??1;return (w*cw)/(h*ch);}; console.log(f(1920,0)); console.log(f(1920,1080,{x:0,y:0,width:0.5,height:0}))'
// Infinity
// Infinity
```

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Fixes #454

## Testing

- New test file `src/utils/aspectRatioUtils.test.ts` (8 cases) — covers the normal path, crop-applied path, `videoHeight = 0`, both-zero, `cropHeight = 0`, `NaN` inputs, negative dimensions, and a property-style check that no pathological input returns `Infinity` / `NaN` / non-positive.
- `npx vitest run src/utils/aspectRatioUtils.test.ts` → 8/8 pass.

Manual repro steps for reviewers:

1. Open a video, and while it is still buffering metadata, switch the aspect ratio dropdown to **Native** — preview no longer collapses.
2. With **Native** active, drag the crop bottom edge up until the crop height reaches 0 — the layout stays on the 16/9 fallback instead of breaking.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aspect-ratio handling: calculations validate inputs and consistently fall back to a standard 16:9 ratio for invalid, missing, non-positive or non-finite dimensions, ensuring returned ratios are always finite and positive. "Native" aspect formatting now uses this fallback when no native value is available.

* **Tests**
  * Added comprehensive tests covering normal, edge, and pathological aspect-ratio scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->