### PR TITLE
feat: support Tab cycling for blur regions

### DIFF
--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1373,26 +1373,45 @@ export default function TimelineEditor({
 				handleAddSpeed();
 			}
 
-			// Tab: Cycle through overlapping annotations at current time
-			if (e.key === "Tab" && annotationRegions.length > 0) {
+			// Tab: Cycle through overlapping annotations or blur regions at current time.
+			// Context-aware: if a blur is currently selected, cycle blurs first;
+			// otherwise cycle annotations. Falls back to the other type if no
+			// overlapping items of the primary type exist at the playhead.
+			if (e.key === "Tab") {
 				const currentTimeMs = Math.round(currentTime * 1000);
-				const overlapping = annotationRegions
-					.filter((a) => currentTimeMs >= a.startMs && currentTimeMs <= a.endMs)
-					.sort((a, b) => a.zIndex - b.zIndex); // Sort by z-index
+				const isBlurSelected = !!selectedBlurId;
 
-				if (overlapping.length > 0) {
+				const tryCycle = (
+					regions: AnnotationRegion[],
+					selectedId: string | null | undefined,
+					selectFn: ((id: string | null) => void) | undefined,
+				): boolean => {
+					const overlapping = regions
+						.filter((a) => currentTimeMs >= a.startMs && currentTimeMs <= a.endMs)
+						.sort((a, b) => a.zIndex - b.zIndex);
+					if (overlapping.length === 0) return false;
 					e.preventDefault();
-
-					if (!selectedAnnotationId || !overlapping.some((a) => a.id === selectedAnnotationId)) {
-						onSelectAnnotation?.(overlapping[0].id);
+					if (!selectedId || !overlapping.some((a) => a.id === selectedId)) {
+						selectFn?.(overlapping[0].id);
 					} else {
-						// Cycle to next annotation
-						const currentIndex = overlapping.findIndex((a) => a.id === selectedAnnotationId);
+						const currentIndex = overlapping.findIndex((a) => a.id === selectedId);
 						const nextIndex = e.shiftKey
-							? (currentIndex - 1 + overlapping.length) % overlapping.length // Shift+Tab = backward
-							: (currentIndex + 1) % overlapping.length; // Tab = forward
-						onSelectAnnotation?.(overlapping[nextIndex].id);
+							? (currentIndex - 1 + overlapping.length) % overlapping.length
+							: (currentIndex + 1) % overlapping.length;
+						selectFn?.(overlapping[nextIndex].id);
 					}
+					return true;
+				};
+
+				const primaryRegions = isBlurSelected ? blurRegions : annotationRegions;
+				const primarySelectedId = isBlurSelected ? selectedBlurId : selectedAnnotationId;
+				const primarySelect = isBlurSelected ? onSelectBlur : onSelectAnnotation;
+
+				if (!tryCycle(primaryRegions, primarySelectedId, primarySelect)) {
+					const secondaryRegions = isBlurSelected ? annotationRegions : blurRegions;
+					const secondarySelectedId = isBlurSelected ? selectedAnnotationId : selectedBlurId;
+					const secondarySelect = isBlurSelected ? onSelectAnnotation : onSelectBlur;
+					tryCycle(secondaryRegions, secondarySelectedId, secondarySelect);
 				}
 			}
 			// Delete key or Ctrl+D / Cmd+D
@@ -1438,8 +1457,10 @@ export default function TimelineEditor({
 		selectedBlurId,
 		selectedSpeedId,
 		annotationRegions,
+		blurRegions,
 		currentTime,
 		onSelectAnnotation,
+		onSelectBlur,
 		keyShortcuts,
 		isMac,
 	]);

--- a/src/i18n/locales/ar/shortcuts.json
+++ b/src/i18n/locales/ar/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "تراجع",
 		"redo": "إعادة",
-		"cycleAnnotationsForward": "التنقل بين الشروح للأمام",
-		"cycleAnnotationsBackward": "التنقل بين الشروح للخلف",
+		"cycleAnnotationsForward": "التنقل بين الشروح / التمويه للأمام",
+		"cycleAnnotationsBackward": "التنقل بين الشروح / التمويه للخلف",
 		"deleteSelectedAlt": "حذف المحدد (alt)",
 		"panTimeline": "تحريك المخطط الزمني",
 		"zoomTimeline": "تكبير المخطط الزمني",

--- a/src/i18n/locales/en/shortcuts.json
+++ b/src/i18n/locales/en/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Undo",
 		"redo": "Redo",
-		"cycleAnnotationsForward": "Cycle Annotations Forward",
-		"cycleAnnotationsBackward": "Cycle Annotations Backward",
+		"cycleAnnotationsForward": "Cycle Annotations / Blur Forward",
+		"cycleAnnotationsBackward": "Cycle Annotations / Blur Backward",
 		"deleteSelectedAlt": "Delete Selected (alt)",
 		"panTimeline": "Pan Timeline",
 		"zoomTimeline": "Zoom Timeline",

--- a/src/i18n/locales/es/shortcuts.json
+++ b/src/i18n/locales/es/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Deshacer",
 		"redo": "Rehacer",
-		"cycleAnnotationsForward": "Recorrer anotaciones hacia adelante",
-		"cycleAnnotationsBackward": "Recorrer anotaciones hacia atrás",
+		"cycleAnnotationsForward": "Recorrer anotaciones / desenfoque hacia adelante",
+		"cycleAnnotationsBackward": "Recorrer anotaciones / desenfoque hacia atrás",
 		"deleteSelectedAlt": "Eliminar seleccionado (alt)",
 		"panTimeline": "Desplazar línea de tiempo",
 		"zoomTimeline": "Zoom en línea de tiempo",

--- a/src/i18n/locales/fr/shortcuts.json
+++ b/src/i18n/locales/fr/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Annuler",
 		"redo": "Rétablir",
-		"cycleAnnotationsForward": "Parcourir les annotations en avant",
-		"cycleAnnotationsBackward": "Parcourir les annotations en arrière",
+		"cycleAnnotationsForward": "Parcourir les annotations / flou en avant",
+		"cycleAnnotationsBackward": "Parcourir les annotations / flou en arrière",
 		"deleteSelectedAlt": "Supprimer la sélection (alt)",
 		"panTimeline": "Panoramique de la timeline",
 		"zoomTimeline": "Zoom de la timeline",

--- a/src/i18n/locales/it/shortcuts.json
+++ b/src/i18n/locales/it/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Annulla",
 		"redo": "Ripeti",
-		"cycleAnnotationsForward": "Scorri annotazioni in avanti",
-		"cycleAnnotationsBackward": "Scorri annotazioni indietro",
+		"cycleAnnotationsForward": "Scorri annotazioni / sfocatura in avanti",
+		"cycleAnnotationsBackward": "Scorri annotazioni / sfocatura indietro",
 		"deleteSelectedAlt": "Elimina selezionato (alt)",
 		"panTimeline": "Panoramica timeline",
 		"zoomTimeline": "Zoom timeline",

--- a/src/i18n/locales/ja-JP/shortcuts.json
+++ b/src/i18n/locales/ja-JP/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "元に戻す",
 		"redo": "やり直す",
-		"cycleAnnotationsForward": "注釈を順に切り替え",
-		"cycleAnnotationsBackward": "注釈を逆順に切り替え",
+		"cycleAnnotationsForward": "注釈・ブラーを順に切り替え",
+		"cycleAnnotationsBackward": "注釈・ブラーを逆順に切り替え",
 		"deleteSelectedAlt": "選択を削除 (alt)",
 		"panTimeline": "タイムラインをパン",
 		"zoomTimeline": "タイムラインをズーム",

--- a/src/i18n/locales/ko-KR/shortcuts.json
+++ b/src/i18n/locales/ko-KR/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "실행 취소",
 		"redo": "다시 실행",
-		"cycleAnnotationsForward": "주석 앞으로 순환",
-		"cycleAnnotationsBackward": "주석 뒤로 순환",
+		"cycleAnnotationsForward": "주석/블러 앞으로 순환",
+		"cycleAnnotationsBackward": "주석/블러 뒤로 순환",
 		"deleteSelectedAlt": "선택 항목 삭제 (대체)",
 		"panTimeline": "타임라인 이동",
 		"zoomTimeline": "타임라인 확대/축소",

--- a/src/i18n/locales/pt-BR/shortcuts.json
+++ b/src/i18n/locales/pt-BR/shortcuts.json
@@ -26,8 +26,8 @@
 	"fixedActions": {
 		"undo": "Desfazer",
 		"redo": "Refazer",
-		"cycleAnnotationsForward": "Alternar Anotações (Próximo)",
-		"cycleAnnotationsBackward": "Alternar Anotações (Anterior)",
+		"cycleAnnotationsForward": "Alternar Anotações / Desfoque (Próximo)",
+		"cycleAnnotationsBackward": "Alternar Anotações / Desfoque (Anterior)",
 		"deleteSelectedAlt": "Excluir Selecionado (alt)",
 		"panTimeline": "Mover Linha do Tempo",
 		"zoomTimeline": "Zoom na Linha do Tempo",

--- a/src/i18n/locales/ru/shortcuts.json
+++ b/src/i18n/locales/ru/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Отменить",
 		"redo": "Повторить",
-		"cycleAnnotationsForward": "Циклически переключить аннотации вперёд",
-		"cycleAnnotationsBackward": "Циклически переключить аннотации назад",
+		"cycleAnnotationsForward": "Циклически переключить аннотации / размытие вперёд",
+		"cycleAnnotationsBackward": "Циклически переключить аннотации / размытие назад",
 		"deleteSelectedAlt": "Удалить выбранное (альт)",
 		"panTimeline": "Панорамирование таймлайна",
 		"zoomTimeline": "Масштабирование таймлайна",

--- a/src/i18n/locales/tr/shortcuts.json
+++ b/src/i18n/locales/tr/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Geri Al",
 		"redo": "Yinele",
-		"cycleAnnotationsForward": "Açıklamalar Arasında İleri Geç",
-		"cycleAnnotationsBackward": "Açıklamalar Arasında Geri Geç",
+		"cycleAnnotationsForward": "Açıklamalar / Bulanıklık Arasında İleri Geç",
+		"cycleAnnotationsBackward": "Açıklamalar / Bulanıklık Arasında Geri Geç",
 		"deleteSelectedAlt": "Seçileni Sil (alternatif)",
 		"panTimeline": "Zaman Çizelgesini Kaydır",
 		"zoomTimeline": "Zaman Çizelgesini Yakınlaştır",

--- a/src/i18n/locales/vi/shortcuts.json
+++ b/src/i18n/locales/vi/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "Hoàn tác",
 		"redo": "Làm lại",
-		"cycleAnnotationsForward": "Chuyển tiếp qua các chú thích",
-		"cycleAnnotationsBackward": "Chuyển lùi qua các chú thích",
+		"cycleAnnotationsForward": "Chuyển tiếp qua các chú thích / làm mờ",
+		"cycleAnnotationsBackward": "Chuyển lùi qua các chú thích / làm mờ",
 		"deleteSelectedAlt": "Xóa mục đã chọn (alt)",
 		"panTimeline": "Xoay Trục thời gian",
 		"zoomTimeline": "Thu phóng Trục thời gian",

--- a/src/i18n/locales/zh-CN/shortcuts.json
+++ b/src/i18n/locales/zh-CN/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "撤销",
 		"redo": "重做",
-		"cycleAnnotationsForward": "向前切换标注",
-		"cycleAnnotationsBackward": "向后切换标注",
+		"cycleAnnotationsForward": "向前切换标注 / 模糊",
+		"cycleAnnotationsBackward": "向后切换标注 / 模糊",
 		"deleteSelectedAlt": "删除所选（替代）",
 		"panTimeline": "平移时间轴",
 		"zoomTimeline": "缩放时间轴",

--- a/src/i18n/locales/zh-TW/shortcuts.json
+++ b/src/i18n/locales/zh-TW/shortcuts.json
@@ -28,8 +28,8 @@
 	"fixedActions": {
 		"undo": "復原",
 		"redo": "重做",
-		"cycleAnnotationsForward": "向前切換標註",
-		"cycleAnnotationsBackward": "向後切換標註",
+		"cycleAnnotationsForward": "向前切換標註 / 模糊",
+		"cycleAnnotationsBackward": "向後切換標註 / 模糊",
 		"deleteSelectedAlt": "刪除所選（替代）",
 		"panTimeline": "平移時間軸",
 		"zoomTimeline": "縮放時間軸",

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -42,13 +42,13 @@ export const FIXED_SHORTCUTS: FixedShortcut[] = [
 	},
 	{
 		i18nKey: "cycleAnnotationsForward",
-		label: "Cycle Annotations Forward",
+		label: "Cycle Annotations / Blur Forward",
 		display: "Tab",
 		bindings: [{ key: "tab" }],
 	},
 	{
 		i18nKey: "cycleAnnotationsBackward",
-		label: "Cycle Annotations Backward",
+		label: "Cycle Annotations / Blur Backward",
 		display: "Shift + Tab",
 		bindings: [{ key: "tab", shift: true }],
 	},


### PR DESCRIPTION
## Description

Tab now cycles through overlapping blur regions in addition to annotations. The behavior is context-aware:

- If a **blur region** is currently selected, Tab cycles through blur regions first
- Otherwise Tab cycles through **annotations** (existing behavior)
- When no overlapping items of the primary type exist at the playhead, it **falls back** to the other type

Also updates the shortcuts label and all 13 locale translations to reflect that Tab now handles both annotations and blur regions.

## Motivation

Currently, blur regions cannot be cycled with Tab like annotations can. When multiple blur regions overlap at the same time, users have no keyboard shortcut to switch between them.

## Changes

- **TimelineEditor.tsx**: Replaced the Tab handler with a context-aware tryCycle function that supports both annotation and blur regions
- **shortcuts.ts**: Updated FIXED_SHORTCUTS labels from "Cycle Annotations" to "Cycle Annotations / Blur"
- **13 locale files**: Updated translations for cycleAnnotationsForward and cycleAnnotationsBackward keys

## Related Issue(s)

Closes #630

## Testing

1. Add multiple annotation regions that overlap at the same time → Tab cycles through them (unchanged behavior)
2. Add multiple blur regions that overlap at the same time → Tab now cycles through them
3. Select a blur region, press Tab → cycles through blur regions
4. With nothing selected, press Tab → cycles through annotations first, then blur regions as fallback
5. Shift+Tab cycles backward in all cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab and Shift+Tab now cycle through both annotations and blur regions with context-sensitive behavior: if a blur is selected, cycles through overlapping blurs first; otherwise cycles through annotations first, with fallback to the other region type.

* **Localization**
  * Updated keyboard shortcut descriptions across 13 languages to reflect that cycling actions now include both annotations and blur regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->