### PR TITLE
Harden Electron renderer security

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const nodeRequire = createRequire(import.meta.url);
 
@@ -11,6 +11,8 @@ import {
 	desktopCapturer,
 	dialog,
 	ipcMain,
+	net,
+	protocol,
 	screen,
 	shell,
 	systemPreferences,
@@ -33,6 +35,7 @@ const PROJECT_FILE_EXTENSION = "openscreen";
 const SHORTCUTS_FILE = path.join(app.getPath("userData"), "shortcuts.json");
 const RECORDING_SESSION_SUFFIX = ".session.json";
 const ALLOWED_IMPORT_VIDEO_EXTENSIONS = new Set([".webm", ".mp4", ".mov", ".avi", ".mkv"]);
+const LOCAL_MEDIA_PROTOCOL = "openscreen-media";
 
 /**
  * Paths explicitly approved by the user via file picker dialogs or project loads.
@@ -77,6 +80,41 @@ function buildDialogOptions<T extends Electron.OpenDialogOptions | Electron.Save
 
 function hasAllowedImportVideoExtension(filePath: string): boolean {
 	return ALLOWED_IMPORT_VIDEO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+let localMediaProtocolRegistered = false;
+
+function parseLocalMediaPath(url: string): string | null {
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== `${LOCAL_MEDIA_PROTOCOL}:` || parsed.hostname !== "local") {
+			return null;
+		}
+		const encodedPath = parsed.pathname.replace(/^\/+/, "");
+		return encodedPath ? decodeURIComponent(encodedPath) : null;
+	} catch {
+		return null;
+	}
+}
+
+function registerLocalMediaProtocol() {
+	if (localMediaProtocolRegistered) return;
+
+	protocol.handle(LOCAL_MEDIA_PROTOCOL, async (request) => {
+		const requestedPath = parseLocalMediaPath(request.url);
+		const normalizedPath = normalizeVideoSourcePath(requestedPath);
+
+		if (
+			!normalizedPath ||
+			!isPathAllowed(normalizedPath) ||
+			!hasAllowedImportVideoExtension(normalizedPath)
+		) {
+			return new Response("Not found", { status: 404 });
+		}
+
+		return net.fetch(pathToFileURL(normalizedPath).toString());
+	});
+	localMediaProtocolRegistered = true;
 }
 
 async function approveReadableVideoPath(
@@ -486,6 +524,8 @@ export function registerIpcHandlers(
 	onRecordingStateChange?: (recording: boolean, sourceName: string) => void,
 	switchToHud?: () => void,
 ) {
+	registerLocalMediaProtocol();
+
 	const supportsWindowOpacity = process.platform !== "linux";
 	const countdownOverlayState = {
 		visible: false,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -82,10 +82,46 @@ let tray: Tray | null = null;
 let selectedSourceName = "";
 const isMac = process.platform === "darwin";
 const trayIconSize = isMac ? 16 : 24;
+const ALLOWED_MEDIA_PERMISSIONS = new Set([
+	"media",
+	"audioCapture",
+	"microphone",
+	"videoCapture",
+	"camera",
+]);
 
 // Tray Icons
 const defaultTrayIcon = getTrayIcon("openscreen.png", trayIconSize);
 const recordingTrayIcon = getTrayIcon("rec-button.png", trayIconSize);
+
+function isTrustedRendererUrl(url: string) {
+	if (!url) return false;
+
+	try {
+		const parsed = new URL(url);
+
+		if (VITE_DEV_SERVER_URL) {
+			return parsed.origin === new URL(VITE_DEV_SERVER_URL).origin;
+		}
+
+		if (parsed.protocol !== "file:") {
+			return false;
+		}
+
+		return path.normalize(fileURLToPath(parsed)) === path.join(RENDERER_DIST, "index.html");
+	} catch {
+		return false;
+	}
+}
+
+function isTrustedMediaPermissionRequest(
+	webContents: Electron.WebContents | null | undefined,
+	permission: string,
+) {
+	return (
+		ALLOWED_MEDIA_PERMISSIONS.has(permission) && isTrustedRendererUrl(webContents?.getURL() ?? "")
+	);
+}
 
 function createWindow() {
 	mainWindow = createHudOverlayWindow();
@@ -377,15 +413,13 @@ app.on("activate", () => {
 
 // Register all IPC handlers when app is ready
 app.whenReady().then(async () => {
-	// Allow microphone/media permission checks
-	session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
-		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];
-		return allowed.includes(permission);
-	});
+	// Allow capture permissions only for first-party renderer windows.
+	session.defaultSession.setPermissionCheckHandler((webContents, permission) =>
+		isTrustedMediaPermissionRequest(webContents, permission),
+	);
 
-	session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];
-		callback(allowed.includes(permission));
+	session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+		callback(isTrustedMediaPermissionRequest(webContents, permission));
 	});
 
 	// Request microphone permission from macOS

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import {
 	ipcMain,
 	Menu,
 	nativeImage,
+	protocol,
 	session,
 	systemPreferences,
 	Tray,
@@ -88,6 +89,19 @@ const ALLOWED_MEDIA_PERMISSIONS = new Set([
 	"microphone",
 	"videoCapture",
 	"camera",
+]);
+const LOCAL_MEDIA_PROTOCOL = "openscreen-media";
+
+protocol.registerSchemesAsPrivileged([
+	{
+		scheme: LOCAL_MEDIA_PROTOCOL,
+		privileges: {
+			standard: true,
+			secure: true,
+			stream: true,
+			supportFetchAPI: true,
+		},
+	},
 ]);
 
 // Tray Icons

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { BrowserWindow, ipcMain, screen } from "electron";
+import { BrowserWindow, ipcMain, screen, shell } from "electron";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,8 +15,58 @@ const ASSET_BASE_DIR = process.defaultApp
 	? path.join(__dirname, "..", "public")
 	: process.resourcesPath;
 const ASSET_BASE_URL_ARG = `--asset-base-url=${pathToFileURL(`${ASSET_BASE_DIR}${path.sep}`).toString()}`;
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
 
 let hudOverlayWindow: BrowserWindow | null = null;
+
+function isRendererAppUrl(url: string) {
+	if (!url) return false;
+
+	try {
+		const parsed = new URL(url);
+
+		if (parsed.protocol === "about:") {
+			return parsed.href === "about:blank";
+		}
+
+		if (VITE_DEV_SERVER_URL) {
+			return parsed.origin === new URL(VITE_DEV_SERVER_URL).origin;
+		}
+
+		if (parsed.protocol !== "file:") {
+			return false;
+		}
+
+		return path.normalize(fileURLToPath(parsed)) === path.join(RENDERER_DIST, "index.html");
+	} catch {
+		return false;
+	}
+}
+
+function openExternalUrl(url: string) {
+	try {
+		const parsed = new URL(url);
+		if (ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+			void shell.openExternal(parsed.toString());
+		}
+	} catch {
+		// Ignore malformed renderer-supplied URLs.
+	}
+}
+
+function configureNavigationGuards(win: BrowserWindow) {
+	win.webContents.setWindowOpenHandler(({ url }) => {
+		openExternalUrl(url);
+		return { action: "deny" };
+	});
+
+	win.webContents.on("will-navigate", (event, url) => {
+		if (isRendererAppUrl(url)) return;
+
+		event.preventDefault();
+		openExternalUrl(url);
+	});
+}
 
 ipcMain.on("hud-overlay-hide", () => {
 	if (hudOverlayWindow && !hudOverlayWindow.isDestroyed()) {
@@ -63,6 +113,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 			backgroundThrottling: false,
 		},
 	});
+	configureNavigationGuards(win);
 
 	// Follow the user across macOS Spaces (virtual desktops).
 	// Without this the HUD stays pinned to the Space it was first opened on.
@@ -121,10 +172,10 @@ export function createEditorWindow(): BrowserWindow {
 			additionalArguments: [ASSET_BASE_URL_ARG],
 			nodeIntegration: false,
 			contextIsolation: true,
-			webSecurity: false,
 			backgroundThrottling: false,
 		},
 	});
+	configureNavigationGuards(win);
 
 	// Maximize the window by default
 	win.maximize();
@@ -170,6 +221,7 @@ export function createSourceSelectorWindow(): BrowserWindow {
 			contextIsolation: true,
 		},
 	});
+	configureNavigationGuards(win);
 
 	// Follow the user across macOS Spaces so the selector appears on the
 	// active desktop regardless of where the HUD was originally opened.
@@ -223,6 +275,7 @@ export function createCountdownOverlayWindow(): BrowserWindow {
 			backgroundThrottling: false,
 		},
 	});
+	configureNavigationGuards(win);
 
 	win.setIgnoreMouseEvents(true);
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: file: https: http:; media-src 'self' data: blob: file: https: http:; font-src 'self' data: https://fonts.gstatic.com; worker-src 'self' blob:; connect-src 'self' data: blob: file: https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*"
+    />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: file: https: http:; media-src 'self' data: blob: file: https: http:; font-src 'self' data: https://fonts.gstatic.com; worker-src 'self' blob:; connect-src 'self' data: blob: file: https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: file: https: http:; media-src 'self' data: blob: file: openscreen-media: https: http:; font-src 'self' data: https://fonts.gstatic.com; worker-src 'self' blob:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*"
     />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -78,6 +78,7 @@ import {
 } from "./videoPlayback/zoomTransform";
 
 const REMOTE_MEDIA_URL_RE = /^(https?:|blob:|data:)/i;
+const LOCAL_MEDIA_PROTOCOL = "openscreen-media";
 
 function getReadableMediaPath(mediaPath: string): string | null {
 	if (!mediaPath || REMOTE_MEDIA_URL_RE.test(mediaPath)) {
@@ -91,16 +92,19 @@ function getReadableMediaPath(mediaPath: string): string | null {
 	return mediaPath;
 }
 
-function getVideoMimeType(mediaPath: string): string {
-	const lowerPath = mediaPath.toLowerCase();
-	if (lowerPath.endsWith(".mp4")) return "video/mp4";
-	if (lowerPath.endsWith(".mov")) return "video/quicktime";
-	if (lowerPath.endsWith(".webm")) return "video/webm";
-	return "application/octet-stream";
+function getPlayableMediaPath(mediaPath: string): string {
+	const readablePath = getReadableMediaPath(mediaPath);
+	if (!readablePath) {
+		return mediaPath;
+	}
+
+	return `${LOCAL_MEDIA_PROTOCOL}://local/${encodeURIComponent(readablePath)}`;
 }
 
 function usePlayableMediaUrl(mediaPath?: string): string | undefined {
-	const [playableUrl, setPlayableUrl] = useState(mediaPath);
+	const [playableUrl, setPlayableUrl] = useState<string | undefined>(() =>
+		mediaPath ? getPlayableMediaPath(mediaPath) : undefined,
+	);
 
 	useEffect(() => {
 		if (!mediaPath) {
@@ -108,38 +112,7 @@ function usePlayableMediaUrl(mediaPath?: string): string | undefined {
 			return;
 		}
 
-		const readablePath = getReadableMediaPath(mediaPath);
-		if (!readablePath || !window.electronAPI?.readBinaryFile) {
-			setPlayableUrl(mediaPath);
-			return;
-		}
-		const localPath = readablePath;
-
-		let canceled = false;
-		let objectUrl: string | null = null;
-
-		async function loadLocalMedia() {
-			const result = await window.electronAPI.readBinaryFile(localPath);
-			if (canceled) return;
-
-			if (!result.success || !result.data) {
-				setPlayableUrl(mediaPath);
-				return;
-			}
-
-			const blob = new Blob([result.data], { type: getVideoMimeType(localPath) });
-			objectUrl = URL.createObjectURL(blob);
-			setPlayableUrl(objectUrl);
-		}
-
-		void loadLocalMedia();
-
-		return () => {
-			canceled = true;
-			if (objectUrl) {
-				URL.revokeObjectURL(objectUrl);
-			}
-		};
+		setPlayableUrl(getPlayableMediaPath(mediaPath));
 	}, [mediaPath]);
 
 	return playableUrl;

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -33,6 +33,7 @@ import {
 	getNativeAspectRatioValue,
 } from "@/utils/aspectRatioUtils";
 import { AnnotationOverlay } from "./AnnotationOverlay";
+import { fromFileUrl } from "./projectPersistence";
 import {
 	type AnnotationRegion,
 	type BlurData,
@@ -78,28 +79,13 @@ import {
 
 const REMOTE_MEDIA_URL_RE = /^(https?:|blob:|data:)/i;
 
-function fileUrlToPath(fileUrl: string): string {
-	const url = new URL(fileUrl);
-	const pathname = decodeURIComponent(url.pathname);
-
-	if (url.host && url.host !== "localhost") {
-		return `//${url.host}${pathname}`;
-	}
-
-	return pathname;
-}
-
 function getReadableMediaPath(mediaPath: string): string | null {
 	if (!mediaPath || REMOTE_MEDIA_URL_RE.test(mediaPath)) {
 		return null;
 	}
 
 	if (/^file:\/\//i.test(mediaPath)) {
-		try {
-			return fileUrlToPath(mediaPath);
-		} catch {
-			return null;
-		}
+		return fromFileUrl(mediaPath);
 	}
 
 	return mediaPath;

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -76,6 +76,89 @@ import {
 	type MotionBlurState,
 } from "./videoPlayback/zoomTransform";
 
+const REMOTE_MEDIA_URL_RE = /^(https?:|blob:|data:)/i;
+
+function fileUrlToPath(fileUrl: string): string {
+	const url = new URL(fileUrl);
+	const pathname = decodeURIComponent(url.pathname);
+
+	if (url.host && url.host !== "localhost") {
+		return `//${url.host}${pathname}`;
+	}
+
+	return pathname;
+}
+
+function getReadableMediaPath(mediaPath: string): string | null {
+	if (!mediaPath || REMOTE_MEDIA_URL_RE.test(mediaPath)) {
+		return null;
+	}
+
+	if (/^file:\/\//i.test(mediaPath)) {
+		try {
+			return fileUrlToPath(mediaPath);
+		} catch {
+			return null;
+		}
+	}
+
+	return mediaPath;
+}
+
+function getVideoMimeType(mediaPath: string): string {
+	const lowerPath = mediaPath.toLowerCase();
+	if (lowerPath.endsWith(".mp4")) return "video/mp4";
+	if (lowerPath.endsWith(".mov")) return "video/quicktime";
+	if (lowerPath.endsWith(".webm")) return "video/webm";
+	return "application/octet-stream";
+}
+
+function usePlayableMediaUrl(mediaPath?: string): string | undefined {
+	const [playableUrl, setPlayableUrl] = useState(mediaPath);
+
+	useEffect(() => {
+		if (!mediaPath) {
+			setPlayableUrl(undefined);
+			return;
+		}
+
+		const readablePath = getReadableMediaPath(mediaPath);
+		if (!readablePath || !window.electronAPI?.readBinaryFile) {
+			setPlayableUrl(mediaPath);
+			return;
+		}
+		const localPath = readablePath;
+
+		let canceled = false;
+		let objectUrl: string | null = null;
+
+		async function loadLocalMedia() {
+			const result = await window.electronAPI.readBinaryFile(localPath);
+			if (canceled) return;
+
+			if (!result.success || !result.data) {
+				setPlayableUrl(mediaPath);
+				return;
+			}
+
+			const blob = new Blob([result.data], { type: getVideoMimeType(localPath) });
+			objectUrl = URL.createObjectURL(blob);
+			setPlayableUrl(objectUrl);
+		}
+
+		void loadLocalMedia();
+
+		return () => {
+			canceled = true;
+			if (objectUrl) {
+				URL.revokeObjectURL(objectUrl);
+			}
+		};
+	}, [mediaPath]);
+
+	return playableUrl;
+}
+
 interface VideoPlaybackProps {
 	videoPath: string;
 	webcamVideoPath?: string;
@@ -250,6 +333,8 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const videoReadyRafRef = useRef<number | null>(null);
 		const smoothedAutoFocusRef = useRef<ZoomFocus | null>(null);
 		const prevTargetProgressRef = useRef(0);
+		const playableVideoPath = usePlayableMediaUrl(videoPath);
+		const playableWebcamVideoPath = usePlayableMediaUrl(webcamVideoPath);
 
 		const clampFocusToStage = useCallback((focus: ZoomFocus, depth: ZoomDepth) => {
 			return clampFocusToStageUtil(focus, depth, stageSizeRef.current);
@@ -1184,7 +1269,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 
 		useEffect(() => {
 			const webcamVideo = webcamVideoRef.current;
-			if (!webcamVideo || !webcamVideoPath) {
+			if (!webcamVideo || !playableWebcamVideoPath) {
 				setWebcamDimensions(null);
 				return;
 			}
@@ -1203,11 +1288,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			return () => {
 				webcamVideo.removeEventListener("loadedmetadata", handleLoadedMetadata);
 			};
-		}, [webcamVideoPath]);
+		}, [playableWebcamVideoPath]);
 
 		useEffect(() => {
 			const webcamVideo = webcamVideoRef.current;
-			if (!webcamVideo || !webcamVideoPath) {
+			if (!webcamVideo || !playableWebcamVideoPath) {
 				return;
 			}
 
@@ -1232,17 +1317,17 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			webcamVideo.play().catch(() => {
 				// Ignore webcam autoplay restoration failures.
 			});
-		}, [currentTime, isPlaying, speedRegions, webcamVideoPath]);
+		}, [currentTime, isPlaying, speedRegions, playableWebcamVideoPath]);
 
 		useEffect(() => {
 			const webcamVideo = webcamVideoRef.current;
-			if (!webcamVideo || !webcamVideoPath) {
+			if (!webcamVideo || !playableWebcamVideoPath) {
 				return;
 			}
 
 			webcamVideo.pause();
 			webcamVideo.currentTime = 0;
-		}, [webcamVideoPath]);
+		}, [playableWebcamVideoPath]);
 
 		useEffect(() => {
 			return () => {
@@ -1303,7 +1388,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								: "none",
 					}}
 				/>
-				{webcamVideoPath &&
+				{playableWebcamVideoPath &&
 					(() => {
 						const clipPath = getCssClipPath(webcamLayout?.maskShape ?? "rectangle");
 						const useClipPath = !!clipPath;
@@ -1325,7 +1410,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 							>
 								<video
 									ref={webcamVideoRef}
-									src={webcamVideoPath}
+									src={playableWebcamVideoPath}
 									className={`w-full h-full object-cover ${webcamLayoutPreset === "picture-in-picture" ? "cursor-grab active:cursor-grabbing" : "pointer-events-none"}`}
 									style={{
 										borderRadius: useClipPath ? 0 : (webcamLayout?.borderRadius ?? 0),
@@ -1479,7 +1564,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				)}
 				<video
 					ref={videoRef}
-					src={videoPath}
+					src={playableVideoPath}
 					className="hidden"
 					preload="metadata"
 					playsInline

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	createProjectData,
 	createProjectSnapshot,
+	fromFileUrl,
 	hasProjectUnsavedChanges,
 	normalizeProjectEditor,
 	PROJECT_VERSION,
@@ -159,6 +160,18 @@ describe("projectPersistence media compatibility", () => {
 				webcamPosition: { cx: 0.2, cy: 0.8 },
 			}).webcamPosition,
 		).toBeNull();
+	});
+});
+
+describe("fromFileUrl", () => {
+	it("preserves Windows drive letters", () => {
+		expect(fromFileUrl("file:///C:/Users/me/Videos/capture.webm")).toBe(
+			"C:/Users/me/Videos/capture.webm",
+		);
+	});
+
+	it("preserves UNC hosts", () => {
+		expect(fromFileUrl("file://server/share/capture.webm")).toBe("//server/share/capture.webm");
 	});
 });
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -408,6 +408,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		}
 	});
 
+	const safeHideCountdownOverlay = useCallback(async (runId: number) => {
+		try {
+			await window.electronAPI.hideCountdownOverlay(runId);
+		} catch (error) {
+			console.warn("Failed to hide countdown overlay:", error);
+		}
+	}, []);
+
 	useEffect(() => {
 		let cleanup: (() => void) | undefined;
 
@@ -450,7 +458,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			webcamRecorder.current = null;
 			teardownMedia();
 		};
-	}, [teardownMedia]);
+	}, [teardownMedia, safeHideCountdownOverlay]);
 
 	const safeShowCountdownOverlay = async (value: number, runId: number) => {
 		try {
@@ -474,14 +482,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			await window.electronAPI.setCountdownOverlayValue(value, runId);
 		} catch (error) {
 			console.warn("Failed to update countdown overlay value:", error);
-		}
-	};
-
-	const safeHideCountdownOverlay = async (runId: number) => {
-		try {
-			await window.electronAPI.hideCountdownOverlay(runId);
-		} catch (error) {
-			console.warn("Failed to hide countdown overlay:", error);
 		}
 	};
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "pixi.js/unsafe-eval";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";

--- a/tests/e2e/gif-export.spec.ts
+++ b/tests/e2e/gif-export.spec.ts
@@ -2,12 +2,40 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { _electron as electron, expect, test } from "@playwright/test";
+import { type ElectronApplication, _electron as electron, expect, test } from "@playwright/test";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "../..");
 const MAIN_JS = path.join(ROOT, "dist-electron/main.js");
 const TEST_VIDEO = path.join(__dirname, "../fixtures/sample.webm");
+
+async function waitForProcessExit(
+	child: ReturnType<ElectronApplication["process"]>,
+	timeoutMs: number,
+) {
+	if (child.exitCode !== null || child.killed) return;
+
+	await Promise.race([
+		new Promise<void>((resolve) => child.once("exit", () => resolve())),
+		new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+	]);
+}
+
+async function closeElectronApp(app: ElectronApplication) {
+	const child = app.process();
+	await app
+		.evaluate(({ app: electronApp }) => {
+			electronApp.exit(0);
+		})
+		.catch(() => {
+			// App may already be closing.
+		});
+	await waitForProcessExit(child, 2_000);
+	if (child.exitCode === null && !child.killed) {
+		child.kill("SIGKILL");
+		await waitForProcessExit(child, 2_000);
+	}
+}
 
 test("exports a GIF from a loaded video", async () => {
 	const outputPath = path.join(os.tmpdir(), `test-gif-export-${Date.now()}.gif`);
@@ -126,7 +154,7 @@ test("exports a GIF from a loaded video", async () => {
 		const stats = fs.statSync(outputPath);
 		expect(stats.size).toBeGreaterThan(1024); // at least 1 KB
 	} finally {
-		await app.close();
+		await closeElectronApp(app);
 		if (fs.existsSync(outputPath)) {
 			fs.unlinkSync(outputPath);
 		}


### PR DESCRIPTION
## Summary
- add a renderer CSP and keep Pixi/GIF export compatibility under it
- remove disabled web security from the editor window
- restrict capture permissions and block untrusted renderer navigation/window opens
- load local preview media through the existing file-read bridge so file access still works with web security enabled
- make the Electron GIF e2e close path deterministic

## Testing
- npm run lint
- npx tsc --noEmit
- npm run test:browser
- npm run build-vite
- npm run test:e2e

<!-- discord-thread-id:1500606637243633816 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Media permissions restricted to verified app origins
  * Stricter Content Security Policy for the renderer
  * Window creation and external navigation limited to trusted targets

* **New Features**
  * Local media protocol added for secure local playback

* **Bug Fixes**
  * Improved local video playback and webcam PiP handling
  * More reliable countdown overlay teardown in screen recording flows
  * Pixi runtime import adjusted for app behavior

* **Tests**
  * Deterministic Electron test shutdown and added file-URL conversion tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->