### PR TITLE
fix(i18n): add missing zoom.threeD translation keys for 7 locales

### DIFF
--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -8,6 +8,14 @@
 			"manual": "Manual",
 			"auto": "Auto",
 			"autoDescription": "La cámara sigue la posición del cursor grabado"
+		},
+		"threeD": {
+			"title": "Rotación 3D",
+			"preset": {
+				"iso": "Iso",
+				"left": "Izquierda",
+				"right": "Derecha"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -15,6 +15,14 @@
 			"fast": "Rapide",
 			"smooth": "Fluide",
 			"lazy": "Lent"
+		},
+		"threeD": {
+			"title": "Rotation 3D",
+			"preset": {
+				"iso": "Iso",
+				"left": "Gauche",
+				"right": "Droite"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/ja-JP/settings.json
+++ b/src/i18n/locales/ja-JP/settings.json
@@ -8,6 +8,14 @@
 			"manual": "手動",
 			"auto": "自動",
 			"autoDescription": "表示範囲が録画中のカーソル位置に追従します"
+		},
+		"threeD": {
+			"title": "3D回転",
+			"preset": {
+				"iso": "Iso",
+				"left": "左",
+				"right": "右"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/ko-KR/settings.json
+++ b/src/i18n/locales/ko-KR/settings.json
@@ -8,6 +8,14 @@
 			"manual": "수동",
 			"auto": "자동",
 			"autoDescription": "녹화된 커서 위치를 따라 카메라가 이동합니다"
+		},
+		"threeD": {
+			"title": "3D 회전",
+			"preset": {
+				"iso": "Iso",
+				"left": "왼쪽",
+				"right": "오른쪽"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -8,6 +8,14 @@
 			"manual": "Manuel",
 			"auto": "Otomatik",
 			"autoDescription": "Kamera kaydedilen imleç konumunu takip eder"
+		},
+		"threeD": {
+			"title": "3D Döndürme",
+			"preset": {
+				"iso": "Iso",
+				"left": "Sol",
+				"right": "Sağ"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -8,6 +8,14 @@
 			"manual": "手动",
 			"auto": "自动",
 			"autoDescription": "摄像头跟随录制时的光标位置"
+		},
+		"threeD": {
+			"title": "3D 旋转",
+			"preset": {
+				"iso": "Iso",
+				"left": "左",
+				"right": "右"
+			}
 		}
 	},
 	"speed": {

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -15,6 +15,14 @@
 			"fast": "快速",
 			"smooth": "平滑",
 			"lazy": "緩慢"
+		},
+		"threeD": {
+			"title": "3D 旋轉",
+			"preset": {
+				"iso": "Iso",
+				"left": "左",
+				"right": "右"
+			}
 		}
 	},
 	"speed": {


### PR DESCRIPTION
## What

`npm run i18n:check` reports MISSING keys in 7 locale files:

```
MISSING in es/settings.json: zoom.threeD.{title,preset.iso,preset.left,preset.right}
MISSING in fr/settings.json: (same)
MISSING in ja-JP/settings.json: (same)
MISSING in ko-KR/settings.json: (same)
MISSING in tr/settings.json: (same)
MISSING in zh-CN/settings.json: (same)
MISSING in zh-TW/settings.json: (same)
```

## Why

The `zoom.threeD` section was added to the English reference (`en/settings.json`) but the corresponding keys were never added to the other supported locales.

## Changes

Added `zoom.threeD.title` and `zoom.threeD.preset.{iso,left,right}` to:
- `es/settings.json` — Spanish
- `fr/settings.json` — French
- `ja-JP/settings.json` — Japanese
- `ko-KR/settings.json` — Korean
- `tr/settings.json` — Turkish
- `zh-CN/settings.json` — Chinese (Simplified)
- `zh-TW/settings.json` — Chinese (Traditional)

> Note: a few pre-existing EXTRA keys remain in `fr`, `tr`, and `zh-TW` — these appear to be from other pending PRs and are out of scope for this fix.

## Testing

```bash
npm run i18n:check
```

The previously-reported MISSING errors are now resolved.

<!-- discord-thread-id:1500989891096346768 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added multilingual support for 3D rotation feature with preset options (iso, left, right) across Spanish, French, Japanese, Korean, Turkish, Simplified Chinese, and Traditional Chinese locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->