### PR TITLE
fix(annotations): wrap CJK text at character boundaries in export renderer

### DIFF
--- a/src/lib/exporter/annotationRenderer.ts
+++ b/src/lib/exporter/annotationRenderer.ts
@@ -10,12 +10,12 @@ import {
 let blurScratchCanvas: HTMLCanvasElement | null = null;
 let blurScratchCtx: CanvasRenderingContext2D | null = null;
 
-// Matches a single code point in Hiragana, Katakana, CJK Unified Ideographs
-// Extension A, CJK Unified Ideographs, Hangul Syllables, or CJK Compatibility
-// Ideographs. Used to split CJK text at character boundaries during wrap,
-// since CJK scripts have no word-separating whitespace.
-const CJK_CHAR =
-	/[\u3040-\u309f\u30a0-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\uf900-\ufaff]/u;
+// Matches a single code point whose script is Han (including non-BMP
+// Extension A-F), Hiragana, Katakana (including halfwidth forms), or
+// Hangul. Used to split CJK text at character boundaries during wrap,
+// since CJK scripts have no word-separating whitespace. Unicode script
+// property escapes require ES2018+; tsconfig target is ES2020.
+const CJK_CHAR = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
 function tokenizeForWrap(line: string): string[] {
 	// Split Latin text on whitespace (preserving the whitespace as its own token,

--- a/src/lib/exporter/annotationRenderer.ts
+++ b/src/lib/exporter/annotationRenderer.ts
@@ -10,6 +10,39 @@ import {
 let blurScratchCanvas: HTMLCanvasElement | null = null;
 let blurScratchCtx: CanvasRenderingContext2D | null = null;
 
+// Matches a single code point in Hiragana, Katakana, CJK Unified Ideographs
+// Extension A, CJK Unified Ideographs, Hangul Syllables, or CJK Compatibility
+// Ideographs. Used to split CJK text at character boundaries during wrap,
+// since CJK scripts have no word-separating whitespace.
+const CJK_CHAR =
+	/[\u3040-\u309f\u30a0-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\uf900-\ufaff]/u;
+
+function tokenizeForWrap(line: string): string[] {
+	// Split Latin text on whitespace (preserving the whitespace as its own token,
+	// matching the original behavior), and split CJK runs into individual
+	// characters so each one becomes a breakable unit. This mirrors the editor's
+	// CSS `word-break: break-word` handling for CJK content.
+	const tokens: string[] = [];
+	let buffer = "";
+	const chars = Array.from(line);
+	const flushBuffer = () => {
+		if (buffer) {
+			tokens.push(...buffer.split(/(\s+)/).filter((s) => s.length > 0));
+			buffer = "";
+		}
+	};
+	for (const ch of chars) {
+		if (CJK_CHAR.test(ch)) {
+			flushBuffer();
+			tokens.push(ch);
+		} else {
+			buffer += ch;
+		}
+	}
+	flushBuffer();
+	return tokens;
+}
+
 // SVG path data for each arrow direction
 const ARROW_PATHS: Record<ArrowDirection, string[]> = {
 	up: ["M 50 20 L 50 80", "M 50 20 L 35 35", "M 50 20 L 65 35"],
@@ -249,13 +282,13 @@ function renderText(
 			lines.push("");
 			continue;
 		}
-		const words = rawLine.split(/(\s+)/);
+		const tokens = tokenizeForWrap(rawLine);
 		let current = "";
-		for (const word of words) {
-			const test = current + word;
+		for (const token of tokens) {
+			const test = current + token;
 			if (current && ctx.measureText(test).width > availableWidth) {
 				lines.push(current);
-				current = word.trimStart();
+				current = token.trimStart();
 			} else {
 				current = test;
 			}


### PR DESCRIPTION
## Summary

Fixes #449. CJK annotation text (Chinese, Japanese, Korean) overflows the exported video's annotation box because the Canvas-based exporter only breaks lines on whitespace. CJK scripts have no word-separating whitespace, so the entire string stays as one unbreakable token.

The editor's HTML preview (`AnnotationOverlay.tsx`) wraps correctly via CSS `word-break: break-word`. This PR ports the same behavior to `renderText` in the exporter.

## Changes

`src/lib/exporter/annotationRenderer.ts`:
- Add `CJK_CHAR` regex covering Hiragana (`U+3040-U+309F`), Katakana (`U+30A0-U+30FF`), CJK Unified Ideographs Extension A (`U+3400-U+4DBF`), CJK Unified Ideographs (`U+4E00-U+9FFF`), Hangul Syllables (`U+AC00-U+D7AF`), and CJK Compatibility Ideographs (`U+F900-U+FAFF`).
- Add `tokenizeForWrap(line)` that yields each CJK character as its own token while keeping Latin word+whitespace tokens intact.
- Replace `rawLine.split(/(\s+)/)` in `renderText`'s wrap loop with `tokenizeForWrap(rawLine)`. The existing width-measurement loop handles per-token wrapping unchanged.

## Why per-character (not ICU segmentation)

Canvas doesn't have access to `Intl.Segmenter` word-break granularity in all renderer contexts, and for CJK the visual expectation is that *any* character boundary is a valid break point (same as `word-break: break-word` does). Per-character tokenization is simpler, matches the editor preview, and avoids pulling in a breaker library.

## Verification

- `npx tsc --noEmit` passes.
- `biome format --write` + `biome check` pass on the modified file.
- `npx vitest run src/lib/exporter/` results are unchanged vs `main` (2 pre-existing browser-test failures on both branches, 19 passing — the change does not touch those tests).

Closes #449

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- discord-thread-id:1495360775269912636 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping and rendering for CJK (Chinese, Japanese, Korean) languages so characters break individually while preserving existing whitespace behavior, reducing line overflow and improving readability in mixed-language content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->