### PR TITLE
fix(macOS): add NSScreenCaptureUsageDescription and screen-capture entitlement

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -51,6 +51,7 @@
       "NSAudioCaptureUsageDescription": "OpenScreen needs audio capture permission to record system audio.",
       "NSMicrophoneUsageDescription": "OpenScreen needs microphone access to record voice audio.",
       "NSCameraUsageDescription": "OpenScreen needs camera access to record webcam video.",
+      "NSScreenCaptureUsageDescription": "OpenScreen needs screen recording permission to detect and capture windows.",
       "NSCameraUseContinuityCameraDeviceType": true,
       "com.apple.security.device.audio-input": true
     }

--- a/macos.entitlements
+++ b/macos.entitlements
@@ -21,5 +21,9 @@
     <!-- Camera (webcam capture) -->
     <key>com.apple.security.device.camera</key>
     <true/>
+
+    <!-- Screen recording (required for desktopCapturer.getSources() on macOS 10.15+) -->
+    <key>com.apple.security.device.screen-capture</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## What

Fixes #548

Adds the missing `NSScreenCaptureUsageDescription` key to the macOS `extendInfo` block in `electron-builder.json5`, and adds the `com.apple.security.device.screen-capture` entitlement to `macos.entitlements`.

## Root cause

macOS 10.15+ enforces TCC (Transparency, Consent, and Control) for screen recording. When an app calls `desktopCapturer.getSources()`, the OS checks for `NSScreenCaptureUsageDescription` in `Info.plist` to show the permission prompt. If the key is absent, the API fails **silently** — no error, no prompt, no sources returned — causing window detection to break completely.

All other permission keys were already present:
- ✅ `NSAudioCaptureUsageDescription`
- ✅ `NSMicrophoneUsageDescription`
- ✅ `NSCameraUsageDescription`
- ❌ `NSScreenCaptureUsageDescription` ← was missing

## Changes

**`electron-builder.json5`** — one line added to `mac.extendInfo`:
```json
"NSScreenCaptureUsageDescription": "OpenScreen needs screen recording permission to detect and capture windows."
```

**`macos.entitlements`** — one entitlement added alongside the existing `camera` and `audio-input` entries:
```xml
<!-- Screen recording (required for desktopCapturer.getSources() on macOS 10.15+) -->
<key>com.apple.security.device.screen-capture</key>
<true/>
```

## Testing

Build the macOS DMG and launch on a clean macOS 10.15+ machine (or one where OpenScreen has not previously been granted screen recording access). On first launch, macOS should now display the screen recording permission prompt. Once granted, `desktopCapturer.getSources()` returns window sources and window detection works correctly.

<!-- discord-thread-id:1502231078931267635 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled screen capture functionality on macOS with proper permission handling and security entitlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->