### PR TITLE
Fix/vp8 vp9 codec normalization

### DIFF
--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -390,18 +390,22 @@ export class StreamingVideoDecoder {
 				support.supported,
 			);
 			if (!support.supported) {
-				throw new DOMException(
-					`Unsupported codec: ${preferredDecoderConfig.codec}`,
-					"NotSupportedError",
-				);
+				throw new Error(`Unsupported codec: ${preferredDecoderConfig.codec}`);
 			}
 			this.decoder.configure(preferredDecoderConfig);
 		} catch (error) {
-			if (!shouldPreferSoftwareDecode) {
+			if (shouldPreferSoftwareDecode) {
+				this.decoder.configure(decoderConfig);
+			} else if (/^avc1/i.test(codec)) {
+				const fallback = { ...decoderConfig, codec: "avc1.640033" };
+				console.warn(
+					`[StreamingVideoDecoder] codec "${codec}" unsupported, ` +
+						`falling back to "${fallback.codec}"`,
+				);
+				this.decoder.configure(fallback);
+			} else {
 				throw error;
 			}
-			// Fall back to default decoder config if software preference isn't supported.
-			this.decoder.configure(decoderConfig);
 		}
 
 		const getNextFrame = (): Promise<VideoFrame | null> => {

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -311,8 +311,16 @@ export class StreamingVideoDecoder {
 			);
 		}
 
+		if (/^vp08$/i.test(decoderConfig.codec)) {
+			decoderConfig.codec = "vp8";
+		}
+		if (/^vp09$/i.test(decoderConfig.codec)) {
+			decoderConfig.codec = "vp9";
+		}
+
 		const codec = decoderConfig.codec.toLowerCase();
-		const shouldPreferSoftwareDecode = codec.includes("av01") || codec.includes("av1");
+		const shouldPreferSoftwareDecode =
+			codec.includes("av01") || codec.includes("av1") || codec.includes("vp09");
 		const segments = this.splitBySpeed(
 			this.computeSegments(this.metadata.duration, trimRegions),
 			speedRegions,

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -302,9 +302,12 @@ export class StreamingVideoDecoder {
 
 		const decoderConfig = await this.demuxer.getDecoderConfig("video");
 
-		// web-demuxer may return a bare "av01" for AV1 in WebM containers when the
-		// extradata isn't in the expected ISOBMFF format. WebCodecs requires the
-		// full parametrized form (e.g. "av01.0.05M.08").
+		console.log("[StreamingVideoDecoder] decoderConfig.codec:", decoderConfig.codec);
+		console.log("[StreamingVideoDecoder] decoderConfig.description:", decoderConfig.description);
+
+		// web-demuxer may return bare four-character code strings ("av01", "vp08",
+		// "vp09", "avc1") that WebCodecs rejects. Normalize them to the short or
+		// full parametrized forms that VideoDecoder accepts.
 		if (/^av01$/i.test(decoderConfig.codec)) {
 			decoderConfig.codec = buildAV1CodecString(
 				decoderConfig.description as BufferSource | undefined,
@@ -318,9 +321,19 @@ export class StreamingVideoDecoder {
 			decoderConfig.codec = "vp9";
 		}
 
+		if (/^avc1$/i.test(decoderConfig.codec)) {
+			decoderConfig.codec = "avc1.640033";
+		}
+		if (/^h264$/i.test(decoderConfig.codec)) {
+			decoderConfig.codec = "avc1.640033";
+		}
+
 		const codec = decoderConfig.codec.toLowerCase();
 		const shouldPreferSoftwareDecode =
-			codec.includes("av01") || codec.includes("av1") || codec.includes("vp09");
+			codec.includes("av01") ||
+			codec.includes("av1") ||
+			codec.includes("vp09") ||
+			codec.includes("vp9");
 		const segments = this.splitBySpeed(
 			this.computeSegments(this.metadata.duration, trimRegions),
 			speedRegions,
@@ -351,6 +364,10 @@ export class StreamingVideoDecoder {
 				}
 			},
 			error: (e: DOMException) => {
+				console.warn(
+					`[StreamingVideoDecoder] decoder error for codec "${decoderConfig.codec}":`,
+					e.message,
+				);
 				decodeError = new Error(`VideoDecoder error: ${e.message}`);
 				if (frameResolve) {
 					const resolve = frameResolve;
@@ -367,6 +384,17 @@ export class StreamingVideoDecoder {
 			: decoderConfig;
 
 		try {
+			const support = await VideoDecoder.isConfigSupported(preferredDecoderConfig);
+			console.log(
+				`[StreamingVideoDecoder] isConfigSupported for "${preferredDecoderConfig.codec}":`,
+				support.supported,
+			);
+			if (!support.supported) {
+				throw new DOMException(
+					`Unsupported codec: ${preferredDecoderConfig.codec}`,
+					"NotSupportedError",
+				);
+			}
 			this.decoder.configure(preferredDecoderConfig);
 		} catch (error) {
 			if (!shouldPreferSoftwareDecode) {


### PR DESCRIPTION
## Description

Fixes H.264 video export failing with `"VideoDecoder error: Unknown or ambiguous codec name"` / `"Unsupported codec"`.

## Motivation

When exporting a recording, the `StreamingVideoDecoder` calls `web-demuxer.getDecoderConfig("video")` which returns a `codec` string and an optional `description` (the AVCDecoderConfigurationRecord / `avcC` box). In some cases — particularly WebM containers repaired by `@fix-webm-duration/fix` — the extradata is missing (`description: undefined`), and `web-demuxer` falls back to a malformed codec string like `avc1.2420032`. This string is rejected by Chromium's WebCodecs `VideoDecoder` with `"Unknown or ambiguous codec name"`.

The same root cause can also produce bare four-character code strings (`av01`, `vp08`, `vp09`, `avc1`, `h264`) that lack the full parametrized form WebCodecs requires.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

#500 

## Changes

**`src/lib/exporter/streamingDecoder.ts`**

1. **H.264 codec fallback** — When `VideoDecoder.isConfigSupported()` returns `false` (or `configure()` throws) for a codec string starting with `avc1`, the decoder now falls back to `avc1.640033` (H.264 High Profile Level 5.1, universally supported on Chromium).  
   _Rationale:_ The actual H.264 bitstream profile/level is conveyed in-band via SPS NAL units, so a decode-capable codec string (even a generic one) is sufficient for the decoder to configure itself.

2. **Bare codec string normalization** — Added normalization for four-character code strings returned by `web-demuxer`:
   - `vp08` → `vp8`
   - `vp09` → `vp9`
   - `avc1` → `avc1.640033`
   - `h264` → `avc1.640033`

   These follow the existing `av01` → parametrized AV1 string pattern from PR #334 .

3. **Extended `shouldPreferSoftwareDecode`** — Added `vp09` and `vp9` to the software-decode preference (consistent with AV1, which also benefits from software decode for CPU-intensive codecs).

4. **Diagnostic logging** — Added `console.log` / `console.warn` statements to surface the raw `codec`, `description`, and `isConfigSupported` result at runtime. These can be removed once the fix is stable.

## Testing

1. Check out the `fix/vp8-vp9-codec-normalization` branch
2. Build and run the app (`npm run dev`)
3. Record a screen capture (system must not support H.264 hardware acceleration, or produce a WebM with a malformed codec string)
4. Try to export the recording
5. Verify export completes without `"VideoDecoder error"` or `"Unsupported codec"` in the DevTools console
6. Confirm the output video plays correctly

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- discord-thread-id:1498661518458486965 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced codec support and normalization for VP8, VP9, AVC1, and H.264 formats to improve video playback compatibility
  * Improved error handling with detailed diagnostic information when decoder configuration fails
  * Added validation of decoder configuration before initialization for more reliable playback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->