### PR TITLE
[codex] fix language prompt HUD clicks

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -374,6 +374,7 @@ export function LaunchWindow() {
 		>
 			{systemLocaleSuggestion && (
 				<div
+					data-hud-interactive="true"
 					className={`fixed top-8 left-1/2 z-30 w-[calc(100vw-1rem)] max-w-[520px] -translate-x-1/2 rounded-xl border border-white/15 bg-[rgba(20,20,28,0.95)] p-3 shadow-2xl backdrop-blur-xl text-white animate-in fade-in-0 zoom-in-95 duration-200 ${styles.electronNoDrag}`}
 				>
 					<div className="text-[13px] font-semibold text-white">


### PR DESCRIPTION
## Summary
- Mark the system language prompt as a HUD interactive region.
- This lets Electron stop ignoring pointer events while the cursor is over the prompt, so the prompt buttons can be clicked.

## Root Cause
The HUD window toggles `setHudOverlayIgnoreMouseEvents` based on whether the pointer is over an element with `data-hud-interactive="true"`. The language prompt had clickable buttons but was not marked interactive, so the HUD could pass clicks through instead of delivering them to the buttons.

## Validation
- `npx tsc --noEmit`
- `npx biome check --formatter-enabled=false src/components/launch/LaunchWindow.tsx`

## Manual QA
- Start the app with no stored locale and a non-English system language.
- Confirm the system language prompt appears.
- Click both language prompt buttons in separate runs.
- Confirm each button dismisses the prompt and performs the expected action.

Fixes #590

<!-- discord-thread-id:1505161327646343178 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the system language suggestion prompt was not responding to mouse input when displayed over the HUD overlay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->