### PR TITLE
chore: add winget-releaser workflow

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,26 @@
+name: Publish release to WinGet
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to winget (e.g. v1.4.0)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: SiddharthVaddem.OpenScreen
+          # Match the Windows installer asset attached to each release.
+          # Today: "Openscreen.Setup.latest.exe". Adjust this regex if you
+          # ever rename the installer to include a version (e.g. "Setup\.\d+\.\d+\.\d+\.exe").
+          installers-regex: 'Setup\..*\.exe$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_ACC_TOKEN }}


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publish-winget.yml`. On every published GitHub Release, the [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) action opens a PR against `microsoft/winget-pkgs` bumping `SiddharthVaddem.OpenScreen` to the new version. Closes #299.

The workflow is also runnable manually via `workflow_dispatch` with a `tag` input, useful for backfilling existing releases.

## Setup required (one-time, before this can run)
1. **Create a classic PAT** at https://github.com/settings/tokens/new with `public_repo` scope. Fine-grained PATs are not supported by the action.
2. **Add the PAT** as a repo secret named `WINGET_ACC_TOKEN`.
3. **Fork** [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under `siddharthvaddem` (the action commits to this fork before opening a PR back to upstream).

## Notes on the installer regex
The current release attaches `Openscreen.Setup.latest.exe`. The regex `Setup\..*\.exe$` matches this. If you ever rename installers to include a version (e.g. `Openscreen.Setup.1.5.0.exe`), the regex still matches.

## Test plan
- [ ] `WINGET_ACC_TOKEN` secret is set
- [ ] `siddharthvaddem/winget-pkgs` fork exists
- [ ] After merge, run: `gh workflow run publish-winget.yml -f tag=v1.4.0`
- [ ] Verify a PR is opened against `microsoft/winget-pkgs` for `SiddharthVaddem.OpenScreen` v1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1502817367997157497 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release publishing to WinGet. New releases are now automatically published to the Windows Package Manager, making installation and updates more convenient for Windows users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/565)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->