### PR TITLE
fix(export): clear timeline selection when opening export panel

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -284,6 +284,7 @@ interface SettingsPanelProps {
 	onGifSizePresetChange?: (preset: GifSizePreset) => void;
 	gifOutputDimensions?: { width: number; height: number };
 	onExport?: () => void;
+	onExportPanelOpen?: () => void;
 	unsavedExport?: {
 		arrayBuffer: ArrayBuffer;
 		fileName: string;
@@ -414,6 +415,7 @@ export function SettingsPanel({
 	onGifSizePresetChange,
 	gifOutputDimensions = DEFAULT_GIF_SETTINGS.outputDimensions,
 	onExport,
+	onExportPanelOpen,
 	unsavedExport,
 	onSaveUnsavedExport,
 	selectedAnnotationId,
@@ -822,7 +824,10 @@ export function SettingsPanel({
 						data-testid={getTestId("export-panel-button")}
 						type="button"
 						title={exportPanelMode.label}
-						onClick={() => setActivePanelMode(exportPanelMode.id)}
+						onClick={() => {
+							setActivePanelMode(exportPanelMode.id);
+							onExportPanelOpen?.();
+						}}
 						className={cn(
 							"mt-auto flex h-8 w-8 items-center justify-center rounded-lg border transition-all",
 							activePanelMode === "export" && !hasTimelineSelection

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2256,6 +2256,11 @@ export default function VideoEditor() {
 											: getAspectRatioValue(aspectRatio),
 									)}
 									onExport={handleOpenExportDialog}
+									onExportPanelOpen={() => {
+										setSelectedZoomId(null);
+										setSelectedTrimId(null);
+										setSelectedSpeedId(null);
+									}}
 									selectedAnnotationId={selectedAnnotationId}
 									annotationRegions={annotationOnlyRegions}
 									onAnnotationContentChange={handleAnnotationContentChange}


### PR DESCRIPTION
## Problem

After manually clicking a zoom (or trim/speed) region in the timeline, the Download button stops working. The export panel never appears — the user is stuck seeing the zoom-edit panel and must click elsewhere in the timeline to deselect before they can export.

## Root Cause

`SettingsPanel` computes:

```ts
const hasTimelineSelection = Boolean(selectedZoomId || selectedTrimId || selectedSpeedId);
```

Both the export button's active highlight and the export panel content are gated on `!hasTimelineSelection`:

```tsx
// button highlight
activePanelMode === "export" && !hasTimelineSelection ? "active" : "inactive"

// panel content
{activePanelMode === "export" && !hasTimelineSelection && ( ... )}
```

When the user clicks a zoom region, `selectedZoomId` becomes non-null in `VideoEditor`. Clicking the Download button only calls `setActivePanelMode("export")` (local `SettingsPanel` state) — it does **not** clear the selection in `VideoEditor`. So `hasTimelineSelection` stays `true` and the export panel never renders.

## Fix

Add an `onExportPanelOpen` callback prop to `SettingsPanel`. When the Download button is clicked, the callback fires alongside the local mode switch, clearing `selectedZoomId`, `selectedTrimId`, and `selectedSpeedId` in `VideoEditor` so `hasTimelineSelection` drops to `false` and the export panel renders immediately.

```tsx
// VideoEditor.tsx
onExportPanelOpen={() => {
  setSelectedZoomId(null);
  setSelectedTrimId(null);
  setSelectedSpeedId(null);
}}
```

(`selectedAnnotationId` and `selectedBlurId` are intentionally excluded — they are not part of `hasTimelineSelection` and don't affect export panel visibility.)

## Relation to PR #611

PR #611 fixed a sibling bug: the "Suggest Zooms" bulk path called `setSelectedZoomId` for every auto-zoom, leaving the last one selected and hiding the export panel. Fix: don't steal selection in the bulk path.

This PR covers the remaining path: **manual selection** via a timeline click. Together they ensure the Download button works from any editor state.

## Changes

| File | Change |
|------|--------|
| `src/components/video-editor/SettingsPanel.tsx` | Add `onExportPanelOpen` prop; call it in the Download button `onClick` |
| `src/components/video-editor/VideoEditor.tsx` | Pass `onExportPanelOpen` that clears the three timeline selection states |

## Verification

1. Load a video in the editor
2. Add a zoom region and click it — zoom settings panel appears
3. Click the Download (↓) button in the left rail
4. **Expected**: export panel appears immediately, zoom deselected
5. Repeat with a trim region and a speed region — same result

<!-- discord-thread-id:1507658182577754132 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline selections (trim, zoom, speed) are now automatically cleared when opening the export panel, preventing accidental edits or lingering selection state during export.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->