### PR TITLE
[codex] fix native 16:10 layout and export sizing

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -18,6 +18,7 @@ import { type Locale } from "@/i18n/config";
 import { getAvailableLocales, getLocaleName } from "@/i18n/loader";
 import { hasNativeCursorRecordingData } from "@/lib/cursor/nativeCursor";
 import {
+	calculateMp4ExportDimensions,
 	calculateOutputDimensions,
 	type ExportFormat,
 	type ExportProgress,
@@ -1667,83 +1668,16 @@ export default function VideoEditor() {
 				} else {
 					// MP4 Export
 					const quality = settings.quality || exportQuality;
-					let exportWidth: number;
-					let exportHeight: number;
-					let bitrate: number;
-
-					if (quality === "source") {
-						exportWidth = sourceWidth;
-						exportHeight = sourceHeight;
-
-						// Use the source's longer dimension as the long axis of the export so
-						// a landscape recording can still fill a portrait target (and vice versa).
-						const sourceLongDim = Math.max(sourceWidth, sourceHeight);
-
-						if (aspectRatioValue === 1) {
-							const baseDimension = Math.floor(Math.min(sourceWidth, sourceHeight) / 2) * 2;
-							exportWidth = baseDimension;
-							exportHeight = baseDimension;
-						} else if (aspectRatioValue > 1) {
-							const baseWidth = Math.floor(sourceLongDim / 2) * 2;
-							let found = false;
-							for (let w = baseWidth; w >= 100 && !found; w -= 2) {
-								const h = Math.round(w / aspectRatioValue);
-								if (h % 2 === 0 && Math.abs(w / h - aspectRatioValue) < 0.0001) {
-									exportWidth = w;
-									exportHeight = h;
-									found = true;
-								}
-							}
-							if (!found) {
-								exportWidth = baseWidth;
-								exportHeight = Math.floor(baseWidth / aspectRatioValue / 2) * 2;
-							}
-						} else {
-							const baseHeight = Math.floor(sourceLongDim / 2) * 2;
-							let found = false;
-							for (let h = baseHeight; h >= 100 && !found; h -= 2) {
-								const w = Math.round(h * aspectRatioValue);
-								if (w % 2 === 0 && Math.abs(w / h - aspectRatioValue) < 0.0001) {
-									exportWidth = w;
-									exportHeight = h;
-									found = true;
-								}
-							}
-							if (!found) {
-								exportHeight = baseHeight;
-								exportWidth = Math.floor((baseHeight * aspectRatioValue) / 2) * 2;
-							}
-						}
-
-						const totalPixels = exportWidth * exportHeight;
-						bitrate = 30_000_000;
-						if (totalPixels > 1920 * 1080 && totalPixels <= 2560 * 1440) {
-							bitrate = 50_000_000;
-						} else if (totalPixels > 2560 * 1440) {
-							bitrate = 80_000_000;
-						}
-					} else {
-						// Quality presets target the SHORT side; the long side derives from the
-						// aspect ratio. This keeps 1080p portrait at 1080×1920 instead of 607×1080.
-						const targetShortDim = quality === "medium" ? 720 : 1080;
-
-						if (aspectRatioValue >= 1) {
-							exportHeight = Math.floor(targetShortDim / 2) * 2;
-							exportWidth = Math.floor((exportHeight * aspectRatioValue) / 2) * 2;
-						} else {
-							exportWidth = Math.floor(targetShortDim / 2) * 2;
-							exportHeight = Math.floor(exportWidth / aspectRatioValue / 2) * 2;
-						}
-
-						const totalPixels = exportWidth * exportHeight;
-						if (totalPixels <= 1280 * 720) {
-							bitrate = 10_000_000;
-						} else if (totalPixels <= 1920 * 1080) {
-							bitrate = 20_000_000;
-						} else {
-							bitrate = 30_000_000;
-						}
-					}
+					const {
+						width: exportWidth,
+						height: exportHeight,
+						bitrate,
+					} = calculateMp4ExportDimensions({
+						sourceWidth,
+						sourceHeight,
+						aspectRatio: aspectRatioValue,
+						quality,
+					});
 
 					const exporter = new VideoExporter({
 						videoUrl: videoPath,

--- a/src/lib/compositeLayout.test.ts
+++ b/src/lib/compositeLayout.test.ts
@@ -128,6 +128,21 @@ describe("computeCompositeLayout", () => {
 		expect(aboveMax!.webcamRect!.height).toBe(atMax!.webcamRect!.height);
 	});
 
+	it("snaps rounding-only source aspect gaps to the full canvas", () => {
+		const layout = computeCompositeLayout({
+			canvasSize: { width: 319, height: 199 },
+			maxContentSize: { width: 319, height: 199 },
+			screenSize: { width: 1680, height: 1050 },
+		});
+
+		expect(layout?.screenRect).toEqual({
+			x: 0,
+			y: 0,
+			width: 319,
+			height: 199,
+		});
+	});
+
 	it("centers the combined screen and webcam stack in vertical stack mode", () => {
 		const layout = computeCompositeLayout({
 			canvasSize: { width: 1920, height: 1080 },

--- a/src/lib/compositeLayout.ts
+++ b/src/lib/compositeLayout.ts
@@ -405,6 +405,20 @@ function centerRectInBounds(params: { bounds: RenderRect; size: Size; maxSize: S
 	const resolvedWidth = Math.round(width * scale);
 	const resolvedHeight = Math.round(height * scale);
 
+	if (
+		maxWidth >= boundsWidth &&
+		maxHeight >= boundsHeight &&
+		Math.abs(boundsWidth - resolvedWidth) <= 1 &&
+		Math.abs(boundsHeight - resolvedHeight) <= 1
+	) {
+		return {
+			x: boundsX,
+			y: boundsY,
+			width: boundsWidth,
+			height: boundsHeight,
+		};
+	}
+
 	return {
 		x: boundsX + Math.max(0, Math.floor((boundsWidth - resolvedWidth) / 2)),
 		y: boundsY + Math.max(0, Math.floor((boundsHeight - resolvedHeight) / 2)),

--- a/src/lib/exporter/index.ts
+++ b/src/lib/exporter/index.ts
@@ -21,4 +21,5 @@ export {
 	VALID_GIF_FRAME_RATES,
 } from "./types";
 export { VideoFileDecoder } from "./videoDecoder";
+export { calculateMp4ExportDimensions } from "./videoDimensions";
 export { VideoExporter } from "./videoExporter";

--- a/src/lib/exporter/videoDimensions.test.ts
+++ b/src/lib/exporter/videoDimensions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { calculateMp4ExportDimensions } from "./videoDimensions";
+
+describe("calculateMp4ExportDimensions", () => {
+	it("does not upscale 16:10 recordings above their source bounds for quality presets", () => {
+		expect(
+			calculateMp4ExportDimensions({
+				sourceWidth: 1680,
+				sourceHeight: 1050,
+				aspectRatio: 16 / 10,
+				quality: "good",
+			}),
+		).toMatchObject({
+			width: 1680,
+			height: 1050,
+		});
+	});
+
+	it("keeps 1080p landscape output for a 16:9 source when good quality is selected", () => {
+		expect(
+			calculateMp4ExportDimensions({
+				sourceWidth: 1920,
+				sourceHeight: 1080,
+				aspectRatio: 16 / 9,
+				quality: "good",
+			}),
+		).toMatchObject({
+			width: 1920,
+			height: 1080,
+		});
+	});
+
+	it("preserves source dimensions for the source quality path", () => {
+		expect(
+			calculateMp4ExportDimensions({
+				sourceWidth: 1680,
+				sourceHeight: 1050,
+				aspectRatio: 16 / 10,
+				quality: "source",
+			}),
+		).toMatchObject({
+			width: 1680,
+			height: 1050,
+		});
+	});
+});

--- a/src/lib/exporter/videoDimensions.ts
+++ b/src/lib/exporter/videoDimensions.ts
@@ -1,0 +1,129 @@
+import type { ExportQuality } from "./types";
+
+interface Mp4ExportDimensionsParams {
+	sourceWidth: number;
+	sourceHeight: number;
+	aspectRatio: number;
+	quality: ExportQuality;
+}
+
+export interface Mp4ExportDimensions {
+	width: number;
+	height: number;
+	bitrate: number;
+}
+
+function toEven(value: number) {
+	return Math.max(2, Math.floor(value / 2) * 2);
+}
+
+function getBitrate(width: number, height: number) {
+	const totalPixels = width * height;
+	if (totalPixels <= 1280 * 720) {
+		return 10_000_000;
+	}
+	if (totalPixels <= 1920 * 1080) {
+		return 20_000_000;
+	}
+	if (totalPixels <= 2560 * 1440) {
+		return 50_000_000;
+	}
+	return 80_000_000;
+}
+
+function getSourceQualityBitrate(width: number, height: number) {
+	const totalPixels = width * height;
+	if (totalPixels > 2560 * 1440) {
+		return 80_000_000;
+	}
+	if (totalPixels > 1920 * 1080) {
+		return 50_000_000;
+	}
+	return 30_000_000;
+}
+
+function calculateSourceQualityDimensions(
+	sourceWidth: number,
+	sourceHeight: number,
+	aspectRatio: number,
+) {
+	if (aspectRatio === 1) {
+		const baseDimension = toEven(Math.min(sourceWidth, sourceHeight));
+		return { width: baseDimension, height: baseDimension };
+	}
+
+	const sourceLongDim = Math.max(sourceWidth, sourceHeight);
+
+	if (aspectRatio > 1) {
+		const baseWidth = toEven(sourceLongDim);
+		for (let width = baseWidth; width >= 100; width -= 2) {
+			const height = Math.round(width / aspectRatio);
+			if (height % 2 === 0 && Math.abs(width / height - aspectRatio) < 0.0001) {
+				return { width, height };
+			}
+		}
+		return { width: baseWidth, height: toEven(baseWidth / aspectRatio) };
+	}
+
+	const baseHeight = toEven(sourceLongDim);
+	for (let height = baseHeight; height >= 100; height -= 2) {
+		const width = Math.round(height * aspectRatio);
+		if (width % 2 === 0 && Math.abs(width / height - aspectRatio) < 0.0001) {
+			return { width, height };
+		}
+	}
+	return { width: toEven(baseHeight * aspectRatio), height: baseHeight };
+}
+
+function getMaxDimensionsWithinSourceBounds(
+	sourceWidth: number,
+	sourceHeight: number,
+	aspectRatio: number,
+) {
+	const sourceAspect = sourceWidth / sourceHeight;
+
+	if (aspectRatio >= sourceAspect) {
+		const width = toEven(sourceWidth);
+		return { width, height: toEven(width / aspectRatio) };
+	}
+
+	const height = toEven(sourceHeight);
+	return { width: toEven(height * aspectRatio), height };
+}
+
+export function calculateMp4ExportDimensions({
+	sourceWidth,
+	sourceHeight,
+	aspectRatio,
+	quality,
+}: Mp4ExportDimensionsParams): Mp4ExportDimensions {
+	const safeAspectRatio =
+		Number.isFinite(aspectRatio) && aspectRatio > 0 ? aspectRatio : sourceWidth / sourceHeight;
+
+	if (quality === "source") {
+		const dimensions = calculateSourceQualityDimensions(sourceWidth, sourceHeight, safeAspectRatio);
+		return { ...dimensions, bitrate: getSourceQualityBitrate(dimensions.width, dimensions.height) };
+	}
+
+	const targetShortDim = quality === "medium" ? 720 : 1080;
+	const maxDimensions = getMaxDimensionsWithinSourceBounds(
+		sourceWidth,
+		sourceHeight,
+		safeAspectRatio,
+	);
+	const maxShortDim = Math.min(maxDimensions.width, maxDimensions.height);
+	const exportShortDim = Math.min(targetShortDim, maxShortDim);
+
+	const dimensions =
+		safeAspectRatio >= 1
+			? {
+					height: toEven(exportShortDim),
+					width: toEven(exportShortDim * safeAspectRatio),
+				}
+			: {
+					width: toEven(exportShortDim),
+					height: toEven(exportShortDim / safeAspectRatio),
+				};
+
+	return { ...dimensions, bitrate: getBitrate(dimensions.width, dimensions.height) };
+}


### PR DESCRIPTION
﻿## Summary
- Snap rounding-only full-canvas layout misses to the full canvas, avoiding 1px preview gaps for native/16:10 recordings such as 1680x1050.
- Move MP4 export dimension selection into a tested helper.
- Prevent quality preset exports from upscaling beyond source bounds, so a 1680x1050 16:10 recording exports at 1680x1050 instead of 1728x1080.

## Root Cause
For certain integer preview sizes, fitting a same-aspect source such as 1680x1050 into a 16:10 canvas rounded the fitted rect down by 1px, exposing the background. Separately, MP4 quality presets targeted a fixed short side, which could upscale smaller native recordings even when padding was zero.

## Validation
- `npx vitest --run src/lib/compositeLayout.test.ts src/lib/exporter/videoDimensions.test.ts src/lib/exporter/videoExporter.test.ts`
- `npx tsc --noEmit`
- `npx biome check src/lib/compositeLayout.ts src/lib/compositeLayout.test.ts src/lib/exporter/videoDimensions.ts src/lib/exporter/videoDimensions.test.ts src/lib/exporter/index.ts src/components/video-editor/VideoEditor.tsx`

## Manual QA
- Reproduced #587 on Windows with a fresh 1680x1050 recording: `upstream/main` exports MP4 Good as `1728x1080`.
- Verified this PR on the same scenario: MP4 Good exports as `1680x1050`.
- Verified a normal 1920x1080 source still exports as `1920x1080` on Good quality.
- Checked the editor preview with Native/16:10 and padding 0; no visible 1px right-side gap was observed locally.
- The preview rounding path is also covered by a unit test for the reported 1680x1050 source fitted into a 319x199 16:10 canvas case.

Fixes #586
Fixes #587

<!-- discord-thread-id:1505153420250578975 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MP4 export now includes configurable quality modes (source, medium, good) with intelligent dimension and bitrate calculation that adapts to your video's resolution and aspect ratio.

* **Bug Fixes**
  * Improved aspect ratio handling in layout system to ensure content is placed optimally and canvas space is utilized efficiently across different aspect ratios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->