### PR TITLE
ux: rename 'Native' aspect ratio label to 'Original'

### DIFF
--- a/src/utils/aspectRatioUtils.ts
+++ b/src/utils/aspectRatioUtils.ts
@@ -63,7 +63,7 @@ export function getAspectRatioDimensions(
 }
 
 export function getAspectRatioLabel(aspectRatio: AspectRatio): string {
-	if (aspectRatio === "native") return "Native";
+	if (aspectRatio === "native") return "Original";
 	return aspectRatio;
 }
 


### PR DESCRIPTION
## Summary

Closes #607.

The aspect ratio dropdown showed **`Native`**, which is video-industry jargon that is not self-explanatory for most users. Renaming it to **`Original`** makes it immediately clear that this option preserves the source video's own dimensions — no domain knowledge needed.

## Changes

- `src/utils/aspectRatioUtils.ts` — `getAspectRatioLabel()` now returns `"Original"` instead of `"Native"` for the `"native"` aspect ratio value.

The internal `"native"` string in the `AspectRatio` union type is **unchanged** — this is purely a display-layer fix.

## Test plan

- [ ] Open the aspect ratio dropdown in the timeline editor and confirm it shows **Original** instead of **Native**
- [ ] Selecting the option should behave identically (source dimensions preserved)
- [ ] All existing unit tests in `aspectRatioUtils.test.ts` pass unchanged

<!-- discord-thread-id:1506209882364317777 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the aspect ratio label from "Native" to "Original" for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->