### PR TITLE
[codex] fix native aspect ratio fallback

### DIFF
--- a/src/utils/aspectRatioUtils.test.ts
+++ b/src/utils/aspectRatioUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getNativeAspectRatioValue } from "./aspectRatioUtils";
+
+const FALLBACK_RATIO = 16 / 9;
+
+describe("getNativeAspectRatioValue", () => {
+	it("returns the video ratio when no crop region is provided", () => {
+		expect(getNativeAspectRatioValue(1920, 1080)).toBe(16 / 9);
+	});
+
+	it("applies crop width and height to the video ratio", () => {
+		expect(getNativeAspectRatioValue(1920, 1080, { x: 0, y: 0, width: 0.5, height: 1 })).toBe(
+			8 / 9,
+		);
+	});
+
+	it("falls back when video metadata is zero or non-finite", () => {
+		expect(getNativeAspectRatioValue(0, 1080)).toBe(FALLBACK_RATIO);
+		expect(getNativeAspectRatioValue(1920, 0)).toBe(FALLBACK_RATIO);
+		expect(getNativeAspectRatioValue(Number.NaN, 1080)).toBe(FALLBACK_RATIO);
+		expect(getNativeAspectRatioValue(1920, Number.POSITIVE_INFINITY)).toBe(FALLBACK_RATIO);
+	});
+
+	it("falls back when crop dimensions are non-positive or non-finite", () => {
+		expect(getNativeAspectRatioValue(1920, 1080, { x: 0, y: 0, width: 0, height: 1 })).toBe(
+			FALLBACK_RATIO,
+		);
+		expect(getNativeAspectRatioValue(1920, 1080, { x: 0, y: 0, width: 1, height: -1 })).toBe(
+			FALLBACK_RATIO,
+		);
+		expect(
+			getNativeAspectRatioValue(1920, 1080, {
+				x: 0,
+				y: 0,
+				width: Number.POSITIVE_INFINITY,
+				height: 1,
+			}),
+		).toBe(FALLBACK_RATIO);
+	});
+});

--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -11,6 +11,8 @@ export const ASPECT_RATIOS = [
 
 export type AspectRatio = (typeof ASPECT_RATIOS)[number];
 
+const NATIVE_ASPECT_RATIO_FALLBACK = 16 / 9;
+
 /**
  * Returns the numeric value of an aspect ratio.
  * For "native", returns a fallback ratio of 16/9.
@@ -33,7 +35,7 @@ export function getAspectRatioValue(aspectRatio: AspectRatio): number {
 		case "10:16":
 			return 10 / 16;
 		case "native":
-			return 16 / 9;
+			return NATIVE_ASPECT_RATIO_FALLBACK;
 		default: {
 			const _exhaustiveCheck: never = aspectRatio;
 			return _exhaustiveCheck;
@@ -48,7 +50,21 @@ export function getNativeAspectRatioValue(
 ): number {
 	const cropW = cropRegion?.width ?? 1;
 	const cropH = cropRegion?.height ?? 1;
-	return (videoWidth * cropW) / (videoHeight * cropH);
+	if (
+		!Number.isFinite(videoWidth) ||
+		!Number.isFinite(videoHeight) ||
+		!Number.isFinite(cropW) ||
+		!Number.isFinite(cropH) ||
+		videoWidth <= 0 ||
+		videoHeight <= 0 ||
+		cropW <= 0 ||
+		cropH <= 0
+	) {
+		return NATIVE_ASPECT_RATIO_FALLBACK;
+	}
+
+	const ratio = (videoWidth * cropW) / (videoHeight * cropH);
+	return Number.isFinite(ratio) && ratio > 0 ? ratio : NATIVE_ASPECT_RATIO_FALLBACK;
 }
 
 export function getAspectRatioDimensions(
@@ -72,6 +88,6 @@ export function isPortraitAspectRatio(aspectRatio: AspectRatio): boolean {
 }
 
 export function formatAspectRatioForCSS(aspectRatio: AspectRatio, nativeRatio?: number): string {
-	if (aspectRatio === "native") return String(nativeRatio ?? 16 / 9);
+	if (aspectRatio === "native") return String(nativeRatio ?? NATIVE_ASPECT_RATIO_FALLBACK);
 	return aspectRatio.replace(":", "/");
 }


### PR DESCRIPTION
﻿## Summary
- Guard native aspect ratio calculation against zero, non-finite, and non-positive video/crop dimensions.
- Reuse the existing 16:9 native fallback consistently.
- Add unit tests for valid native ratios, crop math, and invalid metadata/crop inputs.

## Root Cause
`getNativeAspectRatioValue` divided video/crop dimensions without validating the denominator or computed ratio, so early metadata states or degenerate crop values could produce `Infinity` or `NaN`.

## Validation
- `npm test -- src/utils/aspectRatioUtils.test.ts`
- `npx tsc --noEmit`

Fixes #454

<!-- discord-thread-id:1505153142134800494 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for aspect ratio calculations with various input scenarios.

* **Bug Fixes**
  * Improved validation of aspect ratio inputs to handle edge cases and invalid data, ensuring consistent fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->