### PR TITLE
Upload Electron E2E failure artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,26 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx vite build
+
+  electron-e2e:
+    name: Electron E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build-vite
+      - run: npx playwright install --with-deps
+      - run: xvfb-run -a npm run test:e2e
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-e2e-artifacts
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -408,6 +408,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		}
 	});
 
+	const safeHideCountdownOverlay = useCallback(async (runId: number) => {
+		try {
+			await window.electronAPI.hideCountdownOverlay(runId);
+		} catch (error) {
+			console.warn("Failed to hide countdown overlay:", error);
+		}
+	}, []);
+
 	useEffect(() => {
 		let cleanup: (() => void) | undefined;
 
@@ -450,7 +458,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			webcamRecorder.current = null;
 			teardownMedia();
 		};
-	}, [teardownMedia]);
+	}, [teardownMedia, safeHideCountdownOverlay]);
 
 	const safeShowCountdownOverlay = async (value: number, runId: number) => {
 		try {
@@ -474,14 +482,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			await window.electronAPI.setCountdownOverlayValue(value, runId);
 		} catch (error) {
 			console.warn("Failed to update countdown overlay value:", error);
-		}
-	};
-
-	const safeHideCountdownOverlay = async (runId: number) => {
-		try {
-			await window.electronAPI.hideCountdownOverlay(runId);
-		} catch (error) {
-			console.warn("Failed to hide countdown overlay:", error);
 		}
 	};
 

--- a/tests/e2e/gif-export.spec.ts
+++ b/tests/e2e/gif-export.spec.ts
@@ -2,12 +2,40 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { _electron as electron, expect, test } from "@playwright/test";
+import { type ElectronApplication, _electron as electron, expect, test } from "@playwright/test";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "../..");
 const MAIN_JS = path.join(ROOT, "dist-electron/main.js");
 const TEST_VIDEO = path.join(__dirname, "../fixtures/sample.webm");
+
+async function waitForProcessExit(
+	child: ReturnType<ElectronApplication["process"]>,
+	timeoutMs: number,
+) {
+	if (child.exitCode !== null || child.killed) return;
+
+	await Promise.race([
+		new Promise<void>((resolve) => child.once("exit", () => resolve())),
+		new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+	]);
+}
+
+async function closeElectronApp(app: ElectronApplication) {
+	const child = app.process();
+	await app
+		.evaluate(({ app: electronApp }) => {
+			electronApp.exit(0);
+		})
+		.catch(() => {
+			// App may already be closing.
+		});
+	await waitForProcessExit(child, 2_000);
+	if (child.exitCode === null && !child.killed) {
+		child.kill("SIGKILL");
+		await waitForProcessExit(child, 2_000);
+	}
+}
 
 test("exports a GIF from a loaded video", async () => {
 	const outputPath = path.join(os.tmpdir(), `test-gif-export-${Date.now()}.gif`);
@@ -126,7 +154,7 @@ test("exports a GIF from a loaded video", async () => {
 		const stats = fs.statSync(outputPath);
 		expect(stats.size).toBeGreaterThan(1024); // at least 1 KB
 	} finally {
-		await app.close();
+		await closeElectronApp(app);
 		if (fs.existsSync(outputPath)) {
 			fs.unlinkSync(outputPath);
 		}

--- a/tests/e2e/gif-export.spec.ts
+++ b/tests/e2e/gif-export.spec.ts
@@ -13,24 +13,24 @@ async function waitForProcessExit(
 	child: ReturnType<ElectronApplication["process"]>,
 	timeoutMs: number,
 ) {
-	if (child.exitCode !== null) return;
+	if (child.exitCode !== null) return true;
 
-	await new Promise<void>((resolve) => {
+	return new Promise<boolean>((resolve) => {
 		let timer: ReturnType<typeof setTimeout>;
 		const cleanup = () => {
 			clearTimeout(timer);
 			child.removeListener("exit", onExit);
 		};
-		const finish = () => {
+		const finish = (exited: boolean) => {
 			cleanup();
-			resolve();
+			resolve(exited);
 		};
-		const onExit = () => finish();
-		const onTimeout = () => finish();
+		const onExit = () => finish(true);
+		const onTimeout = () => finish(false);
 
 		timer = setTimeout(onTimeout, timeoutMs);
 		child.once("exit", onExit);
-		if (child.exitCode !== null) finish();
+		if (child.exitCode !== null) finish(true);
 	});
 }
 
@@ -43,10 +43,15 @@ async function closeElectronApp(app: ElectronApplication) {
 		.catch(() => {
 			// App may already be closing.
 		});
-	await waitForProcessExit(child, 2_000);
+	const exited = await waitForProcessExit(child, 2_000);
 	if (child.exitCode === null) {
 		child.kill("SIGKILL");
-		await waitForProcessExit(child, 2_000);
+		const killed = await waitForProcessExit(child, 2_000);
+		if (!killed) {
+			throw new Error("Electron process did not exit after SIGKILL");
+		}
+	} else if (!exited) {
+		throw new Error("Electron process exit timed out");
 	}
 }
 

--- a/tests/e2e/gif-export.spec.ts
+++ b/tests/e2e/gif-export.spec.ts
@@ -13,12 +13,25 @@ async function waitForProcessExit(
 	child: ReturnType<ElectronApplication["process"]>,
 	timeoutMs: number,
 ) {
-	if (child.exitCode !== null || child.killed) return;
+	if (child.exitCode !== null) return;
 
-	await Promise.race([
-		new Promise<void>((resolve) => child.once("exit", () => resolve())),
-		new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
-	]);
+	await new Promise<void>((resolve) => {
+		let timer: ReturnType<typeof setTimeout>;
+		const cleanup = () => {
+			clearTimeout(timer);
+			child.removeListener("exit", onExit);
+		};
+		const finish = () => {
+			cleanup();
+			resolve();
+		};
+		const onExit = () => finish();
+		const onTimeout = () => finish();
+
+		timer = setTimeout(onTimeout, timeoutMs);
+		child.once("exit", onExit);
+		if (child.exitCode !== null) finish();
+	});
 }
 
 async function closeElectronApp(app: ElectronApplication) {
@@ -31,7 +44,7 @@ async function closeElectronApp(app: ElectronApplication) {
 			// App may already be closing.
 		});
 	await waitForProcessExit(child, 2_000);
-	if (child.exitCode === null && !child.killed) {
+	if (child.exitCode === null) {
 		child.kill("SIGKILL");
 		await waitForProcessExit(child, 2_000);
 	}


### PR DESCRIPTION
## Summary
- add an Electron E2E CI job for the Playwright app test
- upload Playwright test-results and report artifacts when Electron E2E fails
- make Electron app shutdown deterministic in the GIF E2E test
- fix the linted hook dependency used by CI

## Testing
- npm run lint
- npm run build-vite
- npm run test:e2e
- npm run test:browser

<!-- discord-thread-id:1500607383737471126 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds the app and runs Electron end-to-end tests for improved release reliability; test artifacts are uploaded on failures.

* **Bug Fixes**
  * Improved error handling to reliably hide the countdown overlay during cleanup.

* **Tests**
  * Stabilized end-to-end tests with deterministic Electron process shutdown and more reliable test result collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->