### PR TITLE
Rounding increased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ release/**
 test-results
 playwright-report/
 
+
 # Vitest browser mode screenshots
 __screenshots__/
 
@@ -58,3 +59,7 @@ result-*
 
 #kilocode
 .kilo/
+
+#others
+
+**/*.import

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1410,7 +1410,7 @@ export function SettingsPanel({
 															onValueChange={(values) => onBorderRadiusChange?.(values[0])}
 															onValueCommit={() => onBorderRadiusCommit?.()}
 															min={0}
-															max={16}
+															max={64}
 															step={0.5}
 															className="w-full [&_[role=slider]]:bg-[#34B27B] [&_[role=slider]]:border-[#34B27B] [&_[role=slider]]:h-3 [&_[role=slider]]:w-3"
 														/>


### PR DESCRIPTION
# Pull Request to Increase max rounding

## Description
16 px for rounding is not enough for my case. A bigger value as 64 makes more sense in my view

## Motivation
It's just a quality of life improvement

## Type of Change
- [ ] Other (please specify)

## Related Issue(s)
N/A

## Screenshots / Video
<img width="398" height="229" alt="image" src="https://github.com/user-attachments/assets/429ef7a3-8d06-480a-a28e-155b97207fe3" />


## Testing
Open or import a project/video and go to video effects. Now the rounding slider goes until 64px.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---

<!-- discord-thread-id:1508393856222232577 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum border radius limit in the video editor's effects panel, allowing for greater corner rounding on video elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->