### PR TITLE
feat: add 'No Webcam' layout preset to hide webcam in final recording

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -821,6 +821,7 @@ export function SettingsPanel({
 										<SelectContent>
 											{WEBCAM_LAYOUT_PRESETS.filter((preset) => {
 												if (preset.value === "picture-in-picture") return true;
+												if (preset.value === "no-webcam") return true;
 												if (preset.value === "vertical-stack") return isPortraitCanvas;
 												return !isPortraitCanvas;
 											}).map((preset) => (
@@ -829,7 +830,9 @@ export function SettingsPanel({
 														? t("layout.pictureInPicture")
 														: preset.value === "vertical-stack"
 															? t("layout.verticalStack")
-															: t("layout.dualFrame")}
+															: preset.value === "no-webcam"
+																? t("layout.noWebcam")
+																: t("layout.dualFrame")}
 												</SelectItem>
 											))}
 										</SelectContent>

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -100,6 +100,7 @@ function computeNormalizedWebcamLayoutPreset(
 ): WebcamLayoutPreset {
 	switch (webcamLayoutPreset) {
 		case "picture-in-picture":
+		case "no-webcam":
 			return webcamLayoutPreset;
 		case "vertical-stack":
 			return isPortraitAspectRatio(normalizedAspectRatio)

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -35,6 +35,7 @@
 		"pictureInPicture": "Picture in Picture",
 		"verticalStack": "Vertical Stack",
 		"dualFrame": "Dual Frame",
+		"noWebcam": "No Webcam",
 		"webcamShape": "Camera Shape",
 		"webcamSize": "Webcam Size"
 	},

--- a/src/lib/compositeLayout.ts
+++ b/src/lib/compositeLayout.ts
@@ -15,7 +15,11 @@ export interface Size {
 	height: number;
 }
 
-export type WebcamLayoutPreset = "picture-in-picture" | "vertical-stack" | "dual-frame";
+export type WebcamLayoutPreset =
+	| "picture-in-picture"
+	| "vertical-stack"
+	| "dual-frame"
+	| "no-webcam";
 /** Webcam size as a percentage of the canvas reference dimension (10–50). */
 export type WebcamSizePreset = number;
 
@@ -126,6 +130,21 @@ const WEBCAM_LAYOUT_PRESET_MAP: Record<WebcamLayoutPreset, WebcamLayoutPresetDef
 		},
 		shadow: null,
 	},
+	"no-webcam": {
+		label: "No Webcam",
+		transform: {
+			type: "overlay",
+			marginFraction: 0,
+			minMargin: 0,
+			minSize: 0,
+		},
+		borderRadius: {
+			max: 0,
+			min: 0,
+			fraction: 0,
+		},
+		shadow: null,
+	},
 };
 
 export const WEBCAM_LAYOUT_PRESETS = Object.entries(WEBCAM_LAYOUT_PRESET_MAP).map(
@@ -172,6 +191,17 @@ export function computeCompositeLayout(params: {
 	} = params;
 	const { width: canvasWidth, height: canvasHeight } = canvasSize;
 	const { width: screenWidth, height: screenHeight } = screenSize;
+
+	// "no-webcam" preset: hide the webcam entirely, screen fills the canvas normally
+	if (layoutPreset === "no-webcam") {
+		const screenRect = centerRect({
+			canvasSize,
+			size: screenSize,
+			maxSize: maxContentSize,
+		});
+		return { screenRect, webcamRect: null };
+	}
+
 	const webcamWidth = webcamSize?.width;
 	const webcamHeight = webcamSize?.height;
 	const preset = getWebcamLayoutPresetDefinition(layoutPreset);


### PR DESCRIPTION
## Description

Adds a new **"No Webcam"** layout preset option to the webcam layout dropdown in the video editor. When selected, the webcam feed is completely hidden from both the preview and the exported video  the screen recording fills the canvas normally as if no webcam was recorded.

## Motivation

Currently, if a user records their screen with a webcam enabled, there is no way to hide the webcam overlay in the final output. The only layout options are "Picture in Picture", "Vertical Stack", and "Dual Frame" all of which display the webcam. Users who change their mind about including the webcam after recording have no option to remove it. This adds that missing option.

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

None

## Screenshots / Video

**Screenshot**:

<img width="482" height="266" alt="image" src="https://github.com/user-attachments/assets/b28926b4-65f5-4bb1-8872-85fbdae21723" />

<img width="1914" height="1015" alt="image" src="https://github.com/user-attachments/assets/49429d99-b1ce-4229-961d-109da37f41af" />

## Testing

1. Open a recording that has webcam enabled
2. In the editor sidebar, expand the **Layout** accordion
3. Open the **Preset** dropdown "No Webcam" should appear as an option
4. Select "No Webcam" the webcam should disappear from the preview
5. Export the video the final output should have no webcam overlay
6. Save and reload the project the "No Webcam" preset should persist correctly

### Files changed:
| File | Change |
|---|---|
| `src/lib/compositeLayout.ts` | Added `"no-webcam"` to type union, preset map, and `computeCompositeLayout` |
| `src/components/video-editor/projectPersistence.ts` | Added `"no-webcam"` normalization case |
| `src/components/video-editor/SettingsPanel.tsx` | Added option to dropdown filter and label |
| `src/i18n/locales/en/settings.json` | Added `"noWebcam"` translation (en only) |

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

> **Note:** Only the English locale translation has been added. Other locales may need `"noWebcam"` translations from native speakers.

<!-- discord-thread-id:1501840579980693545 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "no-webcam" layout preset option in the video editor settings, allowing users to display content without the webcam overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->