### PR TITLE
feat: replace native OS close dialog with custom in-app dialog

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -143,6 +143,8 @@ interface Window {
 		setMicrophoneExpanded: (expanded: boolean) => void;
 		setHasUnsavedChanges: (hasChanges: boolean) => void;
 		onRequestSaveBeforeClose: (callback: () => Promise<boolean> | boolean) => () => void;
+		onRequestCloseConfirm: (callback: () => void) => () => void;
+		sendCloseConfirmResponse: (choice: "save" | "discard" | "cancel") => void;
 		setLocale: (locale: string) => Promise<void>;
 	};
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -252,6 +252,7 @@ function updateTrayMenu(recording: boolean = false) {
 
 let editorHasUnsavedChanges = false;
 let isForceClosing = false;
+let isCloseConfirmInFlight = false;
 
 ipcMain.on("set-has-unsaved-changes", (_, hasChanges: boolean) => {
 	editorHasUnsavedChanges = hasChanges;
@@ -283,9 +284,10 @@ function createEditorWindowWrapper() {
 	editorHasUnsavedChanges = false;
 
 	mainWindow.on("close", (event) => {
-		if (isForceClosing || !editorHasUnsavedChanges) return;
+		if (isForceClosing || !editorHasUnsavedChanges || isCloseConfirmInFlight) return;
 
 		event.preventDefault();
+		isCloseConfirmInFlight = true;
 
 		const windowToClose = mainWindow;
 		if (!windowToClose || windowToClose.isDestroyed()) return;
@@ -294,6 +296,7 @@ function createEditorWindowWrapper() {
 		windowToClose.webContents.send("request-close-confirm");
 
 		ipcMain.once("close-confirm-response", (_, choice: "save" | "discard" | "cancel") => {
+			isCloseConfirmInFlight = false;
 			if (!windowToClose || windowToClose.isDestroyed()) return;
 
 			if (choice === "save") {
@@ -306,7 +309,7 @@ function createEditorWindowWrapper() {
 			} else if (choice === "discard") {
 				forceCloseEditorWindow(windowToClose);
 			}
-			// "cancel": do nothing, window stays open
+			// "cancel": flag reset, window stays open
 		});
 	});
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 import {
 	app,
 	BrowserWindow,
-	dialog,
 	ipcMain,
 	Menu,
 	nativeImage,
@@ -288,35 +287,27 @@ function createEditorWindowWrapper() {
 
 		event.preventDefault();
 
-		const choice = dialog.showMessageBoxSync(mainWindow!, {
-			type: "warning",
-			buttons: [
-				mainT("dialogs", "unsavedChanges.saveAndClose"),
-				mainT("dialogs", "unsavedChanges.discardAndClose"),
-				mainT("common", "actions.cancel"),
-			],
-			defaultId: 0,
-			cancelId: 2,
-			title: mainT("dialogs", "unsavedChanges.title"),
-			message: mainT("dialogs", "unsavedChanges.message"),
-			detail: mainT("dialogs", "unsavedChanges.detail"),
-		});
-
 		const windowToClose = mainWindow;
 		if (!windowToClose || windowToClose.isDestroyed()) return;
 
-		if (choice === 0) {
-			// Save & Close — tell renderer to save, then close
-			windowToClose.webContents.send("request-save-before-close");
-			ipcMain.once("save-before-close-done", (_, shouldClose: boolean) => {
-				if (!shouldClose) return;
+		// Ask renderer to show the custom in-app dialog
+		windowToClose.webContents.send("request-close-confirm");
+
+		ipcMain.once("close-confirm-response", (_, choice: "save" | "discard" | "cancel") => {
+			if (!windowToClose || windowToClose.isDestroyed()) return;
+
+			if (choice === "save") {
+				// Tell renderer to save the project, then close when done
+				windowToClose.webContents.send("request-save-before-close");
+				ipcMain.once("save-before-close-done", (_, shouldClose: boolean) => {
+					if (!shouldClose) return;
+					forceCloseEditorWindow(windowToClose);
+				});
+			} else if (choice === "discard") {
 				forceCloseEditorWindow(windowToClose);
-			});
-		} else if (choice === 1) {
-			// Discard & Close
-			forceCloseEditorWindow(windowToClose);
-		}
-		// choice === 2: Cancel — do nothing, window stays open
+			}
+			// "cancel": do nothing, window stays open
+		});
 	});
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -295,14 +295,16 @@ function createEditorWindowWrapper() {
 		// Ask renderer to show the custom in-app dialog
 		windowToClose.webContents.send("request-close-confirm");
 
-		ipcMain.once("close-confirm-response", (_, choice: "save" | "discard" | "cancel") => {
+		ipcMain.once("close-confirm-response", (event, choice: "save" | "discard" | "cancel") => {
+			if (event.sender.id !== windowToClose?.webContents.id) return;
 			isCloseConfirmInFlight = false;
 			if (!windowToClose || windowToClose.isDestroyed()) return;
 
 			if (choice === "save") {
 				// Tell renderer to save the project, then close when done
 				windowToClose.webContents.send("request-save-before-close");
-				ipcMain.once("save-before-close-done", (_, shouldClose: boolean) => {
+				ipcMain.once("save-before-close-done", (event, shouldClose: boolean) => {
+					if (event.sender.id !== windowToClose?.webContents.id) return;
 					if (!shouldClose) return;
 					forceCloseEditorWindow(windowToClose);
 				});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -163,4 +163,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		ipcRenderer.on("request-save-before-close", listener);
 		return () => ipcRenderer.removeListener("request-save-before-close", listener);
 	},
+	onRequestCloseConfirm: (callback: () => void) => {
+		const listener = () => callback();
+		ipcRenderer.on("request-close-confirm", listener);
+		return () => ipcRenderer.removeListener("request-close-confirm", listener);
+	},
+	sendCloseConfirmResponse: (choice: "save" | "discard" | "cancel") => {
+		ipcRenderer.send("close-confirm-response", choice);
+	},
 });

--- a/src/components/video-editor/UnsavedChangesDialog.tsx
+++ b/src/components/video-editor/UnsavedChangesDialog.tsx
@@ -1,4 +1,11 @@
-import { Save, Trash2, X } from "lucide-react";
+import { Save, Trash2 } from "lucide-react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { useScopedT } from "@/contexts/I18nContext";
 
 interface UnsavedChangesDialogProps {
@@ -17,41 +24,33 @@ export function UnsavedChangesDialog({
 	const td = useScopedT("dialogs");
 	const tc = useScopedT("common");
 
-	if (!isOpen) return null;
-
 	return (
-		<>
-			<div
-				className="fixed inset-0 bg-black/80 backdrop-blur-md z-50 animate-in fade-in duration-200"
-				onClick={onCancel}
-			/>
-			<div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-6 w-[90vw] max-w-sm animate-in zoom-in-95 duration-200">
-				<div className="flex items-center gap-3 mb-5">
-					<img
-						src="/openscreen.png"
-						alt="OpenScreen"
-						className="w-9 h-9 rounded-xl flex-shrink-0"
-					/>
-					<h2 className="text-base font-semibold text-slate-200 leading-tight">
-						{td("unsavedChanges.title")}
-					</h2>
-					<button
-						type="button"
-						onClick={onCancel}
-						className="ml-auto rounded-full p-1 hover:bg-white/10 text-slate-500 hover:text-slate-300 transition-colors flex-shrink-0"
-					>
-						<X className="w-4 h-4" />
-					</button>
-				</div>
+		<Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+			<DialogContent className="bg-[#09090b] border-white/10 rounded-2xl max-w-sm p-6 gap-0">
+				<DialogHeader className="mb-5">
+					<div className="flex items-center gap-3">
+						<img
+							src="/openscreen.png"
+							alt=""
+							aria-hidden="true"
+							className="w-9 h-9 rounded-xl flex-shrink-0"
+						/>
+						<DialogTitle className="text-base font-semibold text-slate-200 leading-tight">
+							{td("unsavedChanges.title")}
+						</DialogTitle>
+					</div>
+				</DialogHeader>
 
 				<p className="text-sm text-slate-300 mb-1">{td("unsavedChanges.message")}</p>
-				<p className="text-sm text-slate-500 mb-6">{td("unsavedChanges.detail")}</p>
+				<DialogDescription className="text-sm text-slate-500 mb-6">
+					{td("unsavedChanges.detail")}
+				</DialogDescription>
 
 				<div className="flex flex-col gap-2">
 					<button
 						type="button"
 						onClick={onSaveAndClose}
-						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-[#34B27B] hover:bg-[#2d9e6c] active:bg-[#27885c] text-white font-medium text-sm transition-colors"
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-[#34B27B] hover:bg-[#2d9e6c] active:bg-[#27885c] text-white font-medium text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#34B27B] focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]"
 					>
 						<Save className="w-4 h-4" />
 						{td("unsavedChanges.saveAndClose")}
@@ -59,7 +58,7 @@ export function UnsavedChangesDialog({
 					<button
 						type="button"
 						onClick={onDiscardAndClose}
-						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-white/5 hover:bg-red-500/15 border border-white/10 hover:border-red-500/30 text-slate-300 hover:text-red-400 font-medium text-sm transition-colors"
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-white/5 hover:bg-red-500/15 border border-white/10 hover:border-red-500/30 text-slate-300 hover:text-red-400 font-medium text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]"
 					>
 						<Trash2 className="w-4 h-4" />
 						{td("unsavedChanges.discardAndClose")}
@@ -67,12 +66,12 @@ export function UnsavedChangesDialog({
 					<button
 						type="button"
 						onClick={onCancel}
-						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg hover:bg-white/5 text-slate-500 hover:text-slate-300 font-medium text-sm transition-colors"
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg hover:bg-white/5 text-slate-500 hover:text-slate-300 font-medium text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]"
 					>
 						{tc("actions.cancel")}
 					</button>
 				</div>
-			</div>
-		</>
+			</DialogContent>
+		</Dialog>
 	);
 }

--- a/src/components/video-editor/UnsavedChangesDialog.tsx
+++ b/src/components/video-editor/UnsavedChangesDialog.tsx
@@ -7,7 +7,6 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { useScopedT } from "@/contexts/I18nContext";
-import getAssetPath from "@/lib/assetPath";
 
 interface UnsavedChangesDialogProps {
 	isOpen: boolean;
@@ -31,7 +30,7 @@ export function UnsavedChangesDialog({
 				<DialogHeader className="mb-5">
 					<div className="flex items-center gap-3">
 						<img
-							src={getAssetPath("openscreen.png")}
+							src="./openscreen.png"
 							alt=""
 							aria-hidden="true"
 							className="w-9 h-9 rounded-xl flex-shrink-0"

--- a/src/components/video-editor/UnsavedChangesDialog.tsx
+++ b/src/components/video-editor/UnsavedChangesDialog.tsx
@@ -7,6 +7,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { useScopedT } from "@/contexts/I18nContext";
+import getAssetPath from "@/lib/assetPath";
 
 interface UnsavedChangesDialogProps {
 	isOpen: boolean;
@@ -30,7 +31,7 @@ export function UnsavedChangesDialog({
 				<DialogHeader className="mb-5">
 					<div className="flex items-center gap-3">
 						<img
-							src="/openscreen.png"
+							src={getAssetPath("openscreen.png")}
 							alt=""
 							aria-hidden="true"
 							className="w-9 h-9 rounded-xl flex-shrink-0"

--- a/src/components/video-editor/UnsavedChangesDialog.tsx
+++ b/src/components/video-editor/UnsavedChangesDialog.tsx
@@ -1,0 +1,78 @@
+import { Save, Trash2, X } from "lucide-react";
+import { useScopedT } from "@/contexts/I18nContext";
+
+interface UnsavedChangesDialogProps {
+	isOpen: boolean;
+	onSaveAndClose: () => void;
+	onDiscardAndClose: () => void;
+	onCancel: () => void;
+}
+
+export function UnsavedChangesDialog({
+	isOpen,
+	onSaveAndClose,
+	onDiscardAndClose,
+	onCancel,
+}: UnsavedChangesDialogProps) {
+	const td = useScopedT("dialogs");
+	const tc = useScopedT("common");
+
+	if (!isOpen) return null;
+
+	return (
+		<>
+			<div
+				className="fixed inset-0 bg-black/80 backdrop-blur-md z-50 animate-in fade-in duration-200"
+				onClick={onCancel}
+			/>
+			<div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] bg-[#09090b] rounded-2xl shadow-2xl border border-white/10 p-6 w-[90vw] max-w-sm animate-in zoom-in-95 duration-200">
+				<div className="flex items-center gap-3 mb-5">
+					<img
+						src="/openscreen.png"
+						alt="OpenScreen"
+						className="w-9 h-9 rounded-xl flex-shrink-0"
+					/>
+					<h2 className="text-base font-semibold text-slate-200 leading-tight">
+						{td("unsavedChanges.title")}
+					</h2>
+					<button
+						type="button"
+						onClick={onCancel}
+						className="ml-auto rounded-full p-1 hover:bg-white/10 text-slate-500 hover:text-slate-300 transition-colors flex-shrink-0"
+					>
+						<X className="w-4 h-4" />
+					</button>
+				</div>
+
+				<p className="text-sm text-slate-300 mb-1">{td("unsavedChanges.message")}</p>
+				<p className="text-sm text-slate-500 mb-6">{td("unsavedChanges.detail")}</p>
+
+				<div className="flex flex-col gap-2">
+					<button
+						type="button"
+						onClick={onSaveAndClose}
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-[#34B27B] hover:bg-[#2d9e6c] active:bg-[#27885c] text-white font-medium text-sm transition-colors"
+					>
+						<Save className="w-4 h-4" />
+						{td("unsavedChanges.saveAndClose")}
+					</button>
+					<button
+						type="button"
+						onClick={onDiscardAndClose}
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-white/5 hover:bg-red-500/15 border border-white/10 hover:border-red-500/30 text-slate-300 hover:text-red-400 font-medium text-sm transition-colors"
+					>
+						<Trash2 className="w-4 h-4" />
+						{td("unsavedChanges.discardAndClose")}
+					</button>
+					<button
+						type="button"
+						onClick={onCancel}
+						className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg hover:bg-white/5 text-slate-500 hover:text-slate-300 font-medium text-sm transition-colors"
+					>
+						{tc("actions.cancel")}
+					</button>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -74,6 +74,7 @@ import {
 	type ZoomFocusMode,
 	type ZoomRegion,
 } from "./types";
+import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
 import VideoPlayback, { VideoPlaybackRef } from "./VideoPlayback";
 
 export default function VideoEditor() {
@@ -144,6 +145,7 @@ export default function VideoEditor() {
 		format: string;
 	} | null>(null);
 	const [isFullscreen, setIsFullscreen] = useState(false);
+	const [showCloseConfirmDialog, setShowCloseConfirmDialog] = useState(false);
 
 	const playerContainerRef = useRef<HTMLDivElement>(null);
 	const videoPlaybackRef = useRef<VideoPlaybackRef>(null);
@@ -523,6 +525,28 @@ export default function VideoEditor() {
 		});
 		return () => cleanup();
 	}, [saveProject]);
+
+	useEffect(() => {
+		const cleanup = window.electronAPI.onRequestCloseConfirm(() => {
+			setShowCloseConfirmDialog(true);
+		});
+		return () => cleanup();
+	}, []);
+
+	const handleCloseConfirmSave = useCallback(() => {
+		setShowCloseConfirmDialog(false);
+		window.electronAPI.sendCloseConfirmResponse("save");
+	}, []);
+
+	const handleCloseConfirmDiscard = useCallback(() => {
+		setShowCloseConfirmDialog(false);
+		window.electronAPI.sendCloseConfirmResponse("discard");
+	}, []);
+
+	const handleCloseConfirmCancel = useCallback(() => {
+		setShowCloseConfirmDialog(false);
+		window.electronAPI.sendCloseConfirmResponse("cancel");
+	}, []);
 
 	const handleSaveProject = useCallback(async () => {
 		await saveProject(false);
@@ -2065,6 +2089,13 @@ export default function VideoEditor() {
 				onShowInFolder={
 					exportedFilePath ? () => void handleShowExportedFile(exportedFilePath) : undefined
 				}
+			/>
+
+			<UnsavedChangesDialog
+				isOpen={showCloseConfirmDialog}
+				onSaveAndClose={handleCloseConfirmSave}
+				onDiscardAndClose={handleCloseConfirmDiscard}
+				onCancel={handleCloseConfirmCancel}
 			/>
 		</div>
 	);


### PR DESCRIPTION
Closes #520 

<img width="2108" height="1207" alt="SaveDialog" src="https://github.com/user-attachments/assets/0165f3e0-fa03-44ab-b440-da83049eb7e6" />


Replaces dialog.showMessageBoxSync in the main process with a custom React dialog rendered inside the Electron window.

### What changed

**electron/main.ts** — close event now sends request-close-confirm IPC to the renderer instead of calling the native dialog
**electron/preload.ts + electron/electron-env.d.ts** — two new bridge functions: onRequestCloseConfirm and sendCloseConfirmResponse
**UnsavedChangesDialog.tsx** — new component matching the app's dark theme, with the app logo and the same three actions
**VideoEditor.tsx** — registers the IPC listener and wires up the dialog state

### What didn't change

The three-action behavior is identical — Save & Close still triggers the existing request-save-before-close / save-before-close-done flow, Discard still force-closes, Cancel keeps the window open. No functional changes.

Tested on Windows — all three actions verified including the save flow.

<!-- discord-thread-id:1500086390174646272 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app unsaved-changes confirmation dialog with Save, Discard, and Cancel actions when closing the editor.
  * Dialog uses localized text, imagery, and full-width action buttons for clarity.

* **Bug Fixes**
  * Editor close flow updated to use the in-app confirmation sequence to improve save-before-close reliability and avoid blocking native prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->