### PR TITLE
feat: native macOS cursor capture using NSCursor

### DIFF
--- a/electron/native-bridge/cursor/recording/macNativeCursorRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/macNativeCursorRecordingSession.ts
@@ -6,9 +6,20 @@ import { type Rectangle, screen, systemPreferences } from "electron";
 import type {
 	CursorRecordingData,
 	CursorRecordingSample,
+	NativeCursorAsset,
 	NativeCursorType,
 } from "../../../../src/native/contracts";
 import type { CursorRecordingSession } from "./session";
+
+interface MacCursorAssetPayload {
+	id: string;
+	imageDataUrl: string;
+	width: number;
+	height: number;
+	hotspotX: number;
+	hotspotY: number;
+	scaleFactor?: number;
+}
 
 interface MacNativeCursorRecordingSessionOptions {
 	getDisplayBounds: () => Rectangle | null;
@@ -28,6 +39,8 @@ type MacCursorEvent =
 			type: "sample";
 			timestampMs: number;
 			cursorType?: NativeCursorType | null;
+			assetId?: string | null;
+			asset?: MacCursorAssetPayload | null;
 			leftButtonDown?: boolean;
 			leftButtonPressed?: boolean;
 			leftButtonReleased?: boolean;
@@ -170,6 +183,7 @@ function normalizeCursorType(value: unknown): NativeCursorType | null {
 
 export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 	private samples: CursorRecordingSample[] = [];
+	private assets = new Map<string, NativeCursorAsset>();
 	private process: ChildProcessByStdio<null, Readable, Readable> | null = null;
 	private lineBuffer = "";
 	private startTimeMs = 0;
@@ -187,6 +201,7 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 
 	async start(): Promise<void> {
 		this.samples = [];
+		this.assets.clear();
 		this.lineBuffer = "";
 		this.startTimeMs = this.options.startTimeMs ?? Date.now();
 		this.previousLeftButtonDown = false;
@@ -263,17 +278,36 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 
 		return {
 			version: 2,
-			provider: "none",
+			provider: this.assets.size > 0 ? "native" : "none",
 			samples: this.samples,
-			assets: [],
+			assets: [...this.assets.values()],
 		};
 	}
 
 	private startPositionOnlyFallback() {
-		this.captureSample(Date.now(), null, false, false, false);
+		this.captureSample(Date.now(), null, null, false, false, false);
 		this.fallbackInterval = setInterval(() => {
-			this.captureSample(Date.now(), null, false, false, false);
+			this.captureSample(Date.now(), null, null, false, false, false);
 		}, this.options.sampleIntervalMs);
+	}
+
+	private rememberAsset(asset: MacCursorAssetPayload | null | undefined) {
+		if (!asset?.id || this.assets.has(asset.id)) {
+			return;
+		}
+
+		const cursor = screen.getCursorScreenPoint();
+		const displayScaleFactor = screen.getDisplayNearestPoint(cursor).scaleFactor;
+		this.assets.set(asset.id, {
+			id: asset.id,
+			platform: "darwin",
+			imageDataUrl: asset.imageDataUrl,
+			width: asset.width,
+			height: asset.height,
+			hotspotX: asset.hotspotX,
+			hotspotY: asset.hotspotY,
+			scaleFactor: asset.scaleFactor ?? displayScaleFactor,
+		});
 	}
 
 	private handleStdoutChunk(chunk: string) {
@@ -307,9 +341,11 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 		}
 
 		if (payload.type === "sample") {
+			this.rememberAsset(payload.asset);
 			this.captureSample(
 				payload.timestampMs,
 				normalizeCursorType(payload.cursorType),
+				payload.assetId ?? null,
 				payload.leftButtonDown === true,
 				payload.leftButtonPressed === true,
 				payload.leftButtonReleased === true,
@@ -320,6 +356,7 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 	private captureSample(
 		timestampMs: number,
 		cursorType: NativeCursorType | null,
+		assetId: string | null,
 		leftButtonDown: boolean,
 		leftButtonPressed: boolean,
 		leftButtonReleased: boolean,
@@ -357,6 +394,7 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 			cy: clamp(normalizedY, 0, 1),
 			visible,
 			interactionType,
+			...(assetId ? { assetId } : {}),
 			...(cursorType ? { cursorType } : {}),
 		});
 

--- a/electron/native-bridge/cursor/recording/macNativeCursorRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/macNativeCursorRecordingSession.ts
@@ -210,7 +210,8 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 		try {
 			systemPreferences.isTrustedAccessibilityClient(true);
 		} catch {
-			// Link cursor detection degrades to arrow when Accessibility is unavailable.
+			// Without Accessibility, text/pointer affordance detection is unavailable;
+			// cursor bitmaps are still captured natively via NSCursor.
 		}
 
 		const helperPath = findMacCursorHelperPath();
@@ -333,7 +334,7 @@ export class MacNativeCursorRecordingSession implements CursorRecordingSession {
 		if (payload.type === "ready") {
 			if (payload.accessibilityTrusted === false) {
 				console.warn(
-					"[cursor-macos] Accessibility is not trusted; cursor shape detection will be arrow-only.",
+					"[cursor-macos] Accessibility is not trusted; text/pointer affordance detection disabled (bitmap capture still active).",
 				);
 			}
 			this.resolveReady();

--- a/electron/native/screencapturekit/Sources/OpenScreenMacOSCursorHelper/main.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenMacOSCursorHelper/main.swift
@@ -314,36 +314,39 @@ emit([
 	"mouseTapReady": mouseTapReady,
 ])
 
-var lastEmittedAssetId: String?
+// Process-wide set so each unique cursor shape is serialised at most once,
+// even if the user alternates between shapes (e.g. arrow → text → arrow).
+var emittedAssetIds = Set<String>()
 
 while true {
-	mouseTracker.pump()
-	let mouseEvents = mouseTracker.consume()
-	let asset = currentCursorAsset()
-	// Only ship the (large) base64 payload the first time a cursor shape is seen;
-	// subsequent samples reference it by assetId so stdout stays small.
-	var assetPayload: [String: Any]?
-	if let asset, asset.id != lastEmittedAssetId {
-		lastEmittedAssetId = asset.id
-		assetPayload = [
-			"id": asset.id,
-			"imageDataUrl": asset.imageDataUrl,
-			"width": asset.width,
-			"height": asset.height,
-			"hotspotX": asset.hotspotX,
-			"hotspotY": asset.hotspotY,
-			"scaleFactor": asset.scaleFactor,
-		]
+	autoreleasepool {
+		mouseTracker.pump()
+		let mouseEvents = mouseTracker.consume()
+		let asset = currentCursorAsset()
+		// Only ship the (large) base64 payload the first time a cursor shape is seen;
+		// subsequent samples reference it by assetId so stdout stays small.
+		var assetPayload: [String: Any]?
+		if let asset, emittedAssetIds.insert(asset.id).inserted {
+			assetPayload = [
+				"id": asset.id,
+				"imageDataUrl": asset.imageDataUrl,
+				"width": asset.width,
+				"height": asset.height,
+				"hotspotX": asset.hotspotX,
+				"hotspotY": asset.hotspotY,
+				"scaleFactor": asset.scaleFactor,
+			]
+		}
+		emit([
+			"type": "sample",
+			"timestampMs": timestampMs(),
+			"cursorType": currentCursorType(),
+			"assetId": asset?.id,
+			"asset": assetPayload,
+			"leftButtonDown": leftButtonDown(),
+			"leftButtonPressed": mouseEvents.leftDownCount > 0,
+			"leftButtonReleased": mouseEvents.leftUpCount > 0,
+		])
+		Thread.sleep(forTimeInterval: Double(intervalMs) / 1000.0)
 	}
-	emit([
-		"type": "sample",
-		"timestampMs": timestampMs(),
-		"cursorType": currentCursorType(),
-		"assetId": asset?.id,
-		"asset": assetPayload,
-		"leftButtonDown": leftButtonDown(),
-		"leftButtonPressed": mouseEvents.leftDownCount > 0,
-		"leftButtonReleased": mouseEvents.leftUpCount > 0,
-	])
-	Thread.sleep(forTimeInterval: Double(intervalMs) / 1000.0)
 }

--- a/electron/native/screencapturekit/Sources/OpenScreenMacOSCursorHelper/main.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenMacOSCursorHelper/main.swift
@@ -1,9 +1,20 @@
 import AppKit
 import ApplicationServices
+import CryptoKit
 import Foundation
 
 struct CursorHelperRequest: Decodable {
 	let sampleIntervalMs: Int?
+}
+
+struct CapturedCursorAsset {
+	let id: String
+	let imageDataUrl: String
+	let width: Int
+	let height: Int
+	let hotspotX: Double
+	let hotspotY: Double
+	let scaleFactor: Double
 }
 
 final class MouseButtonTracker {
@@ -211,10 +222,60 @@ func currentCursorType() -> String? {
 	)
 
 	guard result == .success, let element else {
-		return "arrow"
+		return nil
 	}
 
-	return cursorTypeForElement(element) ?? "arrow"
+	// Returns nil for anything that is not a text/pointer affordance so the
+	// renderer falls through to the natively captured cursor bitmap (this is
+	// what makes default and custom cursors render as their real images).
+	return cursorTypeForElement(element)
+}
+
+func currentCursorAsset() -> CapturedCursorAsset? {
+	guard let cursor = NSCursor.currentSystem ?? NSCursor.current as NSCursor? else {
+		return nil
+	}
+
+	let image = cursor.image
+	let pointSize = image.size
+	guard pointSize.width > 0, pointSize.height > 0 else {
+		return nil
+	}
+
+	var proposedRect = NSRect(origin: .zero, size: pointSize)
+	guard let cgImage = image.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil) else {
+		return nil
+	}
+
+	let bitmap = NSBitmapImageRep(cgImage: cgImage)
+	guard let png = bitmap.representation(using: .png, properties: [:]) else {
+		return nil
+	}
+
+	let pixelsWide = bitmap.pixelsWide
+	let pixelsHigh = bitmap.pixelsHigh
+	guard pixelsWide > 0, pixelsHigh > 0 else {
+		return nil
+	}
+
+	// Intrinsic backing scale of the cursor image (e.g. 2.0 on Retina). The
+	// renderer divides pixel dimensions/hotspot by this to recover point sizes.
+	let scaleFactor = Double(pixelsWide) / Double(pointSize.width)
+	let hotSpot = cursor.hotSpot
+
+	let digest = SHA256.hash(data: png)
+	let id = digest.map { String(format: "%02x", $0) }.joined()
+	let imageDataUrl = "data:image/png;base64,\(png.base64EncodedString())"
+
+	return CapturedCursorAsset(
+		id: id,
+		imageDataUrl: imageDataUrl,
+		width: pixelsWide,
+		height: pixelsHigh,
+		hotspotX: hotSpot.x * scaleFactor,
+		hotspotY: hotSpot.y * scaleFactor,
+		scaleFactor: scaleFactor
+	)
 }
 
 func timestampMs() -> Int {
@@ -253,13 +314,33 @@ emit([
 	"mouseTapReady": mouseTapReady,
 ])
 
+var lastEmittedAssetId: String?
+
 while true {
 	mouseTracker.pump()
 	let mouseEvents = mouseTracker.consume()
+	let asset = currentCursorAsset()
+	// Only ship the (large) base64 payload the first time a cursor shape is seen;
+	// subsequent samples reference it by assetId so stdout stays small.
+	var assetPayload: [String: Any]?
+	if let asset, asset.id != lastEmittedAssetId {
+		lastEmittedAssetId = asset.id
+		assetPayload = [
+			"id": asset.id,
+			"imageDataUrl": asset.imageDataUrl,
+			"width": asset.width,
+			"height": asset.height,
+			"hotspotX": asset.hotspotX,
+			"hotspotY": asset.hotspotY,
+			"scaleFactor": asset.scaleFactor,
+		]
+	}
 	emit([
 		"type": "sample",
 		"timestampMs": timestampMs(),
 		"cursorType": currentCursorType(),
+		"assetId": asset?.id,
+		"asset": assetPayload,
 		"leftButtonDown": leftButtonDown(),
 		"leftButtonPressed": mouseEvents.leftDownCount > 0,
 		"leftButtonReleased": mouseEvents.leftUpCount > 0,

--- a/src/lib/cursor/nativeCursor.test.ts
+++ b/src/lib/cursor/nativeCursor.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { NativeCursorAsset } from "@/native/contracts";
 import {
 	getNativeCursorClickBounceProgress,
 	getNativeCursorClickBounceScale,
 	hasNativeCursorRecordingData,
 	resolveInterpolatedNativeCursorFrame,
+	resolveNativeCursorRenderAsset,
 } from "./nativeCursor";
 
 describe("native cursor click bounce", () => {
@@ -50,6 +52,38 @@ describe("native cursor click bounce", () => {
 		expect(frame?.asset.cursorType).toBe("arrow");
 		expect(frame?.sample.cx).toBeCloseTo(0.5);
 		expect(frame?.sample.cy).toBeCloseTo(0.5);
+	});
+
+	it("renders the natively captured cursor bitmap for untyped macOS samples", () => {
+		const capturedAsset: NativeCursorAsset = {
+			id: "sha-custom",
+			platform: "darwin",
+			imageDataUrl: "data:image/png;base64,CUSTOMCURSOR",
+			width: 48,
+			height: 48,
+			hotspotX: 8,
+			hotspotY: 8,
+			scaleFactor: 2,
+		};
+		const recordingData = {
+			version: 2,
+			provider: "native" as const,
+			assets: [capturedAsset],
+			samples: [
+				{ timeMs: 0, cx: 0.4, cy: 0.4, visible: true, assetId: "sha-custom" },
+				{ timeMs: 100, cx: 0.6, cy: 0.6, visible: true, assetId: "sha-custom" },
+			],
+		};
+
+		const frame = resolveInterpolatedNativeCursorFrame(recordingData, 50);
+		expect(frame?.asset.id).toBe("sha-custom");
+
+		// No cursorType => no bundled pretty SVG substitution => real captured bitmap,
+		// downscaled from pixels to points via the asset scale factor.
+		const rendered = resolveNativeCursorRenderAsset(capturedAsset, 1, frame?.sample);
+		expect(rendered.imageDataUrl).toBe("data:image/png;base64,CUSTOMCURSOR");
+		expect(rendered.width).toBe(24);
+		expect(rendered.hotspotX).toBe(4);
 	});
 
 	it("applies click bounce to telemetry-only macOS recordings", () => {


### PR DESCRIPTION
## Description

Implements native cursor capture on macOS, bringing it in line with the existing Windows WGC path. Custom and default cursors now render from their real system bitmaps instead of being mapped to bundled SVG approximations.

No third-party libraries. The implementation is built entirely on AppKit APIs that ship with macOS — no uiohook, no CGEventTap pixel-scraping, no overlay heuristics.

## Test
My PC is Mac Mini 4, Apple M4 chip, , MacOS 26.5 (25F71)
✅ Local test passed, take video, export, cursor capture & highlight are all good.

## How it works

**Swift helper (`openscreen-macos-cursor-helper`)**
- Calls `NSCursor.currentSystem` every sample interval to grab the live system cursor image
- Converts to PNG, computes a SHA-256 content hash as a stable asset ID
- Emits the full base64 bitmap payload **once** per unique cursor shape; subsequent samples carry only the `assetId` reference — stdout stays small even across many cursor shape changes
- Records pixel dimensions, intrinsic scale factor (`pixelsWide / pointWidth`, e.g. 2.0 on Retina), and hotspot in pixel coordinates so the renderer can convert back to points correctly
- `currentCursorType()` now returns `nil` instead of falling back to `"arrow"` — default and custom cursors fall through to the captured bitmap; only explicit `text` / `pointer` affordances (detected via Accessibility) continue to use the bundled pretty SVGs

**TypeScript session (`MacNativeCursorRecordingSession`)**
- Collects and deduplicates assets received from the helper into a `Map`
- Tags each `CursorRecordingSample` with `assetId`
- Reports `provider: "native"` when at least one bitmap was captured, `"none"` as a graceful fallback (e.g. helper not found, Accessibility denied)

The rendering, persistence, and export layers (`nativeCursor.ts`, `frameRenderer.ts`, etc.) already supported the `assetId` + `imageDataUrl` path used by Windows — no changes needed there.

## Features

- **Real cursor bitmaps** — default arrow, resize handles, crosshair, and any custom application cursor render as their actual system images
- **Content-addressed deduplication** — identical cursor shapes share one asset entry regardless of how many times they appear in the recording
- **Retina / HiDPI aware** — scale factor and hotspot are preserved in pixel coordinates and converted to points at render time
- **Click detection** — left-button down/up events are still tracked via `CGEventTap`; click bounce animation works as before
- **Graceful degradation** — if the helper binary is missing or Accessibility is not granted, falls back to position-only telemetry (`provider: "none"`) without crashing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native cursor recording now captures actual cursor bitmap assets, enabling recorded sessions to preserve the exact appearance of custom cursors instead of using generic replacements.
  * Optimized cursor asset transmission by tracking and caching assets, reducing redundant data included in session recordings.

* **Tests**
  * Added test coverage to verify native cursor asset rendering behaves correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siddharthvaddem/openscreen/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->