### PR TITLE
fix: resolve cursor-sampler telemetry not working

### DIFF
--- a/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
@@ -22,10 +22,14 @@ function getCursorSamplerCandidates(): string[] {
 		const p = join(app.getAppPath(), ...segs);
 		return app.isPackaged ? p.replace(/\.asar([/\\])/, ".asar.unpacked$1") : p;
 	};
+	const resolvePackaged = (...segs: string[]) => {
+		return app.isPackaged ? join(process.resourcesPath, ...segs) : null;
+	};
 	return [
 		envPath,
 		resolve("electron", "native", "wgc-capture", "build", "cursor-sampler.exe"),
 		resolve("electron", "native", "bin", archTag, "cursor-sampler.exe"),
+		resolvePackaged("electron", "native", "bin", archTag, "cursor-sampler.exe"),
 	].filter((c): c is string => Boolean(c));
 }
 

--- a/electron/native/wgc-capture/CMakeLists.txt
+++ b/electron/native/wgc-capture/CMakeLists.txt
@@ -37,7 +37,7 @@ target_compile_definitions(wgc-capture PRIVATE
   _WIN32_WINNT=0x0A00
 )
 
-target_compile_options(wgc-capture PRIVATE /EHsc /W4 /utf-8)
+target_compile_options(wgc-capture PRIVATE /EHsc /W4 /utf-8 /await)
 
 target_link_libraries(wgc-capture PRIVATE
   d3d11

--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -632,8 +632,8 @@ int main(int argc, char* argv[]) {
                         (webcamOutputFrameIndex * 10'000'000ULL) / std::max(1, webcamCapture.fps()));
                     if (!webcamEncoder.writeBgraFrame(webcamFrame, webcamTimestampHns)) {
                         encodeFailed = true;
-                        stopRequested = true;
-                        cv.notify_all();
+                        control.stopRequested = true;
+                        control.cv.notify_all();
                         return;
                     }
                     lastWrittenWebcamSequence = latestWebcamSequence;


### PR DESCRIPTION
### Summary
This PR fixes an issue on Windows where cursor telemetry (`.cursor.json`) was not being generated in the production/packaged app even when the "Editable Cursor" (green icon) mode was active.

### Cause of the Bug
The helper binary `cursor-sampler.exe` is configured as an `extraResource` in `electron-builder.json5` under Windows. This means that in packaged production builds, the executable is placed directly in the `<install-dir>/resources/` folder rather than inside `app.asar.unpacked`. 

However, `WindowsNativeRecordingSession.ts` was only searching for the helper in `app.getAppPath()` (which resolves inside the ASAR) and not checking `process.resourcesPath`. This caused `findCursorSamplerPath()` to return `null` and fail to launch the helper during screen recording.

### Changes
- Updated `getCursorSamplerCandidates` in `WindowsNativeRecordingSession.ts` to include the packaged `resourcesPath` candidate, matching the macOS helper implementation style.

### Verification
- Verified compilation and output target by running a successful production build with `electron-builder` (`release/1.4.0/Openscreen Setup 1.4.0.exe`).
- Verified that `cursor-sampler.exe` runs correctly and outputs samples on Windows.

<!-- discord-thread-id:1511525243724890193 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue in recording state management where the system failed to properly signal recording termination when video frame encoding encountered errors, ensuring clean process shutdown and appropriate resource cleanup.

* **Chores**
  * Improved cursor sampling resource discovery for better compatibility with packaged application environments.
  * Optimized native video capture module compilation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->