### PR TITLE
fix: remove conflicting hover style from shortcuts reset button

### DIFF
--- a/src/components/video-editor/ShortcutsConfigDialog.tsx
+++ b/src/components/video-editor/ShortcutsConfigDialog.tsx
@@ -222,7 +222,7 @@ export function ShortcutsConfigDialog() {
 					<Button
 						variant="ghost"
 						size="sm"
-						className="text-slate-400 hover:text-white gap-1.5"
+						className="text-slate-400 gap-1.5"
 						onClick={handleReset}
 					>
 						<RotateCcw className="w-3 h-3" />


### PR DESCRIPTION
## Description
Fix invisible text on hover for the "Reset to defaults" button in the Shortcuts Configuration dialog.

## Motivation
When hovering over the "Reset to defaults" button, the text becomes invisible. This happens because the custom `hover:text-white` class conflicts with the ghost button variant's `hover:text-accent-foreground` style, which takes precedence due to CSS specificity in the `cn()` merge function.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fixes #666

## Screenshots / Video

**Before:** Button text disappears on hover
<img width="421" height="812" alt="image" src="https://github.com/user-attachments/assets/7fec023f-1123-480d-b2d6-84d36fd02185" />
**After:** Button text remains visible with proper hover styling from ghost variant
<img width="415" height="845" alt="image" src="https://github.com/user-attachments/assets/4a34501a-a162-4bb8-8d4b-5dfacacaa86c" />


## Testing
1. Open the application
2. Go to Settings → Keyboard Shortcuts -> open the shortcuts configuration dialog
3. Hover over the "Reset to defaults" button in the bottom-left of the dialog
4. Verify the button text remains visible on hover

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- discord-thread-id:1509674376138719334 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the reset button styling in the Shortcuts Config Dialog, removing the text color change effect on hover.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->