### PR TITLE
chore: fix homebrew cask audit warnings

### DIFF
--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -112,18 +112,24 @@ jobs:
           mkdir -p tap/Casks
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
 
+          # #{version} is Ruby interpolation written literally to the cask
+          # file (bash heredoc leaves "#{...}" alone). \${VERSION}, \${ARM_SHA},
+          # etc. are bash variables expanded by the heredoc. The literal
+          # #{version} fixes Homebrew's "URL is unversioned" audit warning by
+          # making the version string statically detectable.
           cat > "tap/Casks/${CASK_NAME}.rb" <<EOF
           cask "${CASK_NAME}" do
             version "${VERSION}"
 
             on_arm do
               sha256 "${ARM_SHA}"
-              url "${BASE}/${ARM_NAME}"
+              url "https://github.com/${REPO}/releases/download/v#{version}/${ARM_NAME}",
+                  verified: "github.com/${REPO}/"
             end
-
             on_intel do
               sha256 "${X64_SHA}"
-              url "${BASE}/${X64_NAME}"
+              url "https://github.com/${REPO}/releases/download/v#{version}/${X64_NAME}",
+                  verified: "github.com/${REPO}/"
             end
 
             name "Openscreen"
@@ -137,9 +143,9 @@ jobs:
 
             zap trash: [
               "~/Library/Application Support/Openscreen",
-              "~/Library/Preferences/com.siddharthvaddem.openscreen.plist",
-              "~/Library/Logs/Openscreen",
               "~/Library/Caches/com.siddharthvaddem.openscreen",
+              "~/Library/Logs/Openscreen",
+              "~/Library/Preferences/com.siddharthvaddem.openscreen.plist",
               "~/Library/Saved Application State/com.siddharthvaddem.openscreen.savedState",
             ]
           end


### PR DESCRIPTION
## Summary
Cleans up the cask file the bump workflow generates. After this lands and you re-run the workflow for a release tag, the resulting cask will pass `brew audit --cask siddharthvaddem/openscreen/openscreen` and `brew style --cask ...` cleanly.

Changes to the heredoc:
- URLs now use `v#{version}` Ruby interpolation instead of a hardcoded `v1.4.0`. Fixes the "URL is unversioned" audit warning.
- Removed the blank line between `on_arm` and `on_intel` (rubocop considers them the same stanza group).
- Alphabetized the `zap trash:` array entries.
- Added `verified:` URL for the GitHub release host (good practice for casks pulling from generic URLs).

## Test plan
- [ ] After merge, re-run: `gh workflow run update-homebrew-cask.yml -f tag=v1.4.0`
- [ ] Verify `brew audit --cask siddharthvaddem/openscreen/openscreen` exits clean
- [ ] Verify `brew install --cask siddharthvaddem/openscreen/openscreen` still works on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1502813202684313750 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew cask distribution workflow to improve how download URLs are generated and managed for different architectures.
  * Refined the cask cleanup process for enhanced consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/563)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->