### PR TITLE
fix(macOS): fix three screen capture permission issues in Electron layer

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -52,8 +52,7 @@
       "NSMicrophoneUsageDescription": "OpenScreen needs microphone access to record voice audio.",
       "NSCameraUsageDescription": "OpenScreen needs camera access to record webcam video.",
       "NSScreenCaptureUsageDescription": "OpenScreen needs screen recording permission to detect and capture windows.",
-      "NSCameraUseContinuityCameraDeviceType": true,
-      "com.apple.security.device.audio-input": true
+      "NSCameraUseContinuityCameraDeviceType": true
     }
   },
   "linux": {

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -718,6 +718,32 @@ export function registerIpcHandlers(
 		}
 	});
 
+	ipcMain.handle("request-screen-access", async () => {
+		if (process.platform !== "darwin") {
+			return { success: true, granted: true, status: "granted" };
+		}
+
+		try {
+			const status = systemPreferences.getMediaAccessStatus("screen");
+			if (status === "granted") {
+				return { success: true, granted: true, status };
+			}
+
+			// Screen recording has no askForMediaAccess equivalent — the TCC prompt
+			// is triggered by desktopCapturer.getSources(). Fire it and return so
+			// the renderer can re-check status after the user responds.
+			if (status === "not-determined") {
+				desktopCapturer.getSources({ types: ["screen"] }).catch(() => {});
+				return { success: true, granted: false, status: "not-determined" };
+			}
+
+			return { success: true, granted: false, status };
+		} catch (error) {
+			console.error("Failed to request screen access:", error);
+			return { success: false, granted: false, status: "unknown", error: String(error) };
+		}
+	});
+
 	// macOS Accessibility prompt for global click capture. First call shows the
 	// system dialog; the user has to toggle the app in System Settings (no
 	// programmatic grant exists for Accessibility).

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import {
 	app,
 	BrowserWindow,
+	desktopCapturer,
 	ipcMain,
 	Menu,
 	nativeImage,
@@ -476,11 +477,20 @@ app.whenReady().then(async () => {
 		callback(allowed.includes(permission));
 	});
 
-	// Request microphone permission from macOS
+	// Request microphone and screen recording permissions from macOS
 	if (process.platform === "darwin") {
 		const micStatus = systemPreferences.getMediaAccessStatus("microphone");
 		if (micStatus !== "granted") {
 			await systemPreferences.askForMediaAccess("microphone");
+		}
+
+		// Screen recording has no askForMediaAccess equivalent — the TCC prompt is
+		// triggered by the first desktopCapturer.getSources() call. Firing it here
+		// at startup settles the permission state early and prevents repeated prompts
+		// driven by later getSources() calls (fixes repeated permission dialog).
+		const screenStatus = systemPreferences.getMediaAccessStatus("screen");
+		if (screenStatus === "not-determined") {
+			desktopCapturer.getSources({ types: ["screen"] }).catch(() => {});
 		}
 	}
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -449,14 +449,30 @@ app.whenReady().then(async () => {
 		app.dock?.show();
 	}
 
-	// Allow microphone/media permission checks
+	// Allow microphone/media/screen permission checks
 	session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
-		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];
+		const allowed = [
+			"media",
+			"audioCapture",
+			"microphone",
+			"videoCapture",
+			"camera",
+			"screen",
+			"display-capture",
+		];
 		return allowed.includes(permission);
 	});
 
 	session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-		const allowed = ["media", "audioCapture", "microphone", "videoCapture", "camera"];
+		const allowed = [
+			"media",
+			"audioCapture",
+			"microphone",
+			"videoCapture",
+			"camera",
+			"screen",
+			"display-capture",
+		];
 		callback(allowed.includes(permission));
 	});
 


### PR DESCRIPTION
## Background

While investigating the screen picker showing "Screen (0) / Window (0)" on macOS, three independent permission bugs were found — all related to but distinct from the `NSScreenCaptureUsageDescription` fix in PR #554.

Closes #558

---

## Changes

### Commit 1 — `electron/main.ts`: missing screen permissions in Electron allowlists

Both `setPermissionCheckHandler` and `setPermissionRequestHandler` only allowed:
```
["media", "audioCapture", "microphone", "videoCapture", "camera"]
```
`"screen"` and `"display-capture"` were missing.

**Impact**: when the renderer requests a screen source via `getUserMedia` (chromeMediaSource: 'desktop'), Electron's own permission layer silently rejects it before macOS TCC is ever consulted.

**Fix**: add `"screen"` and `"display-capture"` to both handler allowlists.

---

### Commit 2 — `electron/main.ts` + `electron/ipc/handlers.ts`: no proactive screen permission check

Microphone is checked at startup with `getMediaAccessStatus` + `askForMediaAccess`. Camera has a `request-camera-access` IPC handler. Screen recording had neither — it relied entirely on `desktopCapturer.getSources()` to implicitly trigger the TCC prompt.

**Impact**: permission status is never settled at startup, so the system dialog can reappear on subsequent launches — the root cause of #558.

**Fix**:
- In `app.whenReady()`, check `getMediaAccessStatus("screen")` and trigger the TCC prompt when status is `"not-determined"`, mirroring the mic flow
- Add `request-screen-access` IPC handler, symmetric to `request-camera-access`

---

### Commit 3 — `electron-builder.json5`: entitlement key misplaced in `extendInfo`

`com.apple.security.device.audio-input` is an entitlement key and belongs only in `macos.entitlements`. Writing it into `extendInfo` places it in `Info.plist` where it has no effect and is misleading.

**Fix**: remove it from `extendInfo` — `macos.entitlements` already has the correct entry.

---

## Testing

- Fresh install (or after `tccutil reset ScreenCapture com.siddharthvaddem.openscreen`): only one permission dialog on first launch
- Restart after granting: no repeated prompt (verifies #558)
- `desktopCapturer.getSources()` returns screen and window sources correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added screen-recording/display-capture support and a cross-platform, user-facing screen access request flow; macOS may now prompt earlier for screen access.

* **Bug Fixes**
  * Removed an unnecessary macOS audio-input entitlement to streamline permission prompts and avoid over-requesting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/561)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->