### PR TITLE
fix: bumped npmDepsHash on package.nix

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,7 +33,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-Pd6J9TuggA9vM4s/LjdoK4MoBEivSzAWc/G2+pFOM2U=";
+  npmDepsHash = "sha256-i8QMhvd/ydFPww7qTG3Bz2LOAIFyp65n1NXakr3MTk8=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Briefly describe the purpose of this PR. -->

Broken nix package.nix

## Motivation
<!-- Explain why this change is needed. What problem does it solve? -->

This fixes it by bumping the sha256 of the npm dependencies.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

## Testing
<!-- Describe how reviewers can test the changes. Include steps, commands, or environment setup. -->

`nix run github#siddharthvaddem/openscreen` should be broken, and when testing local flake should run correctly (or `nix run github#0david0mp/openscreen`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*

<!-- discord-thread-id:1498969261656379472 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependency verification to ensure npm package integrity and build reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->