### PR TITLE
feat: remember last export folder across sessions

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -77,7 +77,13 @@ interface Window {
 			videoData: ArrayBuffer,
 			fileName: string,
 			exportFolder?: string,
-		) => Promise<{ success: boolean; path?: string; message?: string; canceled?: boolean }>;
+		) => Promise<{
+			success: boolean;
+			path?: string;
+			dir?: string;
+			message?: string;
+			canceled?: boolean;
+		}>;
 		openVideoFilePicker: () => Promise<{ success: boolean; path?: string; canceled?: boolean }>;
 		setCurrentVideoPath: (path: string) => Promise<{ success: boolean }>;
 		setCurrentRecordingSession: (

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -76,6 +76,7 @@ interface Window {
 		saveExportedVideo: (
 			videoData: ArrayBuffer,
 			fileName: string,
+			exportFolder?: string,
 		) => Promise<{ success: boolean; path?: string; message?: string; canceled?: boolean }>;
 		openVideoFilePicker: () => Promise<{ success: boolean; path?: string; canceled?: boolean }>;
 		setCurrentVideoPath: (path: string) => Promise<{ success: boolean }>;

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -863,6 +863,7 @@ export function registerIpcHandlers(
 				return {
 					success: true,
 					path: normalizedPath,
+					dir: path.dirname(normalizedPath),
 					message: "Video exported successfully",
 				};
 			} catch (error) {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -822,54 +822,59 @@ export function registerIpcHandlers(
 	 * @returns Object with success status, optional file path, and error details.
 	 */
 
-	ipcMain.handle("save-exported-video", async (_, videoData: ArrayBuffer, fileName: string) => {
-		try {
-			// Determine file type from extension
-			const isGif = fileName.toLowerCase().endsWith(".gif");
-			const filters = isGif
-				? [{ name: mainT("dialogs", "fileDialogs.gifImage"), extensions: ["gif"] }]
-				: [{ name: mainT("dialogs", "fileDialogs.mp4Video"), extensions: ["mp4"] }];
+	ipcMain.handle(
+		"save-exported-video",
+		async (_, videoData: ArrayBuffer, fileName: string, exportFolder?: string) => {
+			try {
+				// Determine file type from extension
+				const isGif = fileName.toLowerCase().endsWith(".gif");
+				const filters = isGif
+					? [{ name: mainT("dialogs", "fileDialogs.gifImage"), extensions: ["gif"] }]
+					: [{ name: mainT("dialogs", "fileDialogs.mp4Video"), extensions: ["mp4"] }];
 
-			const result = await dialog.showSaveDialog({
-				title: isGif
-					? mainT("dialogs", "fileDialogs.saveGif")
-					: mainT("dialogs", "fileDialogs.saveVideo"),
-				defaultPath: path.join(app.getPath("downloads"), fileName),
-				filters,
-				properties: ["createDirectory", "showOverwriteConfirmation"],
-			});
+				const baseFolder = exportFolder ?? app.getPath("downloads");
 
-			if (result.canceled || !result.filePath) {
+				const result = await dialog.showSaveDialog({
+					title: isGif
+						? mainT("dialogs", "fileDialogs.saveGif")
+						: mainT("dialogs", "fileDialogs.saveVideo"),
+					defaultPath: path.join(baseFolder, fileName),
+					filters,
+					properties: ["createDirectory", "showOverwriteConfirmation"],
+				});
+
+				if (result.canceled || !result.filePath) {
+					return {
+						success: false,
+						canceled: true,
+						message: "Export canceled",
+					};
+				}
+
+				// --- FIX: Normalize the path for Windows compatibility ---
+				const normalizedPath = path.normalize(result.filePath);
+
+				// Ensure the parent directory exists (Windows may fail if the folder is missing)
+				await fs.mkdir(path.dirname(normalizedPath), { recursive: true });
+				// --- END FIX ---
+
+				await fs.writeFile(normalizedPath, Buffer.from(videoData));
+
+				return {
+					success: true,
+					path: normalizedPath,
+					message: "Video exported successfully",
+				};
+			} catch (error) {
+				console.error("Failed to save exported video:", error);
 				return {
 					success: false,
-					canceled: true,
-					message: "Export canceled",
+					message: "Failed to save exported video",
+					error: String(error),
 				};
 			}
-
-			// --- FIX: Normalize the path for Windows compatibility ---
-			const normalizedPath = path.normalize(result.filePath);
-
-			// Ensure the parent directory exists (Windows may fail if the folder is missing)
-			await fs.mkdir(path.dirname(normalizedPath), { recursive: true });
-			// --- END FIX ---
-
-			await fs.writeFile(normalizedPath, Buffer.from(videoData));
-
-			return {
-				success: true,
-				path: normalizedPath,
-				message: "Video exported successfully",
-			};
-		} catch (error) {
-			console.error("Failed to save exported video:", error);
-			return {
-				success: false,
-				message: "Failed to save exported video",
-				error: String(error),
-			};
-		}
-	});
+		},
+	);
 	ipcMain.handle("open-video-file-picker", async () => {
 		try {
 			const result = await dialog.showOpenDialog({

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -68,8 +68,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	openExternalUrl: (url: string) => {
 		return ipcRenderer.invoke("open-external-url", url);
 	},
-	saveExportedVideo: (videoData: ArrayBuffer, fileName: string) => {
-		return ipcRenderer.invoke("save-exported-video", videoData, fileName);
+	saveExportedVideo: (videoData: ArrayBuffer, fileName: string, exportFolder?: string) => {
+		return ipcRenderer.invoke("save-exported-video", videoData, fileName, exportFolder);
 	},
 	openVideoFilePicker: () => {
 		return ipcRenderer.invoke("open-video-file-picker");

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -133,6 +133,7 @@ export default function VideoEditor() {
 	const [showNewRecordingDialog, setShowNewRecordingDialog] = useState(false);
 	const [exportQuality, setExportQuality] = useState<ExportQuality>("good");
 	const [exportFormat, setExportFormat] = useState<ExportFormat>("mp4");
+	const [exportFolder, setExportFolder] = useState<string | undefined>(undefined);
 	const [gifFrameRate, setGifFrameRate] = useState<GifFrameRate>(15);
 	const [gifLoop, setGifLoop] = useState(true);
 	const [gifSizePreset, setGifSizePreset] = useState<GifSizePreset>("medium");
@@ -409,14 +410,15 @@ export default function VideoEditor() {
 		});
 		setExportQuality(prefs.exportQuality);
 		setExportFormat(prefs.exportFormat);
+		setExportFolder(prefs.exportFolder);
 		setPrefsHydrated(true);
 	}, [updateState]);
 
 	// Auto-save user preferences when settings change
 	useEffect(() => {
 		if (!prefsHydrated) return;
-		saveUserPreferences({ padding, aspectRatio, exportQuality, exportFormat });
-	}, [prefsHydrated, padding, aspectRatio, exportQuality, exportFormat]);
+		saveUserPreferences({ padding, aspectRatio, exportQuality, exportFormat, exportFolder });
+	}, [prefsHydrated, padding, aspectRatio, exportQuality, exportFormat, exportFolder]);
 
 	const saveProject = useCallback(
 		async (forceSaveAs: boolean) => {
@@ -1309,10 +1311,16 @@ export default function VideoEditor() {
 			const saveResult = await window.electronAPI.saveExportedVideo(
 				unsavedExport.arrayBuffer,
 				unsavedExport.fileName,
+				exportFolder,
 			);
 			if (saveResult.canceled) {
 				toast.info("Export canceled");
 			} else if (saveResult.success && saveResult.path) {
+				const folder = saveResult.path.substring(
+					0,
+					Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
+				);
+				setExportFolder(folder);
 				setUnsavedExport(null);
 				handleExportSaved(unsavedExport.format === "gif" ? "GIF" : "Video", saveResult.path);
 			} else {
@@ -1322,7 +1330,7 @@ export default function VideoEditor() {
 			console.error("Error saving unsaved export:", error);
 			toast.error("Failed to save exported video");
 		}
-	}, [unsavedExport, handleExportSaved]);
+	}, [unsavedExport, exportFolder, handleExportSaved]);
 
 	const handleExport = useCallback(
 		async (settings: ExportSettings) => {
@@ -1410,12 +1418,21 @@ export default function VideoEditor() {
 							}
 						}
 
-						const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
+						const saveResult = await window.electronAPI.saveExportedVideo(
+							arrayBuffer,
+							fileName,
+							exportFolder,
+						);
 
 						if (saveResult.canceled) {
 							setUnsavedExport({ arrayBuffer, fileName, format: "gif" });
 							toast.info("Export canceled");
 						} else if (saveResult.success && saveResult.path) {
+							const folder = saveResult.path.substring(
+								0,
+								Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
+							);
+							setExportFolder(folder);
 							setUnsavedExport(null);
 							handleExportSaved("GIF", saveResult.path);
 						} else {
@@ -1550,12 +1567,21 @@ export default function VideoEditor() {
 							}
 						}
 
-						const saveResult = await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
+						const saveResult = await window.electronAPI.saveExportedVideo(
+							arrayBuffer,
+							fileName,
+							exportFolder,
+						);
 
 						if (saveResult.canceled) {
 							setUnsavedExport({ arrayBuffer, fileName, format: "mp4" });
 							toast.info("Export canceled");
 						} else if (saveResult.success && saveResult.path) {
+							const folder = saveResult.path.substring(
+								0,
+								Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
+							);
+							setExportFolder(folder);
 							setUnsavedExport(null);
 							handleExportSaved("Video", saveResult.path);
 						} else {
@@ -1612,6 +1638,7 @@ export default function VideoEditor() {
 			webcamSizePreset,
 			webcamPosition,
 			exportQuality,
+			exportFolder,
 			handleExportSaved,
 			cursorTelemetry,
 			t,

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1316,11 +1316,7 @@ export default function VideoEditor() {
 			if (saveResult.canceled) {
 				toast.info("Export canceled");
 			} else if (saveResult.success && saveResult.path) {
-				const folder = saveResult.path.substring(
-					0,
-					Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
-				);
-				setExportFolder(folder);
+				if (saveResult.dir) setExportFolder(saveResult.dir);
 				setUnsavedExport(null);
 				handleExportSaved(unsavedExport.format === "gif" ? "GIF" : "Video", saveResult.path);
 			} else {
@@ -1428,11 +1424,7 @@ export default function VideoEditor() {
 							setUnsavedExport({ arrayBuffer, fileName, format: "gif" });
 							toast.info("Export canceled");
 						} else if (saveResult.success && saveResult.path) {
-							const folder = saveResult.path.substring(
-								0,
-								Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
-							);
-							setExportFolder(folder);
+							if (saveResult.dir) setExportFolder(saveResult.dir);
 							setUnsavedExport(null);
 							handleExportSaved("GIF", saveResult.path);
 						} else {
@@ -1577,11 +1569,7 @@ export default function VideoEditor() {
 							setUnsavedExport({ arrayBuffer, fileName, format: "mp4" });
 							toast.info("Export canceled");
 						} else if (saveResult.success && saveResult.path) {
-							const folder = saveResult.path.substring(
-								0,
-								Math.max(saveResult.path.lastIndexOf("/"), saveResult.path.lastIndexOf("\\")),
-							);
-							setExportFolder(folder);
+							if (saveResult.dir) setExportFolder(saveResult.dir);
 							setUnsavedExport(null);
 							handleExportSaved("Video", saveResult.path);
 						} else {

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -23,6 +23,8 @@ export interface UserPreferences {
 	exportQuality: ExportQuality;
 	/** Default export format */
 	exportFormat: ExportFormat;
+	/** Last folder used when saving an export */
+	exportFolder?: string;
 }
 
 const DEFAULT_PREFS: UserPreferences = {
@@ -76,6 +78,10 @@ export function loadUserPreferences(): UserPreferences {
 			raw.exportFormat === "gif" || raw.exportFormat === "mp4"
 				? (raw.exportFormat as ExportFormat)
 				: DEFAULT_PREFS.exportFormat,
+		exportFolder:
+			typeof raw.exportFolder === "string" && raw.exportFolder.length > 0
+				? raw.exportFolder
+				: undefined,
 	};
 }
 


### PR DESCRIPTION
The save dialog now opens in the last folder the user exported to, instead of always defaulting to Downloads. The folder is persisted in userPreferences (localStorage) and passed through the IPC layer to the Electron save dialog as defaultPath.

Closes #503

## What
The export save dialog now opens in the last folder the user chose, 
instead of always defaulting to the Downloads directory.

## How
- Added `exportFolder?: string` to `UserPreferences` — persisted in localStorage
- The saved folder is passed from the renderer to the Electron `save-exported-video` 
  IPC handler as `defaultPath`
- On every successful export (MP4, GIF, or re-save of a canceled export), 
  the chosen folder is extracted from the result path and saved back to preferences


## Type of Change
- [ ] New Feature
- [ X] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
https://github.com/siddharthvaddem/openscreen/issues/503

Tested, and works

<!-- discord-thread-id:1499909365162049536 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now choose a custom export folder when saving video exports; the choice is used as the default for subsequent exports (including GIF/MP4/unsaved exports) and is persisted in preferences.
  * Save results now include the output directory so the app can update and remember the selected folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->