### PR TITLE
Improve Arch Linux support and fix video export on Hyprland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,4 +250,5 @@ jobs:
             release/**/*.AppImage
             release/**/*.zsync
             release/**/*.deb
+            release/**/*.pacman
           retention-days: 30

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -50,7 +50,9 @@
   },
   "linux": {
     "target": [
-      "AppImage"
+      "AppImage",
+      "deb",
+      "pacman"
     ],
     "icon": "icons/icons/png",
     "artifactName": "${productName}-Linux-${version}.${ext}",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -359,7 +359,9 @@ export function registerIpcHandlers(
 	onRecordingStateChange?: (recording: boolean, sourceName: string) => void,
 	switchToHud?: () => void,
 ) {
-	const supportsWindowOpacity = process.platform !== "linux";
+	const isWayland =
+		process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY !== undefined;
+	const supportsWindowOpacity = process.platform !== "linux" || isWayland;
 	const countdownOverlayState = {
 		visible: false,
 		value: null as number | null,
@@ -834,14 +836,24 @@ export function registerIpcHandlers(
 				? [{ name: mainT("dialogs", "fileDialogs.gifImage"), extensions: ["gif"] }]
 				: [{ name: mainT("dialogs", "fileDialogs.mp4Video"), extensions: ["mp4"] }];
 
-			const result = await dialog.showSaveDialog({
-				title: isGif
-					? mainT("dialogs", "fileDialogs.saveGif")
-					: mainT("dialogs", "fileDialogs.saveVideo"),
-				defaultPath: path.join(app.getPath("downloads"), fileName),
-				filters,
-				properties: ["createDirectory", "showOverwriteConfirmation"],
-			});
+			const mainWindow = getMainWindow();
+			const result = mainWindow
+				? await dialog.showSaveDialog(mainWindow, {
+						title: isGif
+							? mainT("dialogs", "fileDialogs.saveGif")
+							: mainT("dialogs", "fileDialogs.saveVideo"),
+						defaultPath: path.join(app.getPath("downloads"), fileName),
+						filters,
+						properties: ["createDirectory", "showOverwriteConfirmation"],
+					})
+				: await dialog.showSaveDialog({
+						title: isGif
+							? mainT("dialogs", "fileDialogs.saveGif")
+							: mainT("dialogs", "fileDialogs.saveVideo"),
+						defaultPath: path.join(app.getPath("downloads"), fileName),
+						filters,
+						properties: ["createDirectory", "showOverwriteConfirmation"],
+					});
 
 			if (result.canceled || !result.filePath) {
 				return {
@@ -876,18 +888,32 @@ export function registerIpcHandlers(
 	});
 	ipcMain.handle("open-video-file-picker", async () => {
 		try {
-			const result = await dialog.showOpenDialog({
-				title: mainT("dialogs", "fileDialogs.selectVideo"),
-				defaultPath: RECORDINGS_DIR,
-				filters: [
-					{
-						name: mainT("dialogs", "fileDialogs.videoFiles"),
-						extensions: ["webm", "mp4", "mov", "avi", "mkv"],
-					},
-					{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-				],
-				properties: ["openFile"],
-			});
+			const mainWindow = getMainWindow();
+			const result = mainWindow
+				? await dialog.showOpenDialog(mainWindow, {
+						title: mainT("dialogs", "fileDialogs.selectVideo"),
+						defaultPath: RECORDINGS_DIR,
+						filters: [
+							{
+								name: mainT("dialogs", "fileDialogs.videoFiles"),
+								extensions: ["webm", "mp4", "mov", "avi", "mkv"],
+							},
+							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+						],
+						properties: ["openFile"],
+					})
+				: await dialog.showOpenDialog({
+						title: mainT("dialogs", "fileDialogs.selectVideo"),
+						defaultPath: RECORDINGS_DIR,
+						filters: [
+							{
+								name: mainT("dialogs", "fileDialogs.videoFiles"),
+								extensions: ["webm", "mp4", "mov", "avi", "mkv"],
+							},
+							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+						],
+						properties: ["openFile"],
+					});
 
 			if (result.canceled || result.filePaths.length === 0) {
 				return { success: false, canceled: true };
@@ -966,18 +992,32 @@ export function registerIpcHandlers(
 					? safeName
 					: `${safeName}.${PROJECT_FILE_EXTENSION}`;
 
-				const result = await dialog.showSaveDialog({
-					title: mainT("dialogs", "fileDialogs.saveProject"),
-					defaultPath: path.join(RECORDINGS_DIR, defaultName),
-					filters: [
-						{
-							name: mainT("dialogs", "fileDialogs.openscreenProject"),
-							extensions: [PROJECT_FILE_EXTENSION],
-						},
-						{ name: "JSON", extensions: ["json"] },
-					],
-					properties: ["createDirectory", "showOverwriteConfirmation"],
-				});
+				const mainWindow = getMainWindow();
+				const result = mainWindow
+					? await dialog.showSaveDialog(mainWindow, {
+							title: mainT("dialogs", "fileDialogs.saveProject"),
+							defaultPath: path.join(RECORDINGS_DIR, defaultName),
+							filters: [
+								{
+									name: mainT("dialogs", "fileDialogs.openscreenProject"),
+									extensions: [PROJECT_FILE_EXTENSION],
+								},
+								{ name: "JSON", extensions: ["json"] },
+							],
+							properties: ["createDirectory", "showOverwriteConfirmation"],
+						})
+					: await dialog.showSaveDialog({
+							title: mainT("dialogs", "fileDialogs.saveProject"),
+							defaultPath: path.join(RECORDINGS_DIR, defaultName),
+							filters: [
+								{
+									name: mainT("dialogs", "fileDialogs.openscreenProject"),
+									extensions: [PROJECT_FILE_EXTENSION],
+								},
+								{ name: "JSON", extensions: ["json"] },
+							],
+							properties: ["createDirectory", "showOverwriteConfirmation"],
+						});
 
 				if (result.canceled || !result.filePath) {
 					return {
@@ -1008,19 +1048,34 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("load-project-file", async () => {
 		try {
-			const result = await dialog.showOpenDialog({
-				title: mainT("dialogs", "fileDialogs.openProject"),
-				defaultPath: RECORDINGS_DIR,
-				filters: [
-					{
-						name: mainT("dialogs", "fileDialogs.openscreenProject"),
-						extensions: [PROJECT_FILE_EXTENSION],
-					},
-					{ name: "JSON", extensions: ["json"] },
-					{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-				],
-				properties: ["openFile"],
-			});
+			const mainWindow = getMainWindow();
+			const result = mainWindow
+				? await dialog.showOpenDialog(mainWindow, {
+						title: mainT("dialogs", "fileDialogs.openProject"),
+						defaultPath: RECORDINGS_DIR,
+						filters: [
+							{
+								name: mainT("dialogs", "fileDialogs.openscreenProject"),
+								extensions: [PROJECT_FILE_EXTENSION],
+							},
+							{ name: "JSON", extensions: ["json"] },
+							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+						],
+						properties: ["openFile"],
+					})
+				: await dialog.showOpenDialog({
+						title: mainT("dialogs", "fileDialogs.openProject"),
+						defaultPath: RECORDINGS_DIR,
+						filters: [
+							{
+								name: mainT("dialogs", "fileDialogs.openscreenProject"),
+								extensions: [PROJECT_FILE_EXTENSION],
+							},
+							{ name: "JSON", extensions: ["json"] },
+							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+						],
+						properties: ["openFile"],
+					});
 
 			if (result.canceled || result.filePaths.length === 0) {
 				return { success: false, canceled: true, message: "Open project canceled" };

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -52,6 +52,21 @@ function isPathAllowed(filePath: string): boolean {
 	return getAllowedReadDirs().some((dir) => isPathWithinDir(resolved, dir));
 }
 
+/**
+ * Helper function to build dialog options with a parent window only when it's valid.
+ * This prevents passing stale or destroyed BrowserWindow references to dialog calls.
+ */
+function buildDialogOptions<T extends Electron.OpenDialogOptions | Electron.SaveDialogOptions>(
+	baseOptions: T,
+	parentWindow: BrowserWindow | null,
+): T & { parent?: BrowserWindow } {
+	const mainWindow = parentWindow;
+	if (mainWindow && !mainWindow.isDestroyed()) {
+		return { ...baseOptions, parent: mainWindow };
+	}
+	return baseOptions;
+}
+
 function hasAllowedImportVideoExtension(filePath: string): boolean {
 	return ALLOWED_IMPORT_VIDEO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 }
@@ -359,9 +374,7 @@ export function registerIpcHandlers(
 	onRecordingStateChange?: (recording: boolean, sourceName: string) => void,
 	switchToHud?: () => void,
 ) {
-	const isWayland =
-		process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY !== undefined;
-	const supportsWindowOpacity = process.platform !== "linux" || isWayland;
+	const supportsWindowOpacity = process.platform !== "linux";
 	const countdownOverlayState = {
 		visible: false,
 		value: null as number | null,
@@ -836,24 +849,18 @@ export function registerIpcHandlers(
 				? [{ name: mainT("dialogs", "fileDialogs.gifImage"), extensions: ["gif"] }]
 				: [{ name: mainT("dialogs", "fileDialogs.mp4Video"), extensions: ["mp4"] }];
 
-			const mainWindow = getMainWindow();
-			const result = mainWindow
-				? await dialog.showSaveDialog(mainWindow, {
-						title: isGif
-							? mainT("dialogs", "fileDialogs.saveGif")
-							: mainT("dialogs", "fileDialogs.saveVideo"),
-						defaultPath: path.join(app.getPath("downloads"), fileName),
-						filters,
-						properties: ["createDirectory", "showOverwriteConfirmation"],
-					})
-				: await dialog.showSaveDialog({
-						title: isGif
-							? mainT("dialogs", "fileDialogs.saveGif")
-							: mainT("dialogs", "fileDialogs.saveVideo"),
-						defaultPath: path.join(app.getPath("downloads"), fileName),
-						filters,
-						properties: ["createDirectory", "showOverwriteConfirmation"],
-					});
+			const dialogOptions = buildDialogOptions(
+				{
+					title: isGif
+						? mainT("dialogs", "fileDialogs.saveGif")
+						: mainT("dialogs", "fileDialogs.saveVideo"),
+					defaultPath: path.join(app.getPath("downloads"), fileName),
+					filters,
+					properties: ["createDirectory", "showOverwriteConfirmation"],
+				},
+				getMainWindow(),
+			);
+			const result = await dialog.showSaveDialog(dialogOptions);
 
 			if (result.canceled || !result.filePath) {
 				return {
@@ -888,32 +895,22 @@ export function registerIpcHandlers(
 	});
 	ipcMain.handle("open-video-file-picker", async () => {
 		try {
-			const mainWindow = getMainWindow();
-			const result = mainWindow
-				? await dialog.showOpenDialog(mainWindow, {
-						title: mainT("dialogs", "fileDialogs.selectVideo"),
-						defaultPath: RECORDINGS_DIR,
-						filters: [
-							{
-								name: mainT("dialogs", "fileDialogs.videoFiles"),
-								extensions: ["webm", "mp4", "mov", "avi", "mkv"],
-							},
-							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-						],
-						properties: ["openFile"],
-					})
-				: await dialog.showOpenDialog({
-						title: mainT("dialogs", "fileDialogs.selectVideo"),
-						defaultPath: RECORDINGS_DIR,
-						filters: [
-							{
-								name: mainT("dialogs", "fileDialogs.videoFiles"),
-								extensions: ["webm", "mp4", "mov", "avi", "mkv"],
-							},
-							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-						],
-						properties: ["openFile"],
-					});
+			const dialogOptions = buildDialogOptions(
+				{
+					title: mainT("dialogs", "fileDialogs.selectVideo"),
+					defaultPath: RECORDINGS_DIR,
+					filters: [
+						{
+							name: mainT("dialogs", "fileDialogs.videoFiles"),
+							extensions: ["webm", "mp4", "mov", "avi", "mkv"],
+						},
+						{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+					],
+					properties: ["openFile"],
+				},
+				getMainWindow(),
+			);
+			const result = await dialog.showOpenDialog(dialogOptions);
 
 			if (result.canceled || result.filePaths.length === 0) {
 				return { success: false, canceled: true };
@@ -992,32 +989,22 @@ export function registerIpcHandlers(
 					? safeName
 					: `${safeName}.${PROJECT_FILE_EXTENSION}`;
 
-				const mainWindow = getMainWindow();
-				const result = mainWindow
-					? await dialog.showSaveDialog(mainWindow, {
-							title: mainT("dialogs", "fileDialogs.saveProject"),
-							defaultPath: path.join(RECORDINGS_DIR, defaultName),
-							filters: [
-								{
-									name: mainT("dialogs", "fileDialogs.openscreenProject"),
-									extensions: [PROJECT_FILE_EXTENSION],
-								},
-								{ name: "JSON", extensions: ["json"] },
-							],
-							properties: ["createDirectory", "showOverwriteConfirmation"],
-						})
-					: await dialog.showSaveDialog({
-							title: mainT("dialogs", "fileDialogs.saveProject"),
-							defaultPath: path.join(RECORDINGS_DIR, defaultName),
-							filters: [
-								{
-									name: mainT("dialogs", "fileDialogs.openscreenProject"),
-									extensions: [PROJECT_FILE_EXTENSION],
-								},
-								{ name: "JSON", extensions: ["json"] },
-							],
-							properties: ["createDirectory", "showOverwriteConfirmation"],
-						});
+				const dialogOptions = buildDialogOptions(
+					{
+						title: mainT("dialogs", "fileDialogs.saveProject"),
+						defaultPath: path.join(RECORDINGS_DIR, defaultName),
+						filters: [
+							{
+								name: mainT("dialogs", "fileDialogs.openscreenProject"),
+								extensions: [PROJECT_FILE_EXTENSION],
+							},
+							{ name: "JSON", extensions: ["json"] },
+						],
+						properties: ["createDirectory", "showOverwriteConfirmation"],
+					},
+					getMainWindow(),
+				);
+				const result = await dialog.showSaveDialog(dialogOptions);
 
 				if (result.canceled || !result.filePath) {
 					return {
@@ -1048,34 +1035,23 @@ export function registerIpcHandlers(
 
 	ipcMain.handle("load-project-file", async () => {
 		try {
-			const mainWindow = getMainWindow();
-			const result = mainWindow
-				? await dialog.showOpenDialog(mainWindow, {
-						title: mainT("dialogs", "fileDialogs.openProject"),
-						defaultPath: RECORDINGS_DIR,
-						filters: [
-							{
-								name: mainT("dialogs", "fileDialogs.openscreenProject"),
-								extensions: [PROJECT_FILE_EXTENSION],
-							},
-							{ name: "JSON", extensions: ["json"] },
-							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-						],
-						properties: ["openFile"],
-					})
-				: await dialog.showOpenDialog({
-						title: mainT("dialogs", "fileDialogs.openProject"),
-						defaultPath: RECORDINGS_DIR,
-						filters: [
-							{
-								name: mainT("dialogs", "fileDialogs.openscreenProject"),
-								extensions: [PROJECT_FILE_EXTENSION],
-							},
-							{ name: "JSON", extensions: ["json"] },
-							{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
-						],
-						properties: ["openFile"],
-					});
+			const dialogOptions = buildDialogOptions(
+				{
+					title: mainT("dialogs", "fileDialogs.openProject"),
+					defaultPath: RECORDINGS_DIR,
+					filters: [
+						{
+							name: mainT("dialogs", "fileDialogs.openscreenProject"),
+							extensions: [PROJECT_FILE_EXTENSION],
+						},
+						{ name: "JSON", extensions: ["json"] },
+						{ name: mainT("dialogs", "fileDialogs.allFiles"), extensions: ["*"] },
+					],
+					properties: ["openFile"],
+				},
+				getMainWindow(),
+			);
+			const result = await dialog.showOpenDialog(dialogOptions);
 
 			if (result.canceled || result.filePaths.length === 0) {
 				return { success: false, canceled: true, message: "Open project canceled" };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,18 @@ if (process.platform === "darwin") {
 	app.commandLine.appendSwitch("disable-features", "MacCatapLoopbackAudioForScreenShare");
 }
 
+// Enable Wayland support for proper screen capture and window management
+// on Wayland compositors (Hyprland, GNOME, KDE, etc.)
+if (process.platform === "linux") {
+	const isWayland =
+		process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY !== undefined;
+	if (isWayland) {
+		app.commandLine.appendSwitch("ozone-platform", "wayland");
+		// Enable PipeWire for screen capture on Wayland
+		app.commandLine.appendSwitch("enable-features", "WaylandWindowDrag,PipeWire");
+	}
+}
+
 export const RECORDINGS_DIR = path.join(app.getPath("userData"), "recordings");
 
 async function ensureRecordingsDir() {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,8 +37,8 @@ if (process.platform === "linux") {
 		process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY !== undefined;
 	if (isWayland) {
 		app.commandLine.appendSwitch("ozone-platform", "wayland");
-		// Enable PipeWire for screen capture on Wayland
-		app.commandLine.appendSwitch("enable-features", "WaylandWindowDrag,PipeWire");
+		// Enable WebRTCPipeWireCapturer for screen capture on Wayland
+		app.commandLine.appendSwitch("enable-features", "WaylandWindowDrag,WebRTCPipeWireCapturer");
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"preview": "vite preview",
 		"build:mac": "tsc && vite build && electron-builder --mac",
 		"build:win": "tsc && vite build && electron-builder --win",
-		"build:linux": "tsc && vite build && electron-builder --linux AppImage deb",
+		"build:linux": "tsc && vite build && electron-builder --linux AppImage deb pacman",
 		"test": "vitest --run",
 		"test:watch": "vitest",
 		"build-vite": "tsc && vite build",


### PR DESCRIPTION
- Add pacman package build target for Arch Linux in electron-builder.json5
- Update build:linux script in package.json to include pacman target
- Fix dialog window issues on Wayland/Hyprland:
  * Pass mainWindow reference to dialog.showSaveDialog and dialog.showOpenDialog in electron/ipc/handlers.ts
  * Required for proper dialog functionality on Wayland compositors
  * Previously dialogs opened without parent window attachment causing issues on Hyprland

Changes ensure:
- Correct video export on Arch Linux + Hyprland systems
- Ability to install via pacman package manager
- Improved compatibility with Wayland compositors

<!-- discord-thread-id:1496284958858149919 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Linux builds now also produce Debian (.deb) and Pacman packages in addition to AppImage
  - Improved Wayland support for better window rendering and screen capture

* **Improvements**
  - File open/save dialogs are now attached to the main application window for a more consistent user experience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->