### PR TITLE
chore: final homebrew cask style cleanup

### DIFF
--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -123,13 +123,13 @@ jobs:
 
             on_arm do
               sha256 "${ARM_SHA}"
-              url "https://github.com/${REPO}/releases/download/v#{version}/${ARM_NAME}",
-                  verified: "github.com/${REPO}/"
+
+              url "https://github.com/${REPO}/releases/download/v#{version}/${ARM_NAME}"
             end
             on_intel do
               sha256 "${X64_SHA}"
-              url "https://github.com/${REPO}/releases/download/v#{version}/${X64_NAME}",
-                  verified: "github.com/${REPO}/"
+
+              url "https://github.com/${REPO}/releases/download/v#{version}/${X64_NAME}"
             end
 
             name "Openscreen"


### PR DESCRIPTION
## Summary
Final tweaks so the generated cask passes `brew audit --cask` + `brew style --cask` with zero warnings.

- Removes the `verified:` URL parameter (Homebrew flags it as unnecessary when the URL host matches the homepage host — both are `github.com` here).
- Adds a blank line between `sha256` and `url` inside each `on_arm`/`on_intel` block (rubocop's `Cask/StanzaGrouping` rule).
- Keeps no blank line between consecutive `on_arm` and `on_intel` blocks (same outer stanza group).

## Test plan
- [ ] After merge, re-run: `gh workflow run update-homebrew-cask.yml -f tag=v1.4.0`
- [ ] `brew audit --cask siddharthvaddem/openscreen/openscreen` exits clean
- [ ] `brew style --cask siddharthvaddem/openscreen/openscreen` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1502814534811783249 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the Homebrew cask installation package generation workflow to streamline URL configuration for both ARM and Intel processor architectures. Simplified installation package metadata by removing additional verification parameters, enabling more efficient and consistent package generation across different processor types while maintaining full backwards compatibility and improving overall workflow reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->