### PR TITLE
fix(zoom): keep export panel visible after Suggest Zooms

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -864,11 +864,10 @@ export default function VideoEditor() {
 				customScale: ZOOM_DEPTH_SCALES[DEFAULT_ZOOM_DEPTH],
 				focus: clampFocusToDepth(focus, DEFAULT_ZOOM_DEPTH),
 			};
+			// Bulk suggest must not steal selection — keeping a zoom selected hides
+			// the export panel (SettingsPanel gates it on !hasTimelineSelection),
+			// trapping users who just want to export after auto-zoom.
 			pushState((prev) => ({ zoomRegions: [...prev.zoomRegions, newRegion] }));
-			setSelectedZoomId(id);
-			setSelectedTrimId(null);
-			setSelectedAnnotationId(null);
-			setSelectedBlurId(null);
 		},
 		[pushState],
 	);


### PR DESCRIPTION
## Summary

Fixes #610 — the Export button becomes unresponsive after clicking **Suggest Zooms**, until the user clicks a timeline track.

`handleZoomSuggested` runs once per suggested zoom (bulk) and called `setSelectedZoomId(id)` each time, leaving the last auto-zoom selected. `SettingsPanel` gates the entire export panel on `activePanelMode === "export" && !hasTimelineSelection`, so a lingering selection hides the export button entirely.

This removes the selection side-effects from the **bulk** suggest path only. Single manual add (`handleZoomAdded`) keeps its auto-select, which is the desired behavior there.

## Test plan

- [x] Click **Suggest Zooms** → without clicking a track, click Export → export dialog opens
- [x] Click single **+Zoom** → zoom is auto-selected and zoom settings panel shows (unchanged)
- [x] After Suggest Zooms, press Play → auto-zoom logic still plays correctly
- [x] `npm test` passes

<!-- discord-thread-id:1506120595824443482 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where suggested zoom regions would clear the user's timeline selection. The user's current selection is now preserved when zoom suggestions are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->