### PR TITLE
Fix stale speed controls in the editor

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -808,6 +808,7 @@ export default function VideoEditor() {
 		setSelectedZoomId(id);
 		if (id) {
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedBlurId(null);
 		}
@@ -817,6 +818,7 @@ export default function VideoEditor() {
 		setSelectedTrimId(id);
 		if (id) {
 			setSelectedZoomId(null);
+			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedBlurId(null);
 		}
@@ -827,6 +829,7 @@ export default function VideoEditor() {
 		if (id) {
 			setSelectedZoomId(null);
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
 			setSelectedBlurId(null);
 		}
 	}, []);
@@ -855,6 +858,7 @@ export default function VideoEditor() {
 			pushState((prev) => ({ zoomRegions: [...prev.zoomRegions, newRegion] }));
 			setSelectedZoomId(id);
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedBlurId(null);
 		},
@@ -891,6 +895,7 @@ export default function VideoEditor() {
 			pushState((prev) => ({ trimRegions: [...prev.trimRegions, newRegion] }));
 			setSelectedTrimId(id);
 			setSelectedZoomId(null);
+			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedBlurId(null);
 		},
@@ -1126,6 +1131,7 @@ export default function VideoEditor() {
 			setSelectedAnnotationId(id);
 			setSelectedZoomId(null);
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
 			setSelectedBlurId(null);
 		},
 		[pushState],
@@ -1199,6 +1205,8 @@ export default function VideoEditor() {
 			setSelectedAnnotationId(duplicateId);
 			setSelectedZoomId(null);
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
+			setSelectedBlurId(null);
 		},
 		[pushState],
 	);


### PR DESCRIPTION
Fixes #641.

Found this while checking the speed panel. If a speed region was selected and then you switched to zoom, trim, or annotation, the old speed selection could stay active too. That makes the inspector stack the speed controls under the next timeline tool.

This clears the stale speed selection whenever another timeline item becomes active.

Local screenshots:

Speed selected:
![Speed selected](https://raw.githubusercontent.com/AjTheSpidey/openscreen/codex/pr-assets/pr-assets/openscreen-641-speed-selected.png)

After adding/selecting zoom:
![Zoom selected after speed](https://raw.githubusercontent.com/AjTheSpidey/openscreen/codex/pr-assets/pr-assets/openscreen-641-zoom-after-speed.png)

Checked locally:
- `npm.cmd run build-vite`
- `node_modules\.bin\biome.cmd check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx`
- Playwright/Electron flow: opened the sample video, added speed, added zoom, and verified the speed panel hides once zoom is active

<!-- discord-thread-id:1507693012002537524 -->